### PR TITLE
Make validateServerNameIsDifferentFromHistoryTopicName public.

### DIFF
--- a/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java
+++ b/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java
@@ -595,7 +595,7 @@ public abstract class CommonConnectorConfig {
                 || APICURIO_AVRO_CONVERTER.equals(keyConverter) || APICURIO_AVRO_CONVERTER.equals(valueConverter);
     }
 
-    protected static int validateServerNameIsDifferentFromHistoryTopicName(Configuration config, Field field, ValidationOutput problems) {
+    public static int validateServerNameIsDifferentFromHistoryTopicName(Configuration config, Field field, ValidationOutput problems) {
         String serverName = config.getString(field);
         String historyTopicName = config.getString(KafkaDatabaseHistory.TOPIC);
 


### PR DESCRIPTION
Hit error. Also to make the access modifier consistent with upstream.
```
Caused by: java.lang.IllegalAccessError: class io.debezium.connector.mysql.MySqlConnectorConfig$$Lambda$1159/0x0000000802c36898 tried to access protected method 'int io.debezium.config.CommonConnectorConfig.validateServerNameIsDifferentFromHistoryTopicName(io.debezium.config.Configuration, io.debezium.config.Field, io.debezium.config.Field$ValidationOutput)' (io.debezium.connector.mysql.MySqlConnectorConfig$$Lambda$1159/0x0000000802c36898 and io.debezium.config.CommonConnectorConfig are in unnamed module of loader org.apache.kafka.connect.runtime.isolation.PluginClassLoader @5246f452)
	at io.debezium.config.Field$Validator.lambda$and$0(Field.java:214)
	at io.debezium.config.Field.validate(Field.java:545)
	at io.debezium.config.Field.validate(Field.java:561)
	at io.debezium.config.Configuration.lambda$validate$28(Configuration.java:1890)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:183)
	at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:177)
	at java.base/java.util.Iterator.forEachRemaining(Iterator.java:133)
	at java.base/java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1801)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
	at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:497)
	at io.debezium.config.Field$Set.forEachTopLevelField(Field.java:136)
	at io.debezium.config.Configuration.validate(Configuration.java:1889)
	at io.debezium.connector.mysql.MySqlConnector.validate(MySqlConnector.java:80)
```
