### PR TITLE
Exclude generated code from jacoco plugin in mysql connector.

### DIFF
--- a/debezium-connector-mysql/pom.xml
+++ b/debezium-connector-mysql/pom.xml
@@ -412,6 +412,11 @@
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <version>0.7.9</version>
+                <configuration>
+                    <excludes>
+                        <exclude>io.debezium.ddl.parser.mysql.generated.*</exclude>
+                    </excludes>
+                </configuration>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
Exclude generated code from jacoco plugin in mysql connector to avoid IncompatibleClassChangeError.
