### PR TITLE
DBZ-6039: Reset history recovery attempt counter upon success

### DIFF
--- a/debezium-core/src/main/java/io/debezium/relational/history/KafkaDatabaseHistory.java
+++ b/debezium-core/src/main/java/io/debezium/relational/history/KafkaDatabaseHistory.java
@@ -350,6 +350,7 @@ public class KafkaDatabaseHistory extends AbstractDatabaseHistory {
                 }
                 else {
                     LOGGER.debug("Processed {} records from database history", numRecordsProcessed);
+                    recoveryAttempts = 0;
                 }
             } while (lastProcessedOffset < endOffset - 1);
         }


### PR DESCRIPTION
Recovery attempts counter should be reset once we are able to successfully read some of the records from the database history topic.