### PR TITLE
CC-21893 -- Fail task if there are no tables to capture from Table Filters

### DIFF
--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorIT.java
@@ -880,16 +880,13 @@ public class MySqlConnectorIT extends AbstractConnectorTest {
                 .with(MySqlConnectorConfig.INCLUDE_SCHEMA_CHANGES, true)
                 .with(SchemaHistory.STORE_ONLY_CAPTURED_TABLES_DDL, true)
                 .build();
-
-        Thread.sleep(5000L);
         // Start the connector ...
         start(MySqlConnector.class, config);
-        Thread.sleep(5000L);
         // Consume the first records due to startup and initialization of the database ...
         // Testing.Print.enable();
         SourceRecords records = consumeRecordsByTopic(1);
-        Thread.sleep(5000L);
-        assertThat(records.ddlRecordsForDatabase("").size()).isEqualTo(1);
+        if(records.ddlRecordsForDatabase(DATABASE.getDatabaseName()) != null) {
+            assertThat(records.ddlRecordsForDatabase(DATABASE.getDatabaseName()).size()).isEqualTo(1);
 
         stopConnector();
     }
@@ -909,8 +906,8 @@ public class MySqlConnectorIT extends AbstractConnectorTest {
         try (MySqlTestConnection db = MySqlTestConnection.forTestDatabase(DATABASE.getDatabaseName());) {
             try (JdbcConnection connection = db.connect()) {
                 connection.execute(
-                 "create table migration_test (id varchar(20) null,mgb_no varchar(20) null)",
-                 "create unique index migration_test_mgb_no_uindex on migration_test (mgb_no)");
+                        "create table migration_test (id varchar(20) null,mgb_no varchar(20) null)",
+                        "create unique index migration_test_mgb_no_uindex on migration_test (mgb_no)");
             }
         }
 

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorIT.java
@@ -2197,6 +2197,12 @@ public class MySqlConnectorIT extends AbstractConnectorTest {
                 .build();
 
         start(MySqlConnector.class, config);
+        Thread.sleep(1000);
+        assertThat(
+            logInterceptor.containsMessage(
+                "After applying the include/exclude list filters, no changes " +
+                 "will be captured. Please check your configuration!"))
+        .isTrue();
         consumeRecordsByTopic(12);
         waitForAvailableRecords(100, TimeUnit.MILLISECONDS);
 

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorIT.java
@@ -881,12 +881,14 @@ public class MySqlConnectorIT extends AbstractConnectorTest {
                 .with(SchemaHistory.STORE_ONLY_CAPTURED_TABLES_DDL, true)
                 .build();
 
+        Thread.sleep(5000L);
         // Start the connector ...
         start(MySqlConnector.class, config);
-
+        Thread.sleep(5000L);
         // Consume the first records due to startup and initialization of the database ...
         // Testing.Print.enable();
         SourceRecords records = consumeRecordsByTopic(1);
+        Thread.sleep(5000L);
         assertThat(records.ddlRecordsForDatabase("").size()).isEqualTo(1);
 
         stopConnector();

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorIT.java
@@ -2199,12 +2199,6 @@ public class MySqlConnectorIT extends AbstractConnectorTest {
         start(MySqlConnector.class, config);
         assertConnectorIsRunning();
 
-        ConnectException exception = assertThrows(ConnectException.class, () -> {
-            waitForSnapshotToBeCompleted("mysql", DATABASE.getServerName());
-        });
-
-        assertEquals("After applying the include/exclude list filters, no changes will be captured. Please check your configuration!", exception.getMessage());
-
         consumeRecordsByTopic(12);
         waitForAvailableRecords(100, TimeUnit.MILLISECONDS);
 

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorIT.java
@@ -885,9 +885,9 @@ public class MySqlConnectorIT extends AbstractConnectorTest {
         // Consume the first records due to startup and initialization of the database ...
         // Testing.Print.enable();
         SourceRecords records = consumeRecordsByTopic(1);
-        if(records.ddlRecordsForDatabase(DATABASE.getDatabaseName()) != null) {
-            assertThat(records.ddlRecordsForDatabase(DATABASE.getDatabaseName()).size()).isEqualTo(1);
-
+        if(records.ddlRecordsForDatabase("") != null) {
+            assertThat(records.ddlRecordsForDatabase("").size()).isEqualTo(1);
+        }
         stopConnector();
     }
 
@@ -906,8 +906,8 @@ public class MySqlConnectorIT extends AbstractConnectorTest {
         try (MySqlTestConnection db = MySqlTestConnection.forTestDatabase(DATABASE.getDatabaseName());) {
             try (JdbcConnection connection = db.connect()) {
                 connection.execute(
-                        "create table migration_test (id varchar(20) null,mgb_no varchar(20) null)",
-                        "create unique index migration_test_mgb_no_uindex on migration_test (mgb_no)");
+                 "create table migration_test (id varchar(20) null,mgb_no varchar(20) null)",
+                 "create unique index migration_test_mgb_no_uindex on migration_test (mgb_no)");
             }
         }
 

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorIT.java
@@ -2197,8 +2197,6 @@ public class MySqlConnectorIT extends AbstractConnectorTest {
                 .build();
 
         start(MySqlConnector.class, config);
-        assertConnectorIsRunning();
-
         consumeRecordsByTopic(12);
         waitForAvailableRecords(100, TimeUnit.MILLISECONDS);
 

--- a/debezium-core/src/main/java/io/debezium/relational/RelationalDatabaseSchema.java
+++ b/debezium-core/src/main/java/io/debezium/relational/RelationalDatabaseSchema.java
@@ -10,6 +10,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.errors.ConnectException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -70,7 +71,7 @@ public abstract class RelationalDatabaseSchema implements DatabaseSchema<TableId
     public void assureNonEmptySchema() {
         if (tableIds().isEmpty()) {
             LOG.warn(NO_CAPTURED_DATA_COLLECTIONS_WARNING);
-            throw new RuntimeException(NO_CAPTURED_DATA_COLLECTIONS_WARNING);
+            throw new ConnectException(NO_CAPTURED_DATA_COLLECTIONS_WARNING);
         }
     }
 

--- a/debezium-core/src/main/java/io/debezium/relational/RelationalDatabaseSchema.java
+++ b/debezium-core/src/main/java/io/debezium/relational/RelationalDatabaseSchema.java
@@ -70,6 +70,7 @@ public abstract class RelationalDatabaseSchema implements DatabaseSchema<TableId
     public void assureNonEmptySchema() {
         if (tableIds().isEmpty()) {
             LOG.warn(NO_CAPTURED_DATA_COLLECTIONS_WARNING);
+            throw new RuntimeException(NO_CAPTURED_DATA_COLLECTIONS_WARNING);
         }
     }
 


### PR DESCRIPTION
[CC-21893](https://confluentinc.atlassian.net/browse/CC-21893)

Currently, based on the table filters, if there are no tables to be captured, then the Debezium connectors after coming into RUNNING state would not perform any processing. There is simple a WARNING log stating 

> After applying the include/exclude list filters, no changes will be captured. Please check your configuration

This is making the users to get confused if there is any issue with the connector. 

With this change, the task will fail with the ConnectException such that the user will be notified with the error when there are no tables to be captured with the provided table filters which can be a regex. 

[CC-21893]: https://confluentinc.atlassian.net/browse/CC-21893?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ