### PR TITLE
WIP: add creds provider class support for MySQL

### DIFF
--- a/debezium-connector-mysql/pom.xml
+++ b/debezium-connector-mysql/pom.xml
@@ -57,6 +57,12 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>credential-provider</artifactId>
+            <version>0.1.0</version>
+        </dependency>
+
 
         <!-- Testing -->
         <dependency>

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/JdbcCredentialsUtil.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/JdbcCredentialsUtil.java
@@ -1,12 +1,12 @@
 package io.debezium.connector.mysql;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import io.confluent.credentialprovider.DefaultJdbcCredentials;
 import io.confluent.credentialprovider.JdbcCredentials;
 import io.confluent.credentialprovider.JdbcCredentialsProvider;
 import io.debezium.config.Configuration;
-import io.debezium.connector.mysql.MySqlConnectorConfig;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Utility class for handling JDBC credential providers
@@ -30,7 +30,7 @@ public class JdbcCredentialsUtil {
             return null;
         }
 
-        // If we already have an instance and it's the same provider class, return it
+        // If we already have an instance, and it's the same provider class, return it
         if (PROVIDER_INSTANCE != null && providerClass.equals(configuredProviderClass)) {
             return PROVIDER_INSTANCE;
         }

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/JdbcCredentialsUtil.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/JdbcCredentialsUtil.java
@@ -3,8 +3,8 @@ package io.debezium.connector.mysql;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.confluent.credentialprovider.DefaultJdbcCredentials;
-import io.confluent.credentialprovider.JdbcCredentials;
+import io.confluent.credentialprovider.DefaultJdbcCredential;
+import io.confluent.credentialprovider.JdbcCredential;
 import io.confluent.credentialprovider.JdbcCredentialsProvider;
 import io.debezium.config.Configuration;
 
@@ -60,10 +60,10 @@ public class JdbcCredentialsUtil {
      * @param config the configuration
      * @return credentials object containing username and password
      */
-    public static JdbcCredentials getCredentials(JdbcCredentialsProvider provider, Configuration config) {
+    public static JdbcCredential getCredentials(JdbcCredentialsProvider provider, Configuration config) {
         if (provider != null) {
             try {
-                JdbcCredentials creds = provider.getJdbcCreds();
+                JdbcCredential creds = provider.getJdbcCreds();
                 if (creds != null) {
                     return creds;
                 }
@@ -75,7 +75,7 @@ public class JdbcCredentialsUtil {
         }
 
         // Fall back to config values
-        return new DefaultJdbcCredentials(
+        return new DefaultJdbcCredential(
                 config.getString(MySqlConnectorConfig.USER),
                 config.getString(MySqlConnectorConfig.PASSWORD)
         );

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/JdbcCredentialsUtil.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/JdbcCredentialsUtil.java
@@ -1,0 +1,83 @@
+package io.debezium.connector.mysql;
+
+import io.confluent.credentialprovider.DefaultJdbcCredentials;
+import io.confluent.credentialprovider.JdbcCredentials;
+import io.confluent.credentialprovider.JdbcCredentialsProvider;
+import io.debezium.config.Configuration;
+import io.debezium.connector.mysql.MySqlConnectorConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Utility class for handling JDBC credential providers
+ */
+public class JdbcCredentialsUtil {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(JdbcCredentialsUtil.class);
+
+    // Single cached provider instance
+    private static volatile JdbcCredentialsProvider PROVIDER_INSTANCE = null;
+    private static String configuredProviderClass = null;
+
+    /**
+     * Get or create a credentials provider for the given configuration
+     * @param config the connector configuration
+     * @return the credentials provider, or null if none configured
+     */
+    public static synchronized JdbcCredentialsProvider getCredentialsProvider(Configuration config) {
+        String providerClass = config.getString(MySqlConnectorConfig.CREDENTIALS_PROVIDER);
+        if (providerClass == null) {
+            return null;
+        }
+
+        // If we already have an instance and it's the same provider class, return it
+        if (PROVIDER_INSTANCE != null && providerClass.equals(configuredProviderClass)) {
+            return PROVIDER_INSTANCE;
+        }
+
+        // Otherwise create a new instance
+        try {
+            JdbcCredentialsProvider provider = (JdbcCredentialsProvider) Class.forName(providerClass)
+                    .getDeclaredConstructor().newInstance();
+            provider.configure(config.asMap());
+
+            // Cache the new instance
+            PROVIDER_INSTANCE = provider;
+            configuredProviderClass = providerClass;
+
+            return provider;
+        }
+        catch (Exception e) {
+            LOGGER.warn("Error initializing credentials provider {}: {}", providerClass, e.getMessage());
+            LOGGER.debug("Detailed provider initialization error", e);
+            return null;
+        }
+    }
+
+    /**
+     * Get credentials from the provider or default values from config
+     * @param provider the credentials provider
+     * @param config the configuration
+     * @return credentials object containing username and password
+     */
+    public static JdbcCredentials getCredentials(JdbcCredentialsProvider provider, Configuration config) {
+        if (provider != null) {
+            try {
+                JdbcCredentials creds = provider.getJdbcCreds();
+                if (creds != null) {
+                    return creds;
+                }
+            }
+            catch (Exception e) {
+                LOGGER.warn("Error getting credentials from provider: {}", e.getMessage());
+                LOGGER.debug("Detailed credential retrieval error", e);
+            }
+        }
+
+        // Fall back to config values
+        return new DefaultJdbcCredentials(
+                config.getString(MySqlConnectorConfig.USER),
+                config.getString(MySqlConnectorConfig.PASSWORD)
+        );
+    }
+}

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/JdbcCredentialsUtil.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/JdbcCredentialsUtil.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package io.debezium.connector.mysql;
 
 import org.slf4j.Logger;

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnection.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnection.java
@@ -494,8 +494,6 @@ public class MySqlConnection extends JdbcConnection {
         private final ConnectionFactory factory;
         private final Configuration config;
 
-        private JdbcCredentialsProvider credentialsProvider;
-
         public MySqlConnectionConfiguration(Configuration config) {
             // Set up the JDBC connection without actually connecting, with extra MySQL-specific properties
             // to give us better JDBC database metadata behavior, including using UTF-8 for the client-side character encoding

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnection.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnection.java
@@ -25,7 +25,7 @@ import org.slf4j.LoggerFactory;
 
 import com.mysql.cj.CharsetMapping;
 
-import io.confluent.credentialprovider.JdbcCredentials;
+import io.confluent.credentialprovider.JdbcCredential;
 import io.debezium.DebeziumException;
 import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.CommonConnectorConfig.EventProcessingFailureHandlingMode;
@@ -576,7 +576,7 @@ public class MySqlConnection extends JdbcConnection {
         }
 
         public String username() {
-            JdbcCredentials creds = JdbcCredentialsUtil.getCredentials(
+            JdbcCredential creds = JdbcCredentialsUtil.getCredentials(
                     JdbcCredentialsUtil.getCredentialsProvider(config),
                     config
             );
@@ -590,7 +590,7 @@ public class MySqlConnection extends JdbcConnection {
         }
 
         public String password() {
-            JdbcCredentials creds = JdbcCredentialsUtil.getCredentials(
+            JdbcCredential creds = JdbcCredentialsUtil.getCredentials(
                     JdbcCredentialsUtil.getCredentialsProvider(config),
                     config
             );

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
@@ -18,7 +18,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.confluent.credentialprovider.JdbcCredentials;
-import io.confluent.credentialprovider.JdbcCredentialsProvider;
 import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.ConfigDefinition;
 import io.debezium.config.Configuration;
@@ -972,9 +971,6 @@ public class MySqlConnectorConfig extends HistorizedRelationalDatabaseConnectorC
     private final EventProcessingFailureHandlingMode inconsistentSchemaFailureHandlingMode;
     private final boolean readOnlyConnection;
 
-    private JdbcCredentialsProvider credentialsProvider;
-    private JdbcCredentials cachedCredentials;
-
     public MySqlConnectorConfig(Configuration config) {
         super(
                 MySqlConnector.class,
@@ -1085,14 +1081,6 @@ public class MySqlConnectorConfig extends HistorizedRelationalDatabaseConnectorC
 
         // Everything checks out ok.
         return 0;
-    }
-
-    // Synchronized method to ensure thread-safe credential caching
-    private synchronized JdbcCredentials getCredentials() {
-        if (cachedCredentials == null && credentialsProvider != null) {
-            cachedCredentials = credentialsProvider.getJdbcCreds();
-        }
-        return cachedCredentials;
     }
 
     @Override

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
@@ -17,6 +17,8 @@ import org.apache.kafka.common.config.ConfigDef.Width;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.confluent.credentialprovider.JdbcCredentials;
+import io.confluent.credentialprovider.JdbcCredentialsProvider;
 import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.ConfigDefinition;
 import io.debezium.config.Configuration;
@@ -624,6 +626,16 @@ public class MySqlConnectorConfig extends HistorizedRelationalDatabaseConnectorC
             .withValidation(Field::isClassName)
             .withDescription("JDBC Driver class name used to connect to the MySQL database server.");
 
+    public static final Field CREDENTIALS_PROVIDER = Field.create("credentials.provider.class")
+            .withDisplayName("JDBC Credentials Provider Class Name")
+            .withType(Type.CLASS)
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTION, 41))
+            .withWidth(Width.MEDIUM)
+            .withDefault(com.mysql.cj.jdbc.Driver.class.getName())
+            .withImportance(Importance.LOW)
+            .withValidation(Field::isClassName)
+            .withDescription("JDBC Driver class name used to connect to the MySQL database server.");
+
     public static final Field JDBC_PROTOCOL = Field.create(DATABASE_CONFIG_PREFIX + "protocol")
             .withDisplayName("JDBC Protocol")
             .withType(Type.STRING)
@@ -891,6 +903,7 @@ public class MySqlConnectorConfig extends HistorizedRelationalDatabaseConnectorC
                     ON_CONNECT_STATEMENTS,
                     SERVER_ID,
                     SERVER_ID_OFFSET,
+                    CREDENTIALS_PROVIDER,
                     SSL_MODE,
                     SSL_KEYSTORE,
                     SSL_KEYSTORE_PASSWORD,
@@ -960,6 +973,9 @@ public class MySqlConnectorConfig extends HistorizedRelationalDatabaseConnectorC
     private final EventProcessingFailureHandlingMode inconsistentSchemaFailureHandlingMode;
     private final boolean readOnlyConnection;
 
+    private JdbcCredentialsProvider credentialsProvider;
+    private JdbcCredentials cachedCredentials;
+
     public MySqlConnectorConfig(Configuration config) {
         super(
                 MySqlConnector.class,
@@ -991,6 +1007,20 @@ public class MySqlConnectorConfig extends HistorizedRelationalDatabaseConnectorC
                 : (gtidSetExcludes != null ? Predicates.excludesUuids(gtidSetExcludes) : null);
 
         this.storeOnlyCapturedDatabasesDdl = config.getBoolean(STORE_ONLY_CAPTURED_DATABASES_DDL);
+        try {
+            // try to get the credentials provider class from configuration
+            String credProviderClassName = config.getString(CREDENTIALS_PROVIDER);
+            if (credProviderClassName != null) {
+                Class<?> credProviderClass = Class.forName(credProviderClassName);
+                this.credentialsProvider = (JdbcCredentialsProvider) credProviderClass.getDeclaredConstructor().newInstance();
+
+                // Configure the credentials provider with the current configuration
+                this.credentialsProvider.configure(config.asMap());
+            }
+        } catch (Exception e) {
+            // Log or handle initialization error
+            LOGGER.error("Failed to initialize credentials provider", e);
+        }
     }
 
     public boolean useCursorFetch() {
@@ -1072,6 +1102,14 @@ public class MySqlConnectorConfig extends HistorizedRelationalDatabaseConnectorC
         return 0;
     }
 
+    // Synchronized method to ensure thread-safe credential caching
+    private synchronized JdbcCredentials getCredentials() {
+        if (cachedCredentials == null && credentialsProvider != null) {
+            cachedCredentials = credentialsProvider.getJdbcCreds();
+        }
+        return cachedCredentials;
+    }
+
     @Override
     protected SourceInfoStructMaker<? extends AbstractSourceInfo> getSourceInfoStructMaker(Version version) {
         return getSourceInfoStructMaker(SOURCE_INFO_STRUCT_MAKER, Module.name(), Module.version(), this);
@@ -1113,10 +1151,24 @@ public class MySqlConnectorConfig extends HistorizedRelationalDatabaseConnectorC
     }
 
     public String username() {
+
+        // this is only valid for the streaming part because binlog client uses this. for snapshot we need to tweak the JdbcConnection.java's pattern based factory
+        // here it should always call the credsProvider.getUsername(). The credsProvider in turn would be passed the config and the type of auth to use
+        // if it is iam or something, then it would return the username and the rds token generated for the user using the ChainedAssumeRoleProvider
+        if (credentialsProvider != null) {
+            JdbcCredentials creds = getCredentials();
+            return creds != null ? creds.user() : config.getString(USER);
+        }
         return config.getString(USER);
     }
 
     public String password() {
+        // this is only valid for the streaming part because binlog client uses this. for snapshot we need to tweak the JdbcConnection.java's pattern based factory
+        // here it should always call the credsProvider.getPassword()
+        if (credentialsProvider != null) {
+            JdbcCredentials creds = getCredentials();
+            return creds != null ? creds.password() : config.getString(PASSWORD);
+        }
         return config.getString(PASSWORD);
     }
 

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
@@ -17,7 +17,7 @@ import org.apache.kafka.common.config.ConfigDef.Width;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.confluent.credentialprovider.JdbcCredentials;
+import io.confluent.credentialprovider.JdbcCredential;
 import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.ConfigDefinition;
 import io.debezium.config.Configuration;
@@ -1128,7 +1128,7 @@ public class MySqlConnectorConfig extends HistorizedRelationalDatabaseConnectorC
         // this is only valid for the streaming part because binlog client uses this. for snapshot we need to tweak the JdbcConnection.java's pattern based factory
         // here it should always call the credsProvider.getUsername(). The credsProvider in turn would be passed the config and the type of auth to use
         // if it is iam or something, then it would return the username and the rds token generated for the user using the ChainedAssumeRoleProvider
-        JdbcCredentials creds = JdbcCredentialsUtil.getCredentials(
+        JdbcCredential creds = JdbcCredentialsUtil.getCredentials(
                 JdbcCredentialsUtil.getCredentialsProvider(config),
                 config
         );
@@ -1138,7 +1138,7 @@ public class MySqlConnectorConfig extends HistorizedRelationalDatabaseConnectorC
     public String password() {
         // this is only valid for the streaming part because binlog client uses this. for snapshot we need to tweak the JdbcConnection.java's pattern based factory
         // here it should always call the credsProvider.getPassword()
-        JdbcCredentials creds = JdbcCredentialsUtil.getCredentials(
+        JdbcCredential creds = JdbcCredentialsUtil.getCredentials(
                 JdbcCredentialsUtil.getCredentialsProvider(config),
                 config
         );

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
@@ -632,7 +632,7 @@ public class MySqlConnectorConfig extends HistorizedRelationalDatabaseConnectorC
             .withWidth(Width.MEDIUM)
             .withImportance(Importance.LOW)
             .withValidation(Field::isClassName)
-            .withDescription("JDBC Credentials Provider class name used to provide credentials for connecting to the MySQL database server.\"");
+            .withDescription("JDBC Credentials Provider class name used to provide credentials for connecting to the MySQL database server.");
 
     public static final Field JDBC_PROTOCOL = Field.create(DATABASE_CONFIG_PREFIX + "protocol")
             .withDisplayName("JDBC Protocol")

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
@@ -633,7 +633,7 @@ public class MySqlConnectorConfig extends HistorizedRelationalDatabaseConnectorC
             .withWidth(Width.MEDIUM)
             .withImportance(Importance.LOW)
             .withValidation(Field::isClassName)
-            .withDescription("JDBC Driver class name used to connect to the MySQL database server.");
+            .withDescription("JDBC Credentials Provider class name used to provide credentials for connecting to the MySQL database server.\"");
 
     public static final Field JDBC_PROTOCOL = Field.create(DATABASE_CONFIG_PREFIX + "protocol")
             .withDisplayName("JDBC Protocol")

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
@@ -631,7 +631,6 @@ public class MySqlConnectorConfig extends HistorizedRelationalDatabaseConnectorC
             .withType(Type.CLASS)
             .withGroup(Field.createGroupEntry(Field.Group.CONNECTION, 41))
             .withWidth(Width.MEDIUM)
-            .withDefault(com.mysql.cj.jdbc.Driver.class.getName())
             .withImportance(Importance.LOW)
             .withValidation(Field::isClassName)
             .withDescription("JDBC Driver class name used to connect to the MySQL database server.");


### PR DESCRIPTION
## Status
Works on Kafka Docker Playground. 

## Todo
- check connection refreshing and disable caching as creds would expire after some time (15mins ?)
- onboard the configs to templates and test on cloud

## Description
The modified the factory() method in MySqlConnectionConfiguration returns a decorated ConnectionFactory with the creds from the credentialsProvider if available.
This is required because the connection factory captured configuration values at initialization time rather than connection time.