### PR TITLE
Cherry-pick DBZ-7593 and DBZ-7311

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbSnapshotChangeEventSource.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbSnapshotChangeEventSource.java
@@ -217,7 +217,7 @@ public class MongoDbSnapshotChangeEventSource extends AbstractSnapshotChangeEven
     }
 
     @Override
-    protected SnapshotContext<MongoDbPartition, MongoDbOffsetContext> prepare(MongoDbPartition partition) {
+    protected SnapshotContext<MongoDbPartition, MongoDbOffsetContext> prepare(MongoDbPartition partition, boolean onDemand) {
         return new MongoDbSnapshotContext(partition);
     }
 

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlSnapshotChangeEventSource.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlSnapshotChangeEventSource.java
@@ -116,8 +116,8 @@ public class MySqlSnapshotChangeEventSource extends RelationalSnapshotChangeEven
     }
 
     @Override
-    protected SnapshotContext<MySqlPartition, MySqlOffsetContext> prepare(MySqlPartition partition) throws Exception {
-        return new MySqlSnapshotContext(partition);
+    protected SnapshotContext<MySqlPartition, MySqlOffsetContext> prepare(MySqlPartition partition, boolean onDemand) {
+        return new MySqlSnapshotContext(partition, onDemand);
     }
 
     @Override
@@ -357,7 +357,7 @@ public class MySqlSnapshotChangeEventSource extends RelationalSnapshotChangeEven
                 .collect(Collectors.groupingBy(TableId::catalog, LinkedHashMap::new, Collectors.toList()));
         final Set<String> databases = tablesToRead.keySet();
 
-        if (!snapshottingTask.isBlocking()) {
+        if (!snapshottingTask.isOnDemand()) {
             // Record default charset
             addSchemaEvent(snapshotContext, "", connection.setStatementFor(connection.readMySqlCharsetSystemVariables()));
         }
@@ -383,7 +383,7 @@ public class MySqlSnapshotChangeEventSource extends RelationalSnapshotChangeEven
                     throw new InterruptedException("Interrupted while reading structure of schema " + databases);
                 }
 
-                if (!snapshottingTask.isBlocking()) {
+                if (!snapshottingTask.isOnDemand()) {
                     // in case of blocking snapshot we want to read structures only for collections specified in the signal
                     LOGGER.info("Reading structure of database '{}'", database);
                     addSchemaEvent(snapshotContext, database, "DROP DATABASE IF EXISTS " + quote(database));
@@ -622,8 +622,8 @@ public class MySqlSnapshotChangeEventSource extends RelationalSnapshotChangeEven
      */
     private static class MySqlSnapshotContext extends RelationalSnapshotContext<MySqlPartition, MySqlOffsetContext> {
 
-        MySqlSnapshotContext(MySqlPartition partition) throws SQLException {
-            super(partition, "");
+        MySqlSnapshotContext(MySqlPartition partition, boolean onDemand) {
+            super(partition, "", onDemand);
         }
     }
 
@@ -646,7 +646,7 @@ public class MySqlSnapshotChangeEventSource extends RelationalSnapshotChangeEven
             LOGGER.trace("Processing schema event {}", event);
 
             final TableId tableId = event.getTables().isEmpty() ? null : event.getTables().iterator().next().id();
-            if (snapshottingTask.isBlocking() && !snapshotContext.capturedTables.contains(tableId)) {
+            if (snapshottingTask.isOnDemand() && !snapshotContext.capturedTables.contains(tableId)) {
                 LOGGER.trace("Event {} will be skipped since it's not related to blocking snapshot captured table {}", event, snapshotContext.capturedTables);
                 continue;
             }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleSnapshotChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleSnapshotChangeEventSource.java
@@ -96,19 +96,17 @@ public class OracleSnapshotChangeEventSource extends RelationalSnapshotChangeEve
     }
 
     @Override
-    protected SnapshotContext<OraclePartition, OracleOffsetContext> prepare(OraclePartition partition)
-            throws Exception {
+    protected SnapshotContext<OraclePartition, OracleOffsetContext> prepare(OraclePartition partition, boolean onDemand) {
         if (connectorConfig.getPdbName() != null) {
             jdbcConnection.setSessionToPdb(connectorConfig.getPdbName());
         }
 
-        return new OracleSnapshotContext(partition, connectorConfig.getCatalogName());
+        return new OracleSnapshotContext(partition, connectorConfig.getCatalogName(), onDemand);
     }
 
     @Override
     protected void connectionPoolConnectionCreated(RelationalSnapshotContext<OraclePartition, OracleOffsetContext> snapshotContext,
-                                                   JdbcConnection connection)
-            throws SQLException {
+                                                   JdbcConnection connection) {
         if (connectorConfig.getPdbName() != null) {
             ((OracleConnection) connection).setSessionToPdb(connectorConfig.getPdbName());
         }
@@ -202,7 +200,7 @@ public class OracleSnapshotChangeEventSource extends RelationalSnapshotChangeEve
 
     private Tables.TableFilter getTableFilter(SnapshottingTask snapshottingTask, RelationalSnapshotContext<OraclePartition, OracleOffsetContext> snapshotContext) {
 
-        if (snapshottingTask.isBlocking()) {
+        if (snapshottingTask.isOnDemand()) {
             return Tables.TableFilter.fromPredicate(snapshotContext.capturedTables::contains);
         }
 
@@ -302,8 +300,8 @@ public class OracleSnapshotChangeEventSource extends RelationalSnapshotChangeEve
 
         private Savepoint preSchemaSnapshotSavepoint;
 
-        OracleSnapshotContext(OraclePartition partition, String catalogName) throws SQLException {
-            super(partition, catalogName);
+        OracleSnapshotContext(OraclePartition partition, String catalogName, boolean onDemand) {
+            super(partition, catalogName, onDemand);
         }
     }
 

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSnapshotChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSnapshotChangeEventSource.java
@@ -19,6 +19,7 @@ import org.slf4j.LoggerFactory;
 import io.debezium.connector.postgresql.PostgresOffsetContext.Loader;
 import io.debezium.connector.postgresql.connection.Lsn;
 import io.debezium.connector.postgresql.connection.PostgresConnection;
+import io.debezium.connector.postgresql.snapshot.AlwaysSnapshotter;
 import io.debezium.connector.postgresql.spi.SlotCreationResult;
 import io.debezium.connector.postgresql.spi.SlotState;
 import io.debezium.connector.postgresql.spi.Snapshotter;
@@ -42,6 +43,7 @@ public class PostgresSnapshotChangeEventSource extends RelationalSnapshotChangeE
     private final PostgresConnection jdbcConnection;
     private final PostgresSchema schema;
     private final Snapshotter snapshotter;
+    private final Snapshotter blockingSnapshotter;
     private final SlotCreationResult slotCreatedInfo;
     private final SlotState startingSlotInfo;
 
@@ -57,18 +59,19 @@ public class PostgresSnapshotChangeEventSource extends RelationalSnapshotChangeE
         this.snapshotter = snapshotter;
         this.slotCreatedInfo = slotCreatedInfo;
         this.startingSlotInfo = startingSlotInfo;
+        this.blockingSnapshotter = new AlwaysSnapshotter();
     }
 
     @Override
     public SnapshottingTask getSnapshottingTask(PostgresPartition partition, PostgresOffsetContext previousOffset) {
+
         boolean snapshotSchema = true;
-        boolean snapshotData = true;
 
         List<String> dataCollectionsToBeSnapshotted = connectorConfig.getDataCollectionsToBeSnapshotted();
         Map<String, String> snapshotSelectOverridesByTable = connectorConfig.getSnapshotSelectOverridesByTable().entrySet().stream()
                 .collect(Collectors.toMap(e -> e.getKey().identifier(), Map.Entry::getValue));
 
-        snapshotData = snapshotter.shouldSnapshot();
+        boolean snapshotData = snapshotter.shouldSnapshot();
         if (snapshotData) {
             LOGGER.info("According to the connector configuration data will be snapshotted");
         }
@@ -81,9 +84,8 @@ public class PostgresSnapshotChangeEventSource extends RelationalSnapshotChangeE
     }
 
     @Override
-    protected SnapshotContext<PostgresPartition, PostgresOffsetContext> prepare(PostgresPartition partition)
-            throws Exception {
-        return new PostgresSnapshotContext(partition, connectorConfig.databaseName());
+    protected SnapshotContext<PostgresPartition, PostgresOffsetContext> prepare(PostgresPartition partition, boolean onDemand) {
+        return new PostgresSnapshotContext(partition, connectorConfig.databaseName(), onDemand);
     }
 
     @Override
@@ -200,7 +202,7 @@ public class PostgresSnapshotChangeEventSource extends RelationalSnapshotChangeE
 
             LOGGER.info("Reading structure of schema '{}' of catalog '{}'", schema, snapshotContext.catalogName);
 
-            Tables.TableFilter tableFilter = snapshottingTask.isBlocking() ? Tables.TableFilter.fromPredicate(snapshotContext.capturedTables::contains)
+            Tables.TableFilter tableFilter = snapshottingTask.isOnDemand() ? Tables.TableFilter.fromPredicate(snapshotContext.capturedTables::contains)
                     : connectorConfig.getTableFilters().dataCollectionFilter();
 
             jdbcConnection.readSchema(
@@ -240,6 +242,10 @@ public class PostgresSnapshotChangeEventSource extends RelationalSnapshotChangeE
     @Override
     protected Optional<String> getSnapshotSelect(RelationalSnapshotContext<PostgresPartition, PostgresOffsetContext> snapshotContext,
                                                  TableId tableId, List<String> columns) {
+        if (snapshotContext.onDemand) {
+            return blockingSnapshotter.buildSnapshotQuery(tableId, columns);
+        }
+
         return snapshotter.buildSnapshotQuery(tableId, columns);
     }
 
@@ -255,8 +261,8 @@ public class PostgresSnapshotChangeEventSource extends RelationalSnapshotChangeE
      */
     private static class PostgresSnapshotContext extends RelationalSnapshotContext<PostgresPartition, PostgresOffsetContext> {
 
-        PostgresSnapshotContext(PostgresPartition partition, String catalogName) throws SQLException {
-            super(partition, catalogName);
+        PostgresSnapshotContext(PostgresPartition partition, String catalogName, boolean onDemand) {
+            super(partition, catalogName, onDemand);
         }
     }
 

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/BlockingSnapshotIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/BlockingSnapshotIT.java
@@ -6,18 +6,22 @@
 
 package io.debezium.connector.postgresql;
 
+import static io.debezium.pipeline.signal.actions.AbstractSnapshotSignal.SnapshotType.BLOCKING;
+
 import java.sql.SQLException;
 import java.util.List;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Test;
 
 import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
 import io.debezium.connector.postgresql.PostgresConnectorConfig.SnapshotMode;
+import io.debezium.doc.FixFor;
 import io.debezium.jdbc.JdbcConnection;
 import io.debezium.pipeline.AbstractBlockingSnapshotTest;
-import io.debezium.relational.RelationalDatabaseConnectorConfig;
+import io.debezium.pipeline.source.AbstractSnapshotChangeEventSource;
 
 public class BlockingSnapshotIT extends AbstractBlockingSnapshotTest {
 
@@ -46,19 +50,17 @@ public class BlockingSnapshotIT extends AbstractBlockingSnapshotTest {
         stopConnector();
         TestHelper.dropDefaultReplicationSlot();
         TestHelper.dropPublication();
-
     }
 
     protected Configuration.Builder config() {
         return TestHelper.defaultConfig()
                 .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NEVER.getValue())
-                .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.FALSE)
+                .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.TRUE)
                 .with(PostgresConnectorConfig.SIGNAL_DATA_COLLECTION, "s1.debezium_signal")
                 .with(PostgresConnectorConfig.INCREMENTAL_SNAPSHOT_CHUNK_SIZE, 10)
                 .with(PostgresConnectorConfig.SCHEMA_INCLUDE_LIST, "s1")
                 .with(CommonConnectorConfig.SIGNAL_ENABLED_CHANNELS, "source")
-                .with(CommonConnectorConfig.SIGNAL_POLL_INTERVAL_MS, 5)
-                .with(RelationalDatabaseConnectorConfig.MSG_KEY_COLUMNS, "s1.a42:pk1,pk2,pk3,pk4");
+                .with(CommonConnectorConfig.SIGNAL_POLL_INTERVAL_MS, 5);
     }
 
     @Override
@@ -66,7 +68,7 @@ public class BlockingSnapshotIT extends AbstractBlockingSnapshotTest {
 
         return TestHelper.defaultConfig()
                 .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.INITIAL.getValue())
-                .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.FALSE)
+                .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.TRUE)
                 .with(PostgresConnectorConfig.SIGNAL_DATA_COLLECTION, "s1.debezium_signal")
                 .with(CommonConnectorConfig.SIGNAL_POLL_INTERVAL_MS, 5)
                 .with(PostgresConnectorConfig.INCREMENTAL_SNAPSHOT_CHUNK_SIZE, 10)
@@ -120,4 +122,30 @@ public class BlockingSnapshotIT extends AbstractBlockingSnapshotTest {
         return TestHelper.TEST_SERVER;
     }
 
+    @FixFor("DBZ-7311")
+    @Test
+    public void executeBlockingSnapshotWhenSnapshotModeIsNever() throws Exception {
+        // Testing.Print.enable();
+
+        // Avoid to start the streaming from data inserted before the connector start
+        TestHelper.dropDefaultReplicationSlot();
+        TestHelper.dropPublication();
+
+        populateTable();
+
+        startConnector();
+
+        sendAdHocSnapshotSignalWithAdditionalConditionWithSurrogateKey("", "", BLOCKING, tableDataCollectionId());
+
+        waitForLogMessage("Snapshot completed", AbstractSnapshotChangeEventSource.class);
+
+        int signalingRecords = 1;
+
+        assertRecordsFromSnapshotAndStreamingArePresent(ROW_COUNT, consumeRecordsByTopic(ROW_COUNT + signalingRecords, 10));
+
+        insertRecords(ROW_COUNT, ROW_COUNT * 2);
+
+        assertStreamingRecordsArePresent(ROW_COUNT, consumeRecordsByTopic(ROW_COUNT, 10));
+
+    }
 }

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerSnapshotChangeEventSource.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerSnapshotChangeEventSource.java
@@ -10,6 +10,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Savepoint;
 import java.sql.Statement;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -89,9 +90,8 @@ public class SqlServerSnapshotChangeEventSource extends RelationalSnapshotChange
     }
 
     @Override
-    protected SnapshotContext<SqlServerPartition, SqlServerOffsetContext> prepare(SqlServerPartition partition)
-            throws Exception {
-        return new SqlServerSnapshotContext(partition);
+    protected SnapshotContext<SqlServerPartition, SqlServerOffsetContext> prepare(SqlServerPartition partition, boolean onDemand) {
+        return new SqlServerSnapshotContext(partition, onDemand);
     }
 
     @Override
@@ -186,7 +186,22 @@ public class SqlServerSnapshotChangeEventSource extends RelationalSnapshotChange
                                       SqlServerOffsetContext offsetContext, SnapshottingTask snapshottingTask)
             throws SQLException, InterruptedException {
 
-        Set<String> schemas = snapshotContext.capturedTables.stream()
+        final Set<TableId> capturedSchemaTables;
+        final Tables.TableFilter tableFilter;
+        if (sqlServerDatabaseSchema.storeOnlyCapturedTables()) {
+            capturedSchemaTables = snapshotContext.capturedTables;
+            LOGGER.info("Only captured tables schema should be captured, capturing: {}", capturedSchemaTables);
+            tableFilter = snapshottingTask.isOnDemand() ? Tables.TableFilter.fromPredicate(capturedSchemaTables::contains)
+                    : connectorConfig.getTableFilters().dataCollectionFilter();
+        }
+        else {
+            capturedSchemaTables = snapshotContext.capturedSchemaTables;
+            LOGGER.info("All eligible tables schema should be captured, capturing: {}", capturedSchemaTables);
+            tableFilter = snapshottingTask.isOnDemand() ? Tables.TableFilter.fromPredicate(capturedSchemaTables::contains)
+                    : connectorConfig.getTableFilters().eligibleForSchemaDataCollectionFilter();
+        }
+
+        Set<String> schemas = capturedSchemaTables.stream()
                 .map(TableId::schema)
                 .collect(Collectors.toSet());
 
@@ -208,9 +223,6 @@ public class SqlServerSnapshotChangeEventSource extends RelationalSnapshotChange
             }
 
             LOGGER.info("Reading structure of schema '{}'", snapshotContext.catalogName);
-
-            Tables.TableFilter tableFilter = snapshottingTask.isBlocking() ? Tables.TableFilter.fromPredicate(snapshotContext.capturedTables::contains)
-                    : connectorConfig.getTableFilters().dataCollectionFilter();
 
             jdbcConnection.readSchema(
                     snapshotContext.tables,
@@ -238,6 +250,11 @@ public class SqlServerSnapshotChangeEventSource extends RelationalSnapshotChange
         }
 
         changeTablesByPartition.put(snapshotContext.partition, changeTables);
+    }
+
+    @Override
+    protected Collection<TableId> getTablesForSchemaChange(RelationalSnapshotContext<SqlServerPartition, SqlServerOffsetContext> snapshotContext) {
+        return snapshotContext.capturedSchemaTables;
     }
 
     @Override
@@ -313,8 +330,8 @@ public class SqlServerSnapshotChangeEventSource extends RelationalSnapshotChange
         private int isolationLevelBeforeStart;
         private Savepoint preSchemaSnapshotSavepoint;
 
-        SqlServerSnapshotContext(SqlServerPartition partition) throws SQLException {
-            super(partition, partition.getDatabaseName());
+        SqlServerSnapshotContext(SqlServerPartition partition, boolean onDemand) {
+            super(partition, partition.getDatabaseName(), onDemand);
         }
     }
 

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SchemaHistoryTopicIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SchemaHistoryTopicIT.java
@@ -261,6 +261,7 @@ public class SchemaHistoryTopicIT extends AbstractConnectorTest {
         final Configuration config = TestHelper.defaultConfig()
                 .with(SqlServerConnectorConfig.SNAPSHOT_MODE, SnapshotMode.INITIAL)
                 .with(SqlServerConnectorConfig.INCLUDE_SCHEMA_CHANGES, true)
+                .with(SqlServerConnectorConfig.STORE_ONLY_CAPTURED_TABLES_DDL, "true")
                 .with(SqlServerConnectorConfig.TABLE_INCLUDE_LIST, "dbo.tablec")
                 .build();
 

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectorIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectorIT.java
@@ -2858,6 +2858,82 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
         });
     }
 
+    @Test
+    @FixFor("DBZ-7593")
+    public void shouldCaptureTableSchemaForAllTablesIncludingNonCaptured() throws Exception {
+        Configuration.Builder builder = TestHelper.defaultConfig()
+                .with(SqlServerConnectorConfig.SNAPSHOT_MODE, SqlServerConnectorConfig.SnapshotMode.INITIAL)
+                .with(SqlServerConnectorConfig.TABLE_INCLUDE_LIST, "dbo.tablea")
+                .with(SqlServerConnectorConfig.STORE_ONLY_CAPTURED_TABLES_DDL, "false")
+                .with(SqlServerConnectorConfig.INCLUDE_SCHEMA_CHANGES, "true");
+
+        Configuration config = builder.build();
+        start(SqlServerConnector.class, config);
+
+        int recordCount = 3;
+        SourceRecords sourceRecords = consumeRecordsByTopic(recordCount);
+        assertThat(sourceRecords.allRecordsInOrder()).hasSize(recordCount);
+
+        final TableId tableA = TableId.parse("testDB1.dbo.tablea");
+        final TableId tableB = TableId.parse("testDB1.dbo.tableb");
+
+        List<SourceRecord> schemaChanges = sourceRecords.recordsForTopic("server1");
+        assertThat(schemaChanges).hasSize(2);
+        for (int i = 0; i < 2; i++) {
+            final SourceRecord record = schemaChanges.get(i);
+            assertThat(((Struct) record.key()).getString("databaseName")).isEqualTo("testDB1");
+
+            List<Struct> tableChanges = ((Struct) record.value()).getArray("tableChanges");
+            assertThat(tableChanges).hasSize(1);
+            assertThat(tableChanges.get(0).get("type")).isEqualTo("CREATE");
+
+            final TableId table = i == 0 ? tableA : tableB;
+            assertThat(tableChanges.get(0).get("id")).isEqualTo(table.toDoubleQuotedString());
+        }
+
+        List<SourceRecord> snapshot = sourceRecords.recordsForTopic("server1.testDB1.dbo.tablea");
+        assertThat(snapshot).hasSize(1);
+
+        assertNoRecordsToConsume();
+    }
+
+    @Test
+    @FixFor("DBZ-7593")
+    public void shouldOnlyCaptureTableSchemaForIncluded() throws Exception {
+        Configuration.Builder builder = TestHelper.defaultConfig()
+                .with(SqlServerConnectorConfig.SNAPSHOT_MODE, SqlServerConnectorConfig.SnapshotMode.INITIAL)
+                .with(SqlServerConnectorConfig.TABLE_INCLUDE_LIST, "dbo.tablea")
+                .with(SqlServerConnectorConfig.STORE_ONLY_CAPTURED_TABLES_DDL, "true")
+                .with(SqlServerConnectorConfig.INCLUDE_SCHEMA_CHANGES, "true");
+
+        Configuration config = builder.build();
+        start(SqlServerConnector.class, config);
+
+        int recordCount = 2;
+        SourceRecords sourceRecords = consumeRecordsByTopic(recordCount);
+        assertThat(sourceRecords.allRecordsInOrder()).hasSize(recordCount);
+
+        final TableId tableA = TableId.parse("testDB1.dbo.tablea");
+
+        List<SourceRecord> schemaChanges = sourceRecords.recordsForTopic("server1");
+        assertThat(schemaChanges).hasSize(1);
+        for (int i = 0; i < schemaChanges.size(); i++) {
+            final SourceRecord record = schemaChanges.get(i);
+            assertThat(((Struct) record.key()).getString("databaseName")).isEqualTo("testDB1");
+
+            List<Struct> tableChanges = ((Struct) record.value()).getArray("tableChanges");
+            assertThat(tableChanges).hasSize(1);
+            assertThat(tableChanges.get(0).get("type")).isEqualTo("CREATE");
+
+            assertThat(tableChanges.get(0).get("id")).isEqualTo(tableA.toDoubleQuotedString());
+        }
+
+        List<SourceRecord> snapshot = sourceRecords.recordsForTopic("server1.testDB1.dbo.tablea");
+        assertThat(snapshot).hasSize(1);
+
+        assertNoRecordsToConsume();
+    }
+
     private void shouldStopRetriableRestartsAtConfiguredMaximum(SqlRunnable scenario) throws Exception {
         TestHelper.createTestDatabase(TestHelper.TEST_DATABASE_2);
         connection = TestHelper.testConnection(TEST_DATABASE_2);

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/AbstractSnapshotChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/AbstractSnapshotChangeEventSource.java
@@ -69,7 +69,7 @@ public abstract class AbstractSnapshotChangeEventSource<P extends Partition, O e
 
         final SnapshotContext<P, O> ctx;
         try {
-            ctx = prepare(partition);
+            ctx = prepare(partition, snapshottingTask.isOnDemand());
         }
         catch (Exception e) {
             LOGGER.error("Failed to initialize snapshot context.", e);
@@ -179,7 +179,7 @@ public abstract class AbstractSnapshotChangeEventSource<P extends Partition, O e
     /**
      * Prepares the taking of a snapshot and returns an initial {@link SnapshotContext}.
      */
-    protected abstract SnapshotContext<P, O> prepare(P partition) throws Exception;
+    protected abstract SnapshotContext<P, O> prepare(P partition, boolean onDemand) throws Exception;
 
     /**
      * Completes the snapshot, doing any required clean-up (resource disposal etc.).

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/SnapshottingTask.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/SnapshottingTask.java
@@ -18,14 +18,14 @@ public class SnapshottingTask {
     private final List<String> dataCollections;
     private final Map<String, String> filterQueries;
 
-    private final boolean blocking;
+    private final boolean onDemand;
 
-    public SnapshottingTask(boolean snapshotSchema, boolean snapshotData, List<String> dataCollections, Map<String, String> filterQueries, boolean blocking) {
+    public SnapshottingTask(boolean snapshotSchema, boolean snapshotData, List<String> dataCollections, Map<String, String> filterQueries, boolean onDemand) {
         this.snapshotSchema = snapshotSchema;
         this.snapshotData = snapshotData;
         this.dataCollections = dataCollections;
         this.filterQueries = filterQueries;
-        this.blocking = blocking;
+        this.onDemand = onDemand;
     }
 
     /**
@@ -68,11 +68,11 @@ public class SnapshottingTask {
     }
 
     /**
-     * Determine if the task is a blocking snapshot or not
+     * Determine if the task is an onDemand snapshot or not
      *
      */
-    public boolean isBlocking() {
-        return blocking;
+    public boolean isOnDemand() {
+        return onDemand;
     }
 
     @Override

--- a/debezium-embedded/src/test/java/io/debezium/pipeline/AbstractBlockingSnapshotTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/pipeline/AbstractBlockingSnapshotTest.java
@@ -236,7 +236,7 @@ public abstract class AbstractBlockingSnapshotTest extends AbstractSnapshotTest 
                 .collect(Collectors.toList());
     }
 
-    private static void waitForLogMessage(String message, Class<?> logEmitterClass) {
+    protected static void waitForLogMessage(String message, Class<?> logEmitterClass) {
         LogInterceptor interceptor = new LogInterceptor(logEmitterClass);
         Awaitility.await()
                 .alias("Snapshot not completed on time")
@@ -249,13 +249,13 @@ public abstract class AbstractBlockingSnapshotTest extends AbstractSnapshotTest 
         return Executors.newSingleThreadExecutor().submit(operation);
     }
 
-    private void assertStreamingRecordsArePresent(int expectedRecords, SourceRecords recordsByTopic) throws InterruptedException {
+    protected void assertStreamingRecordsArePresent(int expectedRecords, SourceRecords recordsByTopic) {
 
         assertRecordsWithValuesPresent(expectedRecords, IntStream.range(2000, 2999).boxed().collect(Collectors.toList()), topicName(),
                 recordsByTopic);
     }
 
-    private void assertRecordsFromSnapshotAndStreamingArePresent(int expectedRecords, SourceRecords recordsByTopic) throws InterruptedException {
+    protected void assertRecordsFromSnapshotAndStreamingArePresent(int expectedRecords, SourceRecords recordsByTopic) throws InterruptedException {
 
         assertRecordsWithValuesPresent(expectedRecords, IntStream.range(0, expectedRecords - 1).boxed().collect(Collectors.toList()), topicName(),
                 recordsByTopic);
@@ -270,7 +270,7 @@ public abstract class AbstractBlockingSnapshotTest extends AbstractSnapshotTest 
         assertThat(actual).containsAll(expectedValues);
     }
 
-    private void insertRecords(int rowCount, int startingPkId) throws SQLException {
+    protected void insertRecords(int rowCount, int startingPkId) throws SQLException {
 
         try (JdbcConnection connection = databaseConnection()) {
             connection.setAutoCommit(false);


### PR DESCRIPTION
## What?

The expected behaviour for the SQL Server CDC connector when `schema.history.internal.store.only.captured.tables.ddl` is set to its default value `false` is that schemas of all the tables are captured. However, due to a [bug](https://issues.redhat.com/browse/DBZ-7593), it is not currently happening.

The bug is fixed in version 2.5.3 of the connector. This change cherry-picks the [fix](https://github.com/debezium/debezium/pull/5357). However, due to some merge conflicts because of dependent changes, we are also including another [change](https://github.com/debezium/debezium/pull/5138).

## Test Plan

- Existing tests passing
- Manually tested the change
- Upgrade testing done for before and after this change

