### PR TITLE
CC-28776: add MBean name when failing to register it

### DIFF
--- a/debezium-core/src/main/java/io/debezium/pipeline/JmxUtils.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/JmxUtils.java
@@ -48,6 +48,7 @@ public class JmxUtils {
             for (int attempt = 1; attempt <= REGISTRATION_RETRIES; attempt++) {
                 try {
                     mBeanServer.registerMBean(mxBean, objectName);
+                    LOGGER.trace("Successfully registered MBean '{}'", objectName);
                     break;
                 }
                 catch (InstanceAlreadyExistsException e) {
@@ -92,6 +93,7 @@ public class JmxUtils {
             }
             try {
                 mBeanServer.unregisterMBean(objectName);
+                LOGGER.trace("Successfully unregistered MBean '{}'", objectName);
             }
             catch (InstanceNotFoundException e) {
                 LOGGER.info("Unable to unregister metrics MBean '{}' as it was not found", objectName);
@@ -110,7 +112,7 @@ public class JmxUtils {
             unregisterMXBean(objectName);
         }
         catch (MalformedObjectNameException e) {
-            LOGGER.info("Unable to unregister metrics MBean '{}' as it was not found", jmxObjectName);
+            LOGGER.info("Unable to unregister metrics MBean '{}' as it was not found '{}'", jmxObjectName, e.getMessage());
         }
     }
 

--- a/debezium-core/src/main/java/io/debezium/pipeline/JmxUtils.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/JmxUtils.java
@@ -53,13 +53,13 @@ public class JmxUtils {
                 catch (InstanceAlreadyExistsException e) {
                     if (attempt < REGISTRATION_RETRIES) {
                         LOGGER.warn(
-                                "Unable to register metrics as an old set with the same name exists, retrying in {} (attempt {} out of {})",
+                                "Unable to register metrics MBean {} as an old set with the same name exists, retrying in {} (attempt {} out of {})", objectName,
                                 REGISTRATION_RETRY_DELAY, attempt, REGISTRATION_RETRIES);
                         final Metronome metronome = Metronome.sleeper(REGISTRATION_RETRY_DELAY, Clock.system());
                         metronome.pause();
                     }
                     else {
-                        LOGGER.error("Failed to register metrics MBean, metrics will not be available");
+                        LOGGER.error("Failed to register metrics MBean {}, metrics will not be available", objectName);
                     }
                 }
             }

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc
@@ -14,7 +14,7 @@ The following table describes the `schema.history.internal` properties for confi
 |No default
 |A list of host/port pairs that the connector uses for establishing an initial connection to the Kafka cluster. This connection is used for retrieving the database schema history previously stored by the connector, and for writing each DDL statement read from the source database. Each pair should point to the same Kafka cluster used by the Kafka Connect process.
 
-|[[{context}-property-database-history-kafka-recovery-poll-interval-ms]]<<{context}-property-database-history-kafka-recovery-poll-interval-ms, `+schema.history.internal.kafka.recovery.poll.interval.ms+`>>
+    |[[{context}-property-database-history-kafka-recovery-poll-interval-ms]]<<{context}-property-database-history-kafka-recovery-poll-interval-ms, `+schema.history.internal.kafka.recovery.poll.interval.ms+`>>
 |`100`
 |An integer value that specifies the maximum number of milliseconds the connector should wait during startup/recovery while polling for persisted data. The default is 100ms.
 

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc
@@ -14,7 +14,7 @@ The following table describes the `schema.history.internal` properties for confi
 |No default
 |A list of host/port pairs that the connector uses for establishing an initial connection to the Kafka cluster. This connection is used for retrieving the database schema history previously stored by the connector, and for writing each DDL statement read from the source database. Each pair should point to the same Kafka cluster used by the Kafka Connect process.
 
-    |[[{context}-property-database-history-kafka-recovery-poll-interval-ms]]<<{context}-property-database-history-kafka-recovery-poll-interval-ms, `+schema.history.internal.kafka.recovery.poll.interval.ms+`>>
+|[[{context}-property-database-history-kafka-recovery-poll-interval-ms]]<<{context}-property-database-history-kafka-recovery-poll-interval-ms, `+schema.history.internal.kafka.recovery.poll.interval.ms+`>>
 |`100`
 |An integer value that specifies the maximum number of milliseconds the connector should wait during startup/recovery while polling for persisted data. The default is 100ms.
 


### PR DESCRIPTION
Adding this to the logs to track what is the name of the MBean that it is failing to register. We already see errors logs while trying to unregister some mbeans, adding this will help track if they are the same mbeans.
See the comments on the JIRA https://confluentinc.atlassian.net/browse/CC-28776 for additional details.