### PR TITLE
CC-20150: Add server time zone and offset log to Dbz MySql connector

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorTask.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorTask.java
@@ -90,6 +90,8 @@ public class MySqlConnectorTask extends BaseSourceTask<MySqlPartition, MySqlOffs
 
         final boolean tableIdCaseInsensitive = connection.isTableIdCaseSensitive();
 
+        LOGGER.info("The server time zone is {}, and offset is {}", connection.getServerTimeZone(), connection.getServerTimeZoneOffset());
+
         this.schema = new MySqlDatabaseSchema(connectorConfig, valueConverters, topicSelector, schemaNameAdjuster, tableIdCaseInsensitive);
 
         LOGGER.info("Closing connection before starting schema recovery");

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlSystemVariables.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlSystemVariables.java
@@ -56,6 +56,12 @@ public class MySqlSystemVariables extends SystemVariables {
      */
     public static final String LOWER_CASE_TABLE_NAMES = "lower_case_table_names";
 
+    /**
+     * The system variable name to get the system time zone
+     */
+    public static final String TIME_ZONE = "time_zone";
+    public static final String SYSTEM_TIME_ZONE = "system_time_zone";
+
     public MySqlSystemVariables() {
         super(Arrays.asList(MySqlScope.SESSION, MySqlScope.GLOBAL));
     }


### PR DESCRIPTION
### Problem
Some running connectors in prod have `database.connectionTimeZone` config value in mothership DB. Adding this to low-level configs could cause issues when the stored config in mothership db and the actual server timezone are different.

### Solution
Adding a log to get the server time zone and the offset w.r.t UTC(GMT).

### Testing plan
- Log output for Egypt Timezone:
`INFO [test-connector-2|task-0] The server time zone is EEST, and offset is 03:00:00 (io.debezium.connector.mysql.MySqlConnectorTask:93)`

- Log output for Singapore Timezone:
`INFO [test-connector-2|task-0] The server time zone is GMT+08, and offset is 08:00:00 (io.debezium.connector.mysql.MySqlConnectorTask:93)`

- Log output for America/New_York:
`INFO [test-connector-2|task-0] The server time zone is EDT, and offset is -4:00:00 (io.debezium.connector.mysql.MySqlConnectorTask:93)`