### PR TITLE
CCDB-4383: Validate server version for pgoutput plugin

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnector.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnector.java
@@ -137,7 +137,7 @@ public class PostgresConnector extends RelationalBaseSourceConnector {
                 }
 
                 // check for DB version and LogicalDecoder compatibility
-                if (pluginNameValue.value().equals(LogicalDecoder.PGOUTPUT.getValue())) {
+                if (LogicalDecoder.PGOUTPUT.equals(postgresConfig.plugin())) {
                     final Version dbVersion = ServerVersion.from(
                         connection.queryAndMap(
                             "SHOW server_version",
@@ -152,6 +152,7 @@ public class PostgresConnector extends RelationalBaseSourceConnector {
                                 + "postgres server version 10+";
                         LOGGER.error(errorMessage);
                         hostnameValue.addErrorMessage(errorMessage);
+                        pluginNameValue.addErrorMessage(errorMessage);
                     }
                 }
             }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnector.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnector.java
@@ -14,11 +14,14 @@ import java.util.Map;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigValue;
 import org.apache.kafka.connect.connector.Task;
+import org.postgresql.core.ServerVersion;
+import org.postgresql.core.Version;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.debezium.config.Configuration;
 import io.debezium.connector.common.RelationalBaseSourceConnector;
+import io.debezium.connector.postgresql.PostgresConnectorConfig.LogicalDecoder;
 import io.debezium.connector.postgresql.connection.PostgresConnection;
 import io.debezium.relational.RelationalDatabaseConnectorConfig;
 
@@ -131,6 +134,22 @@ public class PostgresConnector extends RelationalBaseSourceConnector {
                                 "Could not fetch roles"))) {
                     final String errorMessage = "Postgres roles LOGIN and REPLICATION are not assigned to user: " + connection.username();
                     LOGGER.error(errorMessage);
+                }
+
+                // check for DB version and LogicalDecoder compatibility
+                if (pluginNameValue.value().equals(LogicalDecoder.PGOUTPUT.getValue())) {
+                    final Version dbVersion = ServerVersion.from(
+                            connection.queryAndMap(
+                                    "SHOW server_version",
+                                    connection.singleResultMapper(
+                                            rs -> rs.getString("server_version"),
+                                            "Could not fetch db version")));
+                    if (ServerVersion.v10.getVersionNum() > dbVersion.getVersionNum()) {
+                        final String errorMessage = "PGOUTPUT plugin is only supported on "
+                                + "postgres server version 10+";
+                        LOGGER.error(errorMessage);
+                        hostnameValue.addErrorMessage(errorMessage);
+                    }
                 }
             }
             catch (Exception e) {

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnector.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnector.java
@@ -139,11 +139,14 @@ public class PostgresConnector extends RelationalBaseSourceConnector {
                 // check for DB version and LogicalDecoder compatibility
                 if (pluginNameValue.value().equals(LogicalDecoder.PGOUTPUT.getValue())) {
                     final Version dbVersion = ServerVersion.from(
-                            connection.queryAndMap(
-                                    "SHOW server_version",
-                                    connection.singleResultMapper(
-                                            rs -> rs.getString("server_version"),
-                                            "Could not fetch db version")));
+                        connection.queryAndMap(
+                            "SHOW server_version",
+                            connection.singleResultMapper(
+                                rs -> rs.getString("server_version"),
+                                "Could not fetch db version"
+                            )
+                        )
+                    );
                     if (ServerVersion.v10.getVersionNum() > dbVersion.getVersionNum()) {
                         final String errorMessage = "PGOUTPUT plugin is only supported on "
                                 + "postgres server version 10+";

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
@@ -165,6 +165,16 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
     }
 
     @Test
+    public void shouldNotValidatePgoutputDecoder() throws Exception {
+        Configuration config = TestHelper.defaultConfig()
+                .with(PostgresConnectorConfig.PLUGIN_NAME, "pgoutput")
+                .build();
+        Config validatedConfig = new PostgresConnector().validate(config.asMap());
+
+        assertConfigurationErrors(validatedConfig, PostgresConnectorConfig.HOSTNAME, 1);
+    }
+
+    @Test
     public void shouldNotStartWithInvalidSlotConfigAndUserRoles() throws Exception {
         // Start with a clean slate and create database objects
         TestHelper.dropAllSchemas();

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
@@ -15,6 +15,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeTrue;
 
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
@@ -49,12 +50,14 @@ import org.awaitility.Awaitility;
 import org.awaitility.core.ConditionTimeoutException;
 import org.fest.assertions.Assertions;
 import org.junit.After;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestRule;
+import org.postgresql.core.ServerVersion;
 import org.postgresql.util.PSQLState;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -165,13 +168,15 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
     }
 
     @Test
-    public void shouldNotValidatePgoutputDecoder() throws Exception {
+    public void shouldNotValidatePgoutputDecoder() {
+        assumeTrue(ServerVersion.v10.getVersionNum() > TestHelper.getServerVersion().getVersionNum());
         Configuration config = TestHelper.defaultConfig()
                 .with(PostgresConnectorConfig.PLUGIN_NAME, "pgoutput")
                 .build();
         Config validatedConfig = new PostgresConnector().validate(config.asMap());
 
         assertConfigurationErrors(validatedConfig, PostgresConnectorConfig.HOSTNAME, 1);
+        assertConfigurationErrors(validatedConfig, PostgresConnectorConfig.PLUGIN_NAME, 1);
     }
 
     @Test

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/TestHelper.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/TestHelper.java
@@ -26,6 +26,8 @@ import java.util.stream.Collectors;
 
 import org.awaitility.Awaitility;
 import org.awaitility.core.ConditionTimeoutException;
+import org.postgresql.core.ServerVersion;
+import org.postgresql.core.Version;
 import org.postgresql.jdbc.PgConnection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -214,6 +216,24 @@ public final class TestHelper {
         try (final PostgresConnection connection = new PostgresConnection(config.getJdbcConfig(), getPostgresValueConverterBuilder(config))) {
             return connection.getDatabaseCharset();
         }
+    }
+
+    public static Version getServerVersion() {
+        final PostgresConnectorConfig config = new PostgresConnectorConfig(defaultConfig().build());
+        try (final PostgresConnection connection = new PostgresConnection(config.getJdbcConfig(), getPostgresValueConverterBuilder(config))) {
+            return ServerVersion.from(
+                connection.queryAndMap(
+                    "SHOW server_version",
+                    connection.singleResultMapper(
+                        rs -> rs.getString("server_version"),
+                        "Could not fetch db version"
+                    )
+                )
+            );
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return ServerVersion.INVALID;
     }
 
     public static PostgresSchema getSchema(PostgresConnectorConfig config) {


### PR DESCRIPTION
## Problem
pgoutput is the standard logical decoding output plug-in in PostgreSQL 10+. This is not validated currently and the connector can weirdly fail during runtime with following trace:

```
io.debezium.jdbc.JdbcConnectionException: ERROR: syntax error
	at io.debezium.connector.postgresql.connection.PostgresReplicationConnection.initPublication(PostgresReplicationConnection.java:180)
	at io.debezium.connector.postgresql.connection.PostgresReplicationConnection.createReplicationSlot(PostgresReplicationConnection.java:343)
	at io.debezium.connector.postgresql.PostgresConnectorTask.start(PostgresConnectorTask.java:125)
	at io.debezium.connector.common.BaseSourceTask.start(BaseSourceTask.java:103)
	at org.apache.kafka.connect.runtime.WorkerSourceTask.initializeAndStart(WorkerSourceTask.java:235)
	at org.apache.kafka.connect.runtime.WorkerTask.doRun(WorkerTask.java:196)
	at org.apache.kafka.connect.runtime.WorkerTask.run(WorkerTask.java:253)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:630)
	at java.base/java.lang.Thread.run(Thread.java:831)
Caused by: org.postgresql.util.PSQLException: ERROR: syntax error
	at org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2532)
	at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2267)
	at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:312)
	at org.postgresql.jdbc.PgStatement.executeInternal(PgStatement.java:448)
	at org.postgresql.jdbc.PgStatement.execute(PgStatement.java:369)
	at org.postgresql.jdbc.PgStatement.executeWithFlags(PgStatement.java:310)
	at org.postgresql.jdbc.PgStatement.executeCachedSql(PgStatement.java:296)
	at org.postgresql.jdbc.PgStatement.executeWithFlags(PgStatement.java:273)
	at org.postgresql.jdbc.PgStatement.executeQuery(PgStatement.java:226)
	at io.debezium.connector.postgresql.connection.PostgresReplicationConnection.initPublication(PostgresReplicationConnection.java:140)
	... 11 more
```

## Solution

Add validation to cover this scenario