### PR TITLE
CC-29686: Add all dependent configurations for Extract New Record State SMT

### DIFF
--- a/debezium-core/src/main/java/io/debezium/transforms/ExtractNewRecordState.java
+++ b/debezium-core/src/main/java/io/debezium/transforms/ExtractNewRecordState.java
@@ -421,6 +421,9 @@ public class ExtractNewRecordState<R extends ConnectRecord<R>> implements Transf
         Field.group(config, null, ExtractNewRecordStateConfigDefinition.DROP_TOMBSTONES,
                 ExtractNewRecordStateConfigDefinition.HANDLE_DELETES, ExtractNewRecordStateConfigDefinition.ADD_FIELDS,
                 ExtractNewRecordStateConfigDefinition.ADD_HEADERS,
+                ExtractNewRecordStateConfigDefinition.ROUTE_BY_FIELD,
+                ExtractNewRecordStateConfigDefinition.ADD_FIELDS_PREFIX,
+                ExtractNewRecordStateConfigDefinition.ADD_HEADERS_PREFIX,
                 ExtractNewRecordStateConfigDefinition.ROUTE_BY_FIELD);
         return config;
     }

--- a/debezium-core/src/main/java/io/debezium/transforms/ExtractNewRecordState.java
+++ b/debezium-core/src/main/java/io/debezium/transforms/ExtractNewRecordState.java
@@ -423,8 +423,7 @@ public class ExtractNewRecordState<R extends ConnectRecord<R>> implements Transf
                 ExtractNewRecordStateConfigDefinition.ADD_HEADERS,
                 ExtractNewRecordStateConfigDefinition.ROUTE_BY_FIELD,
                 ExtractNewRecordStateConfigDefinition.ADD_FIELDS_PREFIX,
-                ExtractNewRecordStateConfigDefinition.ADD_HEADERS_PREFIX,
-                ExtractNewRecordStateConfigDefinition.ROUTE_BY_FIELD);
+                ExtractNewRecordStateConfigDefinition.ADD_HEADERS_PREFIX);
         return config;
     }
 


### PR DESCRIPTION
[CC-29686](https://confluentinc.atlassian.net/browse/CC-29686) - Adding all the Dependent Configurations in the config method of Extract New Record State SMT.

[CC-29686]: https://confluentinc.atlassian.net/browse/CC-29686?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ