### PR TITLE
Set BinaryLogClient to be non-blocking.

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/BinlogReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/BinlogReader.java
@@ -207,6 +207,7 @@ public class BinlogReader extends AbstractReader {
 
         // Set up the log reader ...
         client = new BinaryLogClient(connectionContext.hostname(), connectionContext.port(), connectionContext.username(), connectionContext.password());
+        client.setBlocking(false);
         // BinaryLogClient will overwrite thread names later
         client.setThreadFactory(
                 Threads.threadFactory(MySqlConnector.class, context.getConnectorConfig().getLogicalName(), "binlog-client", false, false,


### PR DESCRIPTION
Set BinaryLogClient blocking to false to prevent task blocks indefinitely during stop or other scenarios.