### PR TITLE
RCCA-3187: Bump binlog reader dependency patch version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <version.postgresql.driver>42.2.14</version.postgresql.driver>
         <version.mysql.server>5.7</version.mysql.server>
         <version.mysql.driver>8.0.19</version.mysql.driver>
-        <version.mysql.binlog>0.23.1</version.mysql.binlog>
+        <version.mysql.binlog>0.23.4</version.mysql.binlog>
         <version.mongo.server>3.6</version.mongo.server>
         <version.mongo.driver>3.12.3</version.mongo.driver>
         <version.sqlserver.driver>7.2.2.jre8</version.sqlserver.driver>


### PR DESCRIPTION
Pulls in the changes from https://github.com/osheroff/mysql-binlog-connector-java/pull/27, which fixes https://github.com/osheroff/mysql-binlog-connector-java/issues/26, which made the connector impossible to use on Azure.