### PR TITLE
CCLOG-2372: Use re2j in EventRouter SMT instead of RegexRouter

### DIFF
--- a/debezium-bom/pom.xml
+++ b/debezium-bom/pom.xml
@@ -28,6 +28,9 @@
         <version.joda>2.10.1</version.joda>
         <version.google.protos>1.17.0</version.google.protos>
 
+        <!-- re2j Regex Library -->
+        <re2j.version>1.6</re2j.version>
+
         <!-- Oracle dependencies -->
         <version.infinispan>12.1.6.Final</version.infinispan>
         <version.infinispan.protostream>4.4.1.Final</version.infinispan.protostream>
@@ -86,6 +89,11 @@
                 <artifactId>jackson-datatype-jsr310</artifactId>
                 <version>${version.jackson}</version>
                 <optional>true</optional>
+            </dependency>
+            <dependency>
+                <groupId>com.google.re2j</groupId>
+                <artifactId>re2j</artifactId>
+                <version>${re2j.version}</version>
             </dependency>
 
             <!-- Kafka Connect -->

--- a/debezium-core/pom.xml
+++ b/debezium-core/pom.xml
@@ -47,6 +47,10 @@
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.google.re2j</groupId>
+            <artifactId>re2j</artifactId>
+        </dependency>
 
         <!-- OpenTracing Integration, Strimzi version is not aligned with Quarkus -->
         <dependency>

--- a/debezium-core/src/test/java/io/debezium/transforms/outbox/EventRouterTest.java
+++ b/debezium-core/src/test/java/io/debezium/transforms/outbox/EventRouterTest.java
@@ -710,7 +710,7 @@ public class EventRouterTest {
     public void shouldFailOnInvalidConfigurationForTopicRegex() {
         final EventRouter<SourceRecord> router = new EventRouter<>();
         final Map<String, String> config = new HashMap<>();
-        config.put(EventRouterConfigDefinition.ROUTE_TOPIC_REGEX.name(), " [[a-z]");
+        config.put(EventRouterConfigDefinition.ROUTE_TOPIC_REGEX.name(), " [[a-z]**");
         router.configure(config);
     }
 


### PR DESCRIPTION
The EventRouter bundles in the functionality of the RegexRouter. However RegexRouter uses backtracking based regex matching which is prone to ReDoS attacks and hence makes it unsuitable to be used on confluent cloud. 

re2j does a single linear scan of the regex pattern and hence is not affected by ReDoS attacks. We already use a version of regex router called TopicRegexRouter which replaces `java.util.regex` with re2j that we use on cloud. However the SMT is not bundled as an artefact separately and is part of cc-docker-connect. Instead of the code burden of maintaining an releasing TopicRegexRouter separately, its better to just replace the RegexRouter functionality here with re2j. 

re2j is not fully compatible with all the features of `java.util.regex` so we probably cannot move this to OSS debezium without the possibility of breaking some exiting code, however since this will be released only on cloud as a fresh new feature we don't have the same issue there. Its feature set should be more than sufficient for all our customer use cases. 