### PR TITLE
Convert Debezium Snapshot & Schema Metrics to compatible for exposing

### DIFF
--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlMetricsIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlMetricsIT.java
@@ -298,10 +298,10 @@ public class MySqlMetricsIT extends AbstractConnectorTest {
         assertThat(mBeanServer.getAttribute(getSnapshotMetricsObjectName(), "NumberOfEventsFiltered")).isEqualTo(0L);
         assertThat(mBeanServer.getAttribute(getSnapshotMetricsObjectName(), "NumberOfErroneousEvents")).isEqualTo(0L);
         assertThat(mBeanServer.getAttribute(getSnapshotMetricsObjectName(), "RemainingTableCount")).isEqualTo(0);
-        assertThat(mBeanServer.getAttribute(getSnapshotMetricsObjectName(), "SnapshotRunning")).isEqualTo(false);
-        assertThat(mBeanServer.getAttribute(getSnapshotMetricsObjectName(), "SnapshotAborted")).isEqualTo(false);
-        assertThat(mBeanServer.getAttribute(getSnapshotMetricsObjectName(), "SnapshotCompleted")).isEqualTo(true);
-        assertThat(mBeanServer.getAttribute(getSnapshotMetricsObjectName(), "SnapshotPaused")).isEqualTo(false);
+        assertThat(mBeanServer.getAttribute(getSnapshotMetricsObjectName(), "SnapshotRunning")).isEqualTo(0L);
+        assertThat(mBeanServer.getAttribute(getSnapshotMetricsObjectName(), "SnapshotAborted")).isEqualTo(0L);
+        assertThat(mBeanServer.getAttribute(getSnapshotMetricsObjectName(), "SnapshotCompleted")).isEqualTo(1L);
+        assertThat(mBeanServer.getAttribute(getSnapshotMetricsObjectName(), "SnapshotPaused")).isEqualTo(0L);
         assertThat(mBeanServer.getAttribute(getSnapshotMetricsObjectName(), "SnapshotPausedDurationInSeconds")).isEqualTo(0L);
     }
 

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/metrics/SqlServerSnapshotPartitionMetrics.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/metrics/SqlServerSnapshotPartitionMetrics.java
@@ -36,22 +36,22 @@ class SqlServerSnapshotPartitionMetrics extends AbstractSqlServerPartitionMetric
     }
 
     @Override
-    public boolean getSnapshotRunning() {
+    public long getSnapshotRunning() {
         return snapshotMeter.getSnapshotRunning();
     }
 
     @Override
-    public boolean getSnapshotPaused() {
+    public long getSnapshotPaused() {
         return snapshotMeter.getSnapshotPaused();
     }
 
     @Override
-    public boolean getSnapshotCompleted() {
+    public long getSnapshotCompleted() {
         return snapshotMeter.getSnapshotCompleted();
     }
 
     @Override
-    public boolean getSnapshotAborted() {
+    public long getSnapshotAborted() {
         return snapshotMeter.getSnapshotAborted();
     }
 

--- a/debezium-core/src/main/java/io/debezium/pipeline/meters/SnapshotMeter.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/meters/SnapshotMeter.java
@@ -31,10 +31,11 @@ import io.debezium.util.Clock;
 public class SnapshotMeter implements SnapshotMetricsMXBean {
     private static final Logger LOGGER = LoggerFactory.getLogger(SnapshotMeter.class);
 
-    private final AtomicBoolean snapshotRunning = new AtomicBoolean();
-    private final AtomicBoolean snapshotPaused = new AtomicBoolean();
-    private final AtomicBoolean snapshotCompleted = new AtomicBoolean();
-    private final AtomicBoolean snapshotAborted = new AtomicBoolean();
+    private final AtomicLong snapshotRunning = new AtomicLong();
+    private final AtomicLong snapshotPaused = new AtomicLong();
+    private final AtomicLong snapshotCompleted = new AtomicLong();
+
+    private final AtomicLong snapshotAborted = new AtomicLong();
     private final AtomicLong startTime = new AtomicLong();
     private final AtomicLong stopTime = new AtomicLong();
     private final AtomicLong startPauseTime = new AtomicLong();
@@ -69,22 +70,22 @@ public class SnapshotMeter implements SnapshotMetricsMXBean {
     }
 
     @Override
-    public boolean getSnapshotRunning() {
+    public long getSnapshotRunning() {
         return this.snapshotRunning.get();
     }
 
     @Override
-    public boolean getSnapshotPaused() {
+    public long getSnapshotPaused() {
         return this.snapshotPaused.get();
     }
 
     @Override
-    public boolean getSnapshotCompleted() {
+    public long getSnapshotCompleted() {
         return this.snapshotCompleted.get();
     }
 
     @Override
-    public boolean getSnapshotAborted() {
+    public long getSnapshotAborted() {
         return this.snapshotAborted.get();
     }
 
@@ -125,10 +126,10 @@ public class SnapshotMeter implements SnapshotMetricsMXBean {
     }
 
     public void snapshotStarted() {
-        this.snapshotRunning.set(true);
-        this.snapshotPaused.set(false);
-        this.snapshotCompleted.set(false);
-        this.snapshotAborted.set(false);
+        this.snapshotRunning.set(1);
+        this.snapshotPaused.set(0);
+        this.snapshotCompleted.set(0);
+        this.snapshotAborted.set(0);
         this.startTime.set(clock.currentTimeInMillis());
         this.stopTime.set(0L);
         this.startPauseTime.set(0);
@@ -137,19 +138,19 @@ public class SnapshotMeter implements SnapshotMetricsMXBean {
     }
 
     public void snapshotPaused() {
-        this.snapshotRunning.set(false);
-        this.snapshotPaused.set(true);
-        this.snapshotCompleted.set(false);
-        this.snapshotAborted.set(false);
+        this.snapshotRunning.set(0);
+        this.snapshotPaused.set(1);
+        this.snapshotCompleted.set(0);
+        this.snapshotAborted.set(0);
         this.startPauseTime.set(clock.currentTimeInMillis());
         this.stopPauseTime.set(0L);
     }
 
     public void snapshotResumed() {
-        this.snapshotRunning.set(true);
-        this.snapshotPaused.set(false);
-        this.snapshotCompleted.set(false);
-        this.snapshotAborted.set(false);
+        this.snapshotRunning.set(1);
+        this.snapshotPaused.set(0);
+        this.snapshotCompleted.set(0);
+        this.snapshotAborted.set(0);
         final long currTime = clock.currentTimeInMillis();
         this.stopPauseTime.set(currTime);
 
@@ -166,18 +167,18 @@ public class SnapshotMeter implements SnapshotMetricsMXBean {
     }
 
     public void snapshotCompleted() {
-        this.snapshotCompleted.set(true);
-        this.snapshotAborted.set(false);
-        this.snapshotRunning.set(false);
-        this.snapshotPaused.set(false);
+        this.snapshotCompleted.set(1);
+        this.snapshotAborted.set(0);
+        this.snapshotRunning.set(0);
+        this.snapshotPaused.set(0);
         this.stopTime.set(clock.currentTimeInMillis());
     }
 
     public void snapshotAborted() {
-        this.snapshotCompleted.set(false);
-        this.snapshotAborted.set(true);
-        this.snapshotRunning.set(false);
-        this.snapshotPaused.set(false);
+        this.snapshotCompleted.set(0);
+        this.snapshotAborted.set(1);
+        this.snapshotRunning.set(0);
+        this.snapshotPaused.set(0);
         this.stopTime.set(clock.currentTimeInMillis());
     }
 
@@ -232,10 +233,10 @@ public class SnapshotMeter implements SnapshotMetricsMXBean {
     }
 
     public void reset() {
-        snapshotRunning.set(false);
-        snapshotPaused.set(false);
-        snapshotCompleted.set(false);
-        snapshotAborted.set(false);
+        snapshotRunning.set(0);
+        snapshotPaused.set(0);
+        snapshotCompleted.set(0);
+        snapshotAborted.set(0);
         startTime.set(0);
         stopTime.set(0);
         startPauseTime.set(0);

--- a/debezium-core/src/main/java/io/debezium/pipeline/metrics/DefaultSnapshotChangeEventSourceMetrics.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/metrics/DefaultSnapshotChangeEventSourceMetrics.java
@@ -51,22 +51,22 @@ public class DefaultSnapshotChangeEventSourceMetrics<P extends Partition> extend
     }
 
     @Override
-    public boolean getSnapshotRunning() {
+    public long getSnapshotRunning() {
         return snapshotMeter.getSnapshotRunning();
     }
 
     @Override
-    public boolean getSnapshotPaused() {
+    public long getSnapshotPaused() {
         return snapshotMeter.getSnapshotPaused();
     }
 
     @Override
-    public boolean getSnapshotCompleted() {
+    public long getSnapshotCompleted() {
         return snapshotMeter.getSnapshotCompleted();
     }
 
     @Override
-    public boolean getSnapshotAborted() {
+    public long getSnapshotAborted() {
         return snapshotMeter.getSnapshotAborted();
     }
 

--- a/debezium-core/src/main/java/io/debezium/pipeline/metrics/traits/SnapshotMetricsMXBean.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/metrics/traits/SnapshotMetricsMXBean.java
@@ -16,13 +16,13 @@ public interface SnapshotMetricsMXBean extends SchemaMetricsMXBean {
 
     int getRemainingTableCount();
 
-    boolean getSnapshotRunning();
+    long getSnapshotRunning();
 
-    boolean getSnapshotPaused();
+    long getSnapshotPaused();
 
-    boolean getSnapshotCompleted();
+    long getSnapshotCompleted();
 
-    boolean getSnapshotAborted();
+    long getSnapshotAborted();
 
     long getSnapshotDurationInSeconds();
 

--- a/debezium-core/src/main/java/io/debezium/relational/history/SchemaHistoryMXBean.java
+++ b/debezium-core/src/main/java/io/debezium/relational/history/SchemaHistoryMXBean.java
@@ -20,7 +20,7 @@ public interface SchemaHistoryMXBean {
      *
      * @return schema history component state
      */
-    String getStatus();
+    long getStatus();
 
     /**
      * @return time in epoch seconds when recovery has started

--- a/debezium-core/src/main/java/io/debezium/relational/history/SchemaHistoryMetrics.java
+++ b/debezium-core/src/main/java/io/debezium/relational/history/SchemaHistoryMetrics.java
@@ -57,8 +57,14 @@ public class SchemaHistoryMetrics extends Metrics implements SchemaHistoryListen
     }
 
     @Override
-    public String getStatus() {
-        return status.toString();
+    public long getStatus() {
+        if (status == SchemaHistoryStatus.STOPPED) {
+            return 0;
+        } else if (status == SchemaHistoryStatus.RECOVERING) {
+            return 1;
+        } else {
+            return 2;
+        }
     }
 
     @Override

--- a/debezium-embedded/src/test/java/io/debezium/embedded/AbstractConnectorTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/embedded/AbstractConnectorTest.java
@@ -1262,10 +1262,8 @@ public abstract class AbstractConnectorTest implements Testing {
                      Object attribute = mbeanServer.getAttribute(getSnapshotMetricsObjectName(connector, server, task, database), event);
                      if (attribute instanceof Long) {
                          return (Long) attribute == 1L;
-                     } else if (attribute instanceof Boolean) {
-                         return (Boolean) attribute;
                      } else {
-                         throw new IllegalStateException("Unexpected attribute type: " + attribute.getClass());
+                         return (Boolean) attribute;
                      }
                 });
     }

--- a/debezium-embedded/src/test/java/io/debezium/embedded/AbstractConnectorTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/embedded/AbstractConnectorTest.java
@@ -1258,8 +1258,16 @@ public abstract class AbstractConnectorTest implements Testing {
                 .pollInterval(100, TimeUnit.MILLISECONDS)
                 .atMost(waitTimeForRecords() * 30L, TimeUnit.SECONDS)
                 .ignoreException(InstanceNotFoundException.class)
-                .until(() -> (boolean) mbeanServer
-                        .getAttribute(getSnapshotMetricsObjectName(connector, server, task, database), event));
+                .until(() -> {
+                     Object attribute = mbeanServer.getAttribute(getSnapshotMetricsObjectName(connector, server, task, database), event);
+                     if (attribute instanceof Long) {
+                         return (Long) attribute == 1L;
+                     } else if (attribute instanceof Boolean) {
+                         return (Boolean) attribute;
+                     } else {
+                         throw new IllegalStateException("Unexpected attribute type: " + attribute.getClass());
+                     }
+                });
     }
 
     public static void waitForStreamingRunning(String connector, String server) throws InterruptedException {


### PR DESCRIPTION
[CC-27684](https://confluentinc.atlassian.net/browse/CC-27684) - Exposing the Debezium Metrics to customers via metrics API. As part of this ticket, exposing the Snapshot and Schema History metrics which would provide observability of the connector while in this phase.

As, these metrics are type BOOLEAN and STRING which are by default emitted by the Debezium. Currently, there is a issue while emitting these metrics as Otel Collector doesn't support STRING and BOOLEAN type metrics. Hence, converting these metrics to GAUGE_LONG in order to emit to Otel Collector and thus expose to customers via Metrics API>

[CC-27684]: https://confluentinc.atlassian.net/browse/CC-27684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ