### PR TITLE
CC-24280 -- semaphore on master

### DIFF
--- a/.semaphore/project.yml
+++ b/.semaphore/project.yml
@@ -1,0 +1,44 @@
+# This file is managed by ServiceBot plugin - Semaphore. The content in this file is created using a common
+# template and configurations in service.yml.
+# Modifications in this file will be overwritten by generated content in the nightly run.
+# For more information, please refer to the page:
+# https://confluentinc.atlassian.net/wiki/spaces/Foundations/pages/2871296194/Add+SemaphoreCI
+apiVersion: v1alpha
+kind: Project
+metadata:
+  name: debezium
+  description: ""
+spec:
+  visibility: private
+  repository:
+    url: git@github.com:confluentinc/debezium.git
+    run_on:
+      - branches
+      - pull_requests
+    pipeline_file: .semaphore/semaphore.yml
+    integration_type: github_app
+    status:
+      pipeline_files:
+        - path: .semaphore/semaphore.yml
+          level: pipeline
+    whitelist:
+      branches:
+        - master
+        - main
+        - /^\d+\.\d+\.x$/
+        - /v\d+\.\d+\.\d+\-hotfix\-x/
+        - /^gh-readonly-queue.*/
+  custom_permissions: true
+  debug_permissions:
+    - empty
+    - default_branch
+    - non_default_branch
+    - pull_request
+    - forked_pull_request
+    - tag
+  attach_permissions:
+    - default_branch
+    - non_default_branch
+    - pull_request
+    - forked_pull_request
+    - tag

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,0 +1,83 @@
+# This file is managed by ServiceBot plugin - Semaphore. The content in this file is created using a common
+# template and configurations in service.yml.
+# Any modifications made to ths file will be overwritten by the generated content in nightly runs.
+# For more information, please refer to the page:
+# https://confluentinc.atlassian.net/wiki/spaces/Foundations/pages/2871296194/Add+SemaphoreCI
+version: v1.0
+name: build-test-release
+agent:
+  machine:
+    type: s1-prod-ubuntu20-04-amd64-1
+
+fail_fast:
+  cancel:
+    when: "true"
+
+execution_time_limit:
+  hours: 4
+
+queue:
+  - when: "branch != 'master' and branch !~ '[0-9]+\\.[0-9]+\\.x' and branch !~ 'v\\d+\\.\\d+\\.\\d+\\-hotfix\\-x'"
+    processing: parallel
+
+global_job_config:
+  prologue:
+    commands:
+      - checkout
+      - sem-version java 11
+  rajdangwal marked this conversation as resolved.
+- . cache-maven restore
+
+blocks:
+  - name: Test
+    dependencies: []
+    run:
+      # don't run the tests on non-functional changes...
+      when: "change_in('/', {exclude: ['/.deployed-versions/', '.github/']})"
+    task:
+      jobs:
+        - name: Test
+          commands:
+            - mvn -Dcloud -Passembly -pl debezium-connector-mysql,debezium-connector-postgres,debezium-connector-sqlserver -am -U -Dmaven.wagon.http.retryHandler.count=10 --batch-mode --no-transfer-progress clean verify install dependency:analyze validate
+            - . cve-scan
+            - . cache-maven store
+      env_vars:
+        - name: SEMAPHORE_AGENT_UPLOAD_JOB_LOGS
+          value: when-trimmed
+      epilogue:
+        always:
+          commands:
+            - . publish-test-results
+            - artifact push workflow target/test-results
+
+  - name: Release
+    dependencies: ["Test"]
+    run:
+      when: "branch = 'master' or branch =~ '[0-9]+\\.[0-9]+\\.x' or branch =~ 'v\\d+\\.\\d+\\.\\d+\\-hotfix\\-x'"
+    task:
+      jobs:
+        - name: Release
+          commands:
+            - git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
+            - git fetch --unshallow || true
+            - mvn -Dcloud -Passembly -pl debezium-connector-mysql,debezium-connector-postgres,debezium-connector-sqlserver -am -U -Dmaven.wagon.http.retryHandler.count=10 --batch-mode -DaltDeploymentRepository=confluent-codeartifact-internal::default::https://confluent-519856050701.d.codeartifact.us-west-2.amazonaws.com/maven/maven-snapshots/
+              -DrepositoryId=confluent-codeartifact-internal deploy -DskipTests
+
+
+after_pipeline:
+  task:
+    agent:
+      machine:
+        type: s1-prod-ubuntu20-04-arm64-0
+    jobs:
+      - name: Metrics
+        commands:
+          - emit-ci-metrics -p -a test-results
+      - name: Publish Test Results
+        commands:
+          - test-results gen-pipeline-report
+      - name: SonarQube
+        commands:
+          - checkout
+          - sem-version java 11
+          - emit-sonarqube-data -a test-results

--- a/service.yml
+++ b/service.yml
@@ -1,0 +1,19 @@
+name: debezium
+lang: java
+lang_version: 11
+git:
+  enable: true
+codeowners:
+  enable: true
+semaphore:
+  enable: true
+  pipeline_type: cp
+  cve_scan: true
+  extra_build_args: "-Dcloud -Passembly -pl debezium-connector-mysql,debezium-connector-postgres,debezium-connector-sqlserver -am"
+  extra_deploy_args: "-Dcloud -Passembly -pl debezium-connector-mysql,debezium-connector-postgres,debezium-connector-sqlserver -am"
+  branches:
+    - master
+    - main
+    - /^\d+\.\d+\.x$/
+    - /v\d+\.\d+\.\d+\-hotfix\-x/
+    - /^gh-readonly-queue.*/


### PR DESCRIPTION
Although the operation branches on this repo are v1.9.6-hotfix-x and v2.4.2-hotfix-x, for running periodic runs and twistlock scans on the branches, we need these files to be present on master. Most of the other workflows in the org work on the basis of these files being present in master.

Some relevant discussion here --
https://confluent.slack.com/archives/C09EP1SS3/p1705154543166019?thread_ts=1705137907.090639&cid=C09EP1SS3