### PR TITLE
CCDB-5031 Temporary fix for IllegalAccessError

### DIFF
--- a/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java
+++ b/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java
@@ -851,7 +851,7 @@ public abstract class CommonConnectorConfig {
         return count;
     }
 
-    protected static int validateSkippedOperation(Configuration config, Field field, ValidationOutput problems) {
+    public static int validateSkippedOperation(Configuration config, Field field, ValidationOutput problems) {
         String operations = config.getString(field);
 
         if (operations == null || "none".equals(operations)) {

--- a/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java
+++ b/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java
@@ -851,6 +851,7 @@ public abstract class CommonConnectorConfig {
         return count;
     }
 
+    // TODO: revert back the access modifier from public to protected after updating jdk version to 17
     public static int validateSkippedOperation(Configuration config, Field field, ValidationOutput problems) {
         String operations = config.getString(field);
 


### PR DESCRIPTION
Problem
-----------
CCloud is currently at JDK version `OpenJDK 64-Bit Server VM, 16.0.2, 16.0.2+7-67` which has a [bug](https://bugs.openjdk.org/browse/JDK-8270056).
Jira: https://confluentinc.atlassian.net/browse/CCDB-5031

Solution
--------
Temporarily setting the access of the method `validateSkippedOperation` in super class to public to fix the error. Permanent fix would be to upgrade the JDK version that contains the fix. After applying the permanent fix, need to revert this change.

There was a slightly similar issue with Azure Blob Sink Connector which was fixed by adding -illegal-access=permit option to jvm args: https://github.com/confluentinc/cc-docker-connect/pull/1126
But this is not applicable for the current failure. Hence, making the access as public.