### PR TITLE
CC-27188 -- Remove topic prefix restriction of required field

### DIFF
--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorIT.java
@@ -171,8 +171,8 @@ public class MySqlConnectorIT extends AbstractConnectorTest {
         assertConfigurationErrors(result, MySqlConnectorConfig.HOSTNAME, 1);
         assertNoConfigurationErrors(result, MySqlConnectorConfig.PORT);
         assertConfigurationErrors(result, MySqlConnectorConfig.USER, 1);
-        assertConfigurationErrors(result, CommonConnectorConfig.TOPIC_PREFIX, 1);
         assertConfigurationErrors(result, MySqlConnectorConfig.SERVER_ID);
+        assertNoConfigurationErrors(result, CommonConnectorConfig.TOPIC_PREFIX);
         assertNoConfigurationErrors(result, MySqlConnectorConfig.TABLES_IGNORE_BUILTIN);
         assertNoConfigurationErrors(result, MySqlConnectorConfig.DATABASE_INCLUDE_LIST);
         assertNoConfigurationErrors(result, MySqlConnectorConfig.DATABASE_EXCLUDE_LIST);
@@ -210,9 +210,9 @@ public class MySqlConnectorIT extends AbstractConnectorTest {
         assertConfigurationErrors(result, MySqlConnectorConfig.HOSTNAME, 1);
         assertConfigurationErrors(result, MySqlConnectorConfig.USER, 1);
         assertConfigurationErrors(result, MySqlConnectorConfig.SERVER_ID, 1);
-        assertConfigurationErrors(result, CommonConnectorConfig.TOPIC_PREFIX, 1);
 
         // validate the non required fields
+        validateConfigField(result, CommonConnectorConfig.TOPIC_PREFIX, null);
         validateConfigField(result, MySqlConnectorConfig.PORT, 3306);
         validateConfigField(result, MySqlConnectorConfig.PASSWORD, null);
         validateConfigField(result, MySqlConnectorConfig.ON_CONNECT_STATEMENTS, null);

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
@@ -236,7 +236,6 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
         assertConfigurationErrors(validatedConfig, PostgresConnectorConfig.HOSTNAME, 1);
         assertConfigurationErrors(validatedConfig, PostgresConnectorConfig.USER, 1);
         assertConfigurationErrors(validatedConfig, PostgresConnectorConfig.DATABASE_NAME, 1);
-        assertConfigurationErrors(validatedConfig, CommonConnectorConfig.TOPIC_PREFIX, 1);
 
         // validate the non required fields
         validateConfigField(validatedConfig, PostgresConnectorConfig.PLUGIN_NAME, LogicalDecoder.DECODERBUFS.getValue());
@@ -252,6 +251,7 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
         validateConfigField(validatedConfig, PostgresConnectorConfig.SSL_CLIENT_KEY, null);
         validateConfigField(validatedConfig, PostgresConnectorConfig.SSL_CLIENT_KEY_PASSWORD, null);
         validateConfigField(validatedConfig, PostgresConnectorConfig.SSL_ROOT_CERT, null);
+        validateConfigField(validatedConfig, CommonConnectorConfig.TOPIC_PREFIX, null);
         validateConfigField(validatedConfig, PostgresConnectorConfig.SCHEMA_INCLUDE_LIST, null);
         validateConfigField(validatedConfig, PostgresConnectorConfig.SCHEMA_EXCLUDE_LIST, null);
         validateConfigField(validatedConfig, PostgresConnectorConfig.TABLE_INCLUDE_LIST, null);

--- a/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java
+++ b/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java
@@ -402,7 +402,6 @@ public abstract class CommonConnectorConfig {
             .withWidth(Width.MEDIUM)
             .withImportance(Importance.HIGH)
             .withValidation(CommonConnectorConfig::validateTopicName)
-            .required()
             .withDescription("Topic prefix that identifies and provides a namespace for the particular database " +
                     "server/cluster is capturing changes. The topic prefix should be unique across all other connectors, " +
                     "since it is used as a prefix for all Kafka topic names that receive events emitted by this connector. " +


### PR DESCRIPTION
## Problem
On cloud UI, topic prefix is present in the second page (Configuration) and connection related configs(server, username, password, etc) are present on the first page(Authentication). Due to this, when the validate call is made from the first page, it doesn't have table inclusion regex.

The problem is since table inclusion regex is not provided and it has no default value, the validation response contains only this message -- `The 'topic.prefix' value is invalid: A value is required`. But consider the case where there was a genuine issue on page1 configs, let's say the password was wrong. In this case also, the only validation error returned is the above one.

After the introduction of fail-fast validations, the requirement is to show the connectivity related errors on page1 itself. How fail-fast does this is it picks up the error messages for only the configs which are there on the page for which validate call was made and displays them. But in this case, since the validation error message is pertaining to table inclusion regex, which is on next page, no error is shown, which is a bug.

## Solution
We have removed the constraint of `topic.prefix` to be required. Since this repo only contains the code which is used in CC, we need not worry about impact of this change on CP. This is a required config indeed, but removing this constraint will have no impact, as in the templates it's still present as a required config. Hence on cloud we still get the correct validation error.

## Testing
Manually tested by giving wrong connection params along with no topic prefix.
Before -- No connection related errors were returned in validation. Only `topic prefix is required`.
After -- Connection related errors along with topic prefix were returned.