### PR TITLE
CC-33244 -- Move schema history recovery out of the task start

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorTask.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorTask.java
@@ -109,9 +109,9 @@ public class MySqlConnectorTask extends BaseSourceTask<MySqlPartition, MySqlOffs
         MySqlPartition partition = previousOffsets.getTheOnlyPartition();
         MySqlOffsetContext previousOffset = previousOffsets.getTheOnlyOffset();
 
-        validateAndLoadSchemaHistory(connectorConfig, partition, previousOffset, schema);
+        validateSchemaHistory(connectorConfig, partition, previousOffset, schema);
 
-        LOGGER.info("Reconnecting after finishing schema recovery");
+        LOGGER.info("Reconnecting after validating schema history");
 
         try {
             connection.setAutoCommit(false);
@@ -332,7 +332,7 @@ public class MySqlConnectorTask extends BaseSourceTask<MySqlPartition, MySqlOffs
         return found;
     }
 
-    private boolean validateAndLoadSchemaHistory(MySqlConnectorConfig config, MySqlPartition partition, MySqlOffsetContext offset, MySqlDatabaseSchema schema) {
+    private boolean validateSchemaHistory(MySqlConnectorConfig config, MySqlPartition partition, MySqlOffsetContext offset, MySqlDatabaseSchema schema) {
         if (offset == null) {
             if (config.getSnapshotMode().shouldSnapshotOnSchemaError()) {
                 // We are in schema only recovery mode, use the existing binlog position
@@ -362,7 +362,6 @@ public class MySqlConnectorTask extends BaseSourceTask<MySqlPartition, MySqlOffs
             schema.initializeStorage();
             return true;
         }
-        schema.recover(partition, offset);
         return false;
     }
 

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorIT.java
@@ -33,7 +33,6 @@ import java.util.stream.StreamSupport;
 import io.confluent.credentialproviders.DefaultJdbcCredentialsProvider;
 import org.apache.kafka.common.config.Config;
 import org.apache.kafka.connect.data.Struct;
-import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.header.Header;
 import org.apache.kafka.connect.source.SourceRecord;
@@ -2631,19 +2630,19 @@ public class MySqlConnectorIT extends AbstractConnectorTest {
             .build();
 
         start(MySqlConnector.class, config);
-        logger.info("Sleeping for 10 seconds to allow connector to start and commit an offset");
-        Thread.sleep(10_000);
+        logger.info("Sleeping for 2 seconds to allow connector to start and commit an offset");
+        Thread.sleep(2_000);
 
         stopConnector();
 
-        CountDownLatch tastStartLatch = new CountDownLatch(1);
+        CountDownLatch taskStartLatch = new CountDownLatch(1);
 
         Thread startConnectorThread = new Thread(() -> {
             logger.info("Starting connector again");
             start(MySqlConnector.class, config, new DebeziumEngine.ConnectorCallback() {
                 @Override
                 public void taskStarted() {
-                    tastStartLatch.countDown();
+                    taskStartLatch.countDown();
                 }
             });
         });
@@ -2653,10 +2652,10 @@ public class MySqlConnectorIT extends AbstractConnectorTest {
         logger.info("Waiting for task to start");
         
         // Wait for 5 seconds for the task to be started
-        Awaitility.await().atMost(5, TimeUnit.SECONDS).until(() -> tastStartLatch.getCount() == 0);
+        Awaitility.await().atMost(5, TimeUnit.SECONDS).until(() -> taskStartLatch.getCount() == 0);
         
         // fail the test if task did not start in 5 seconds
-        if (tastStartLatch.getCount() != 0) {
+        if (taskStartLatch.getCount() != 0) {
             throw new AssertionError("Task did not start in 5 seconds after " +
                 "connector was started. Task's start method should be lightweight and " +
                 "hence this is not expected.");

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlDatabaseSchemaTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlDatabaseSchemaTest.java
@@ -90,7 +90,7 @@ public class MySqlDatabaseSchemaTest {
     }
 
     @Test
-    public void shouldApplyDdlStatementsAndRecover() throws Exception {
+    public void shouldApplyDdlStatementsAndRecover() throws InterruptedException {
         // Testing.Print.enable();
         final Configuration config = DATABASE.defaultConfig().build();
         mysql = getSchema(config);
@@ -115,7 +115,7 @@ public class MySqlDatabaseSchemaTest {
     }
 
     @Test
-    public void shouldIgnoreUnparseableDdlAndRecover() throws Exception {
+    public void shouldIgnoreUnparseableDdlAndRecover() throws InterruptedException {
         // Testing.Print.enable();
         final Configuration config = DATABASE.defaultConfig()
                 .with(SchemaHistory.SKIP_UNPARSEABLE_DDL_STATEMENTS, true)
@@ -163,7 +163,7 @@ public class MySqlDatabaseSchemaTest {
     }
 
     @Test
-    public void shouldLoadSystemAndNonSystemTablesAndConsumeOnlyFilteredDatabases() throws Exception {
+    public void shouldLoadSystemAndNonSystemTablesAndConsumeOnlyFilteredDatabases() throws InterruptedException {
         // Testing.Print.enable();
         final Configuration config = DATABASE.defaultConfigWithoutDatabaseFilter()
                 .with(SchemaHistory.SKIP_UNPARSEABLE_DDL_STATEMENTS, true)
@@ -196,7 +196,7 @@ public class MySqlDatabaseSchemaTest {
     }
 
     @Test
-    public void shouldLoadSystemAndNonSystemTablesAndConsumeAllDatabases() throws Exception {
+    public void shouldLoadSystemAndNonSystemTablesAndConsumeAllDatabases() throws InterruptedException {
         // Testing.Print.enable();
         final Configuration config = DATABASE.defaultConfigWithoutDatabaseFilter()
                 .with(SchemaHistory.SKIP_UNPARSEABLE_DDL_STATEMENTS, true)
@@ -230,7 +230,7 @@ public class MySqlDatabaseSchemaTest {
     }
 
     @Test
-    public void shouldAllowDecimalPrecision() throws Exception {
+    public void shouldAllowDecimalPrecision() throws InterruptedException {
         // Testing.Print.enable();
         final Configuration config = DATABASE.defaultConfig()
                 .with(SchemaHistory.SKIP_UNPARSEABLE_DDL_STATEMENTS, false)
@@ -459,7 +459,7 @@ public class MySqlDatabaseSchemaTest {
         assertThat(mysql.tableIds().stream().filter(id -> id.catalog().equals(dbName)).count()).isGreaterThan(0);
     }
 
-    protected void assertHistoryRecorded(Configuration config, MySqlPartition partition, OffsetContext offset) throws Exception {
+    protected void assertHistoryRecorded(Configuration config, MySqlPartition partition, OffsetContext offset) throws InterruptedException {
         try (MySqlDatabaseSchema duplicate = getSchema(config)) {
             duplicate.recover(Offsets.of(partition, offset));
 

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlDatabaseSchemaTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlDatabaseSchemaTest.java
@@ -253,7 +253,7 @@ public class MySqlDatabaseSchemaTest {
 
     @Test
     @FixFor("DBZ-3622")
-    public void shouldStoreNonCapturedDatabase() throws Exception {
+    public void shouldStoreNonCapturedDatabase() throws InterruptedException {
         // Testing.Print.enable();
         final Configuration config = DATABASE.defaultConfig()
                 .with(SchemaHistory.SKIP_UNPARSEABLE_DDL_STATEMENTS, false)
@@ -285,7 +285,7 @@ public class MySqlDatabaseSchemaTest {
 
     @Test
     @FixFor("DBZ-3622")
-    public void shouldNotStoreNonCapturedDatabase() throws Exception {
+    public void shouldNotStoreNonCapturedDatabase() throws InterruptedException {
         // Testing.Print.enable();
         final Configuration config = DATABASE.defaultConfig()
                 .with(SchemaHistory.SKIP_UNPARSEABLE_DDL_STATEMENTS, false)
@@ -318,7 +318,7 @@ public class MySqlDatabaseSchemaTest {
 
     @Test
     @FixFor("DBZ-3622")
-    public void shouldStoreNonCapturedTable() throws Exception {
+    public void shouldStoreNonCapturedTable() throws InterruptedException {
         // Testing.Print.enable();
         final Configuration config = DATABASE.defaultConfigWithoutDatabaseFilter()
                 .with(SchemaHistory.SKIP_UNPARSEABLE_DDL_STATEMENTS, false)
@@ -350,7 +350,7 @@ public class MySqlDatabaseSchemaTest {
 
     @Test
     @FixFor("DBZ-3622")
-    public void shouldNotStoreNonCapturedTable() throws Exception {
+    public void shouldNotStoreNonCapturedTable() throws InterruptedException {
         // Testing.Print.enable();
         final Configuration config = DATABASE.defaultConfigWithoutDatabaseFilter()
                 .with(SchemaHistory.SKIP_UNPARSEABLE_DDL_STATEMENTS, false)

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlDatabaseSchemaTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlDatabaseSchemaTest.java
@@ -90,7 +90,7 @@ public class MySqlDatabaseSchemaTest {
     }
 
     @Test
-    public void shouldApplyDdlStatementsAndRecover() throws InterruptedException {
+    public void shouldApplyDdlStatementsAndRecover() throws Exception {
         // Testing.Print.enable();
         final Configuration config = DATABASE.defaultConfig().build();
         mysql = getSchema(config);
@@ -115,7 +115,7 @@ public class MySqlDatabaseSchemaTest {
     }
 
     @Test
-    public void shouldIgnoreUnparseableDdlAndRecover() throws InterruptedException {
+    public void shouldIgnoreUnparseableDdlAndRecover() throws Exception {
         // Testing.Print.enable();
         final Configuration config = DATABASE.defaultConfig()
                 .with(SchemaHistory.SKIP_UNPARSEABLE_DDL_STATEMENTS, true)
@@ -163,7 +163,7 @@ public class MySqlDatabaseSchemaTest {
     }
 
     @Test
-    public void shouldLoadSystemAndNonSystemTablesAndConsumeOnlyFilteredDatabases() throws InterruptedException {
+    public void shouldLoadSystemAndNonSystemTablesAndConsumeOnlyFilteredDatabases() throws Exception {
         // Testing.Print.enable();
         final Configuration config = DATABASE.defaultConfigWithoutDatabaseFilter()
                 .with(SchemaHistory.SKIP_UNPARSEABLE_DDL_STATEMENTS, true)
@@ -196,7 +196,7 @@ public class MySqlDatabaseSchemaTest {
     }
 
     @Test
-    public void shouldLoadSystemAndNonSystemTablesAndConsumeAllDatabases() throws InterruptedException {
+    public void shouldLoadSystemAndNonSystemTablesAndConsumeAllDatabases() throws Exception {
         // Testing.Print.enable();
         final Configuration config = DATABASE.defaultConfigWithoutDatabaseFilter()
                 .with(SchemaHistory.SKIP_UNPARSEABLE_DDL_STATEMENTS, true)
@@ -230,7 +230,7 @@ public class MySqlDatabaseSchemaTest {
     }
 
     @Test
-    public void shouldAllowDecimalPrecision() {
+    public void shouldAllowDecimalPrecision() throws Exception {
         // Testing.Print.enable();
         final Configuration config = DATABASE.defaultConfig()
                 .with(SchemaHistory.SKIP_UNPARSEABLE_DDL_STATEMENTS, false)
@@ -253,7 +253,7 @@ public class MySqlDatabaseSchemaTest {
 
     @Test
     @FixFor("DBZ-3622")
-    public void shouldStoreNonCapturedDatabase() {
+    public void shouldStoreNonCapturedDatabase() throws Exception {
         // Testing.Print.enable();
         final Configuration config = DATABASE.defaultConfig()
                 .with(SchemaHistory.SKIP_UNPARSEABLE_DDL_STATEMENTS, false)
@@ -285,7 +285,7 @@ public class MySqlDatabaseSchemaTest {
 
     @Test
     @FixFor("DBZ-3622")
-    public void shouldNotStoreNonCapturedDatabase() {
+    public void shouldNotStoreNonCapturedDatabase() throws Exception {
         // Testing.Print.enable();
         final Configuration config = DATABASE.defaultConfig()
                 .with(SchemaHistory.SKIP_UNPARSEABLE_DDL_STATEMENTS, false)
@@ -318,7 +318,7 @@ public class MySqlDatabaseSchemaTest {
 
     @Test
     @FixFor("DBZ-3622")
-    public void shouldStoreNonCapturedTable() {
+    public void shouldStoreNonCapturedTable() throws Exception {
         // Testing.Print.enable();
         final Configuration config = DATABASE.defaultConfigWithoutDatabaseFilter()
                 .with(SchemaHistory.SKIP_UNPARSEABLE_DDL_STATEMENTS, false)
@@ -350,7 +350,7 @@ public class MySqlDatabaseSchemaTest {
 
     @Test
     @FixFor("DBZ-3622")
-    public void shouldNotStoreNonCapturedTable() {
+    public void shouldNotStoreNonCapturedTable() throws Exception {
         // Testing.Print.enable();
         final Configuration config = DATABASE.defaultConfigWithoutDatabaseFilter()
                 .with(SchemaHistory.SKIP_UNPARSEABLE_DDL_STATEMENTS, false)
@@ -459,7 +459,7 @@ public class MySqlDatabaseSchemaTest {
         assertThat(mysql.tableIds().stream().filter(id -> id.catalog().equals(dbName)).count()).isGreaterThan(0);
     }
 
-    protected void assertHistoryRecorded(Configuration config, MySqlPartition partition, OffsetContext offset) {
+    protected void assertHistoryRecorded(Configuration config, MySqlPartition partition, OffsetContext offset) throws Exception {
         try (MySqlDatabaseSchema duplicate = getSchema(config)) {
             duplicate.recover(Offsets.of(partition, offset));
 

--- a/debezium-connector-mysql/src/test/java/io/debezium/relational/history/AbstractSchemaHistoryTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/relational/history/AbstractSchemaHistoryTest.java
@@ -85,14 +85,14 @@ public abstract class AbstractSchemaHistoryTest {
         }
     }
 
-    protected Tables recover(long pos, int entry) {
+    protected Tables recover(long pos, int entry) throws InterruptedException {
         Tables result = new Tables();
         history.recover(source1, position("a.log", pos, entry), result, parser);
         return result;
     }
 
     @Test
-    public void shouldRecordChangesAndRecoverToVariousPoints() {
+    public void shouldRecordChangesAndRecoverToVariousPoints() throws InterruptedException {
         record(01, 0, "CREATE TABLE foo ( first VARCHAR(22) NOT NULL );", all, t3, t2, t1, t0);
         record(23, 1, "CREATE TABLE\nperson ( name VARCHAR(22) NOT NULL );", all, t3, t2, t1);
         record(30, 2, "CREATE TABLE address\n( street VARCHAR(22) NOT NULL );", all, t3, t2);

--- a/debezium-connector-mysql/src/test/java/io/debezium/relational/history/KafkaSchemaHistoryTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/relational/history/KafkaSchemaHistoryTest.java
@@ -156,7 +156,7 @@ public class KafkaSchemaHistoryTest {
         return config;
     }
 
-    private void testHistoryTopicContent(String topicName, boolean skipUnparseableDDL) {
+    private void testHistoryTopicContent(String topicName, boolean skipUnparseableDDL) throws InterruptedException {
         Configuration config = startHistory(topicName, skipUnparseableDDL);
 
         DdlParser recoveryParser = new MySqlAntlrDdlParser();
@@ -343,7 +343,7 @@ public class KafkaSchemaHistoryTest {
     }
 
     @Test
-    public void testExists() {
+    public void testExists() throws InterruptedException {
         String topicName = "exists-schema-changes";
 
         // happy path

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerDatabaseSchema.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerDatabaseSchema.java
@@ -70,5 +70,9 @@ public class SqlServerDatabaseSchema extends HistorizedRelationalDatabaseSchema 
     protected DdlParser getDdlParser() {
         return null;
     }
+    
+    public boolean historyExists() {
+        return schemaHistory.exists();
+    }
 
 }

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectorIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectorIT.java
@@ -3057,8 +3057,8 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
             .build();
 
         start(SqlServerConnector.class, config);
-        logger.info("Sleeping for 10 seconds to allow connector to start and commit an offset");
-        Thread.sleep(10_000);
+        logger.info("Sleeping for 2 seconds to allow connector to start and commit an offset");
+        Thread.sleep(2_000);
 
         stopConnector();
 

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectorIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectorIT.java
@@ -12,6 +12,7 @@ import static io.debezium.connector.sqlserver.util.TestHelper.TYPE_SCALE_PARAMET
 import static io.debezium.connector.sqlserver.util.TestHelper.waitForStreamingStarted;
 import static io.debezium.relational.RelationalDatabaseConnectorConfig.SCHEMA_EXCLUDE_LIST;
 import static io.debezium.relational.RelationalDatabaseConnectorConfig.SCHEMA_INCLUDE_LIST;
+import static io.debezium.relational.history.SchemaHistory.SCHEMA_HISTORY_RECOVERY_DELAY_MS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 import static org.junit.Assert.assertEquals;
@@ -33,9 +34,11 @@ import java.util.Set;
 import java.util.TimeZone;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.CountDownLatch;
 
 import javax.management.InstanceNotFoundException;
 
+import io.debezium.engine.DebeziumEngine;
 import org.apache.kafka.common.config.Config;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
@@ -3015,12 +3018,12 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
         }
 
         @Override
-        public void recover(Offsets<?, ?> offsets, Tables schema, DdlParser ddlParser) {
+        public void recover(Offsets<?, ?> offsets, Tables schema, DdlParser ddlParser) throws InterruptedException {
             delegate.recover(offsets, schema, ddlParser);
         }
 
         @Override
-        public void recover(Map<Map<String, ?>, Map<String, ?>> offsets, Tables schema, DdlParser ddlParser) {
+        public void recover(Map<Map<String, ?>, Map<String, ?>> offsets, Tables schema, DdlParser ddlParser) throws InterruptedException {
             delegate.recover(offsets, schema, ddlParser);
         }
 
@@ -3043,5 +3046,46 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
     @FunctionalInterface
     interface SqlRunnable {
         void run() throws SQLException;
+    }
+
+    @Test
+    public void taskStartShouldNotWaitOnSchemaHistoryRecovery() throws InterruptedException {
+        // Introduce a delay of 10 seconds in recovering every record in schema history. This is 
+        // done to increase the time taken to recovery schema history.
+        Configuration config = TestHelper.defaultConfig()
+            .with(SCHEMA_HISTORY_RECOVERY_DELAY_MS, 10_000)
+            .build();
+
+        start(SqlServerConnector.class, config);
+        logger.info("Sleeping for 10 seconds to allow connector to start and commit an offset");
+        Thread.sleep(10_000);
+
+        stopConnector();
+
+        CountDownLatch taskStartLatch = new CountDownLatch(1);
+
+        Thread startConnectorThread = new Thread(() -> {
+            logger.info("Starting connector again");
+            start(SqlServerConnector.class, config, new DebeziumEngine.ConnectorCallback() {
+                @Override
+                public void taskStarted() {
+                    taskStartLatch.countDown();
+                }
+            });
+        });
+        
+        startConnectorThread.start();
+        
+        logger.info("Waiting for task to start");
+        
+        // Wait for 5 seconds for the task to be started
+        Awaitility.await().atMost(5, TimeUnit.SECONDS).until(() -> taskStartLatch.getCount() == 0);
+        
+        // fail the test if task did not start in 5 seconds
+        if (taskStartLatch.getCount() != 0) {
+            throw new AssertionError("Task did not start in 5 seconds after " +
+                "connector was started. Task's start method should be lightweight and " +
+                "hence this is not expected.");
+        }
     }
 }

--- a/debezium-core/src/main/java/io/debezium/pipeline/spi/Offsets.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/spi/Offsets.java
@@ -9,6 +9,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 
 import io.debezium.DebeziumException;
@@ -44,6 +45,10 @@ public final class Offsets<P extends Partition, O extends OffsetContext> impleme
 
     public Map<P, O> getOffsets() {
         return offsets;
+    }
+    
+    public boolean hasNonNullOffsets(){
+        return offsets.values().stream().anyMatch(Objects::nonNull);
     }
 
     @Override

--- a/debezium-core/src/main/java/io/debezium/relational/HistorizedRelationalDatabaseSchema.java
+++ b/debezium-core/src/main/java/io/debezium/relational/HistorizedRelationalDatabaseSchema.java
@@ -52,20 +52,11 @@ public abstract class HistorizedRelationalDatabaseSchema extends RelationalDatab
     }
 
     @Override
-    public void recover(Offsets<?, ?> offsets) {
-        final boolean hasNonNullOffsets = offsets.getOffsets()
-                .values()
-                .stream()
-                .anyMatch(Objects::nonNull);
+    public void recover(Offsets<?, ?> offsets) throws InterruptedException {
 
-        if (!hasNonNullOffsets) {
+        if (!offsets.hasNonNullOffsets()) {
             // there is nothing to recover
             return;
-        }
-
-        if (!schemaHistory.exists()) {
-            String msg = "The db history topic or its content is fully or partially missing. Please check database schema history topic configuration and re-execute the snapshot.";
-            throw new DebeziumException(msg);
         }
 
         schemaHistory.recover(offsets, tables(), getDdlParser());

--- a/debezium-core/src/main/java/io/debezium/relational/history/AbstractFileBasedSchemaHistory.java
+++ b/debezium-core/src/main/java/io/debezium/relational/history/AbstractFileBasedSchemaHistory.java
@@ -124,7 +124,18 @@ public abstract class AbstractFileBasedSchemaHistory extends AbstractSchemaHisto
 
     @Override
     protected void recoverRecords(Consumer<HistoryRecord> records) {
-        lock.write(() -> getRecords().forEach(records));
+        lock.write(() -> {
+            for (HistoryRecord record : getRecords()) {
+                records.accept(record);
+                try {
+                    LOGGER.info("Sleeping for {} ms to emulate CPU-intensive environment", config.getLong(SCHEMA_HISTORY_RECOVERY_DELAY_MS));
+                    Thread.sleep(config.getLong(SCHEMA_HISTORY_RECOVERY_DELAY_MS));
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException("Interrupted while recovering records", e);
+                }
+            }
+        });
     }
 
     @Override

--- a/debezium-core/src/main/java/io/debezium/relational/history/AbstractSchemaHistory.java
+++ b/debezium-core/src/main/java/io/debezium/relational/history/AbstractSchemaHistory.java
@@ -87,7 +87,7 @@ public abstract class AbstractSchemaHistory implements SchemaHistory {
     }
 
     @Override
-    public void recover(Map<Map<String, ?>, Map<String, ?>> offsets, Tables schema, DdlParser ddlParser) {
+    public void recover(Map<Map<String, ?>, Map<String, ?>> offsets, Tables schema, DdlParser ddlParser) throws InterruptedException {
         listener.recoveryStarted();
         Map<Document, HistoryRecord> stopPoints = new HashMap<>();
         offsets.forEach((Map<String, ?> source, Map<String, ?> position) -> {
@@ -161,7 +161,7 @@ public abstract class AbstractSchemaHistory implements SchemaHistory {
 
     protected abstract void storeRecord(HistoryRecord record) throws SchemaHistoryException;
 
-    protected abstract void recoverRecords(Consumer<HistoryRecord> records);
+    protected abstract void recoverRecords(Consumer<HistoryRecord> records) throws InterruptedException;
 
     @Override
     public void stop() {

--- a/debezium-core/src/main/java/io/debezium/relational/history/SchemaHistory.java
+++ b/debezium-core/src/main/java/io/debezium/relational/history/SchemaHistory.java
@@ -53,7 +53,8 @@ public interface SchemaHistory {
                     + "which it cannot parse. If skipping is enabled then Debezium can miss metadata changes.")
             .withDefault(false);
 
-    Field SCHEMA_HISTORY_RECOVERY_DELAY_MS = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + "recovery.delay.ms")
+    // Not intended to be used in production code. This is only for testing.
+    Field SCHEMA_HISTORY_RECOVERY_DELAY_MS = Field.createInternal(CONFIGURATION_FIELD_PREFIX_STRING + "recovery.delay.ms")
             .withDisplayName("Schema history recovery delay in milliseconds")
             .withType(Type.LONG)
             .withWidth(Width.SHORT)

--- a/debezium-core/src/main/java/io/debezium/relational/history/SchemaHistory.java
+++ b/debezium-core/src/main/java/io/debezium/relational/history/SchemaHistory.java
@@ -53,6 +53,15 @@ public interface SchemaHistory {
                     + "which it cannot parse. If skipping is enabled then Debezium can miss metadata changes.")
             .withDefault(false);
 
+    Field SCHEMA_HISTORY_RECOVERY_DELAY_MS = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + "recovery.delay.ms")
+            .withDisplayName("Schema history recovery delay in milliseconds")
+            .withType(Type.LONG)
+            .withWidth(Width.SHORT)
+            .withImportance(Importance.LOW)
+            .withDescription("Specifies the amount of time in milliseconds to wait between processing schema history records.")
+            .withDefault(0L);
+    
+
     Field STORE_ONLY_CAPTURED_TABLES_DDL = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + "store.only.captured.tables.ddl")
             .withDisplayName("Store only DDL that modifies tables that are captured based on include/exclude lists")
             .withType(Type.BOOLEAN)
@@ -165,7 +174,7 @@ public interface SchemaHistory {
      * @deprecated Use {@link #recover(Offsets, Tables, DdlParser)} instead.
      */
     @Deprecated
-    default void recover(Map<String, ?> source, Map<String, ?> position, Tables schema, DdlParser ddlParser) {
+    default void recover(Map<String, ?> source, Map<String, ?> position, Tables schema, DdlParser ddlParser) throws InterruptedException {
         recover(Collections.singletonMap(source, position), schema, ddlParser);
     }
 
@@ -182,7 +191,7 @@ public interface SchemaHistory {
      *            may not be null
      * @param ddlParser the DDL parser that can be used to apply DDL statements to the given {@code schema}; may not be null
      */
-    default void recover(Offsets<?, ?> offsets, Tables schema, DdlParser ddlParser) {
+    default void recover(Offsets<?, ?> offsets, Tables schema, DdlParser ddlParser) throws InterruptedException {
         Map<Map<String, ?>, Map<String, ?>> offsetMap = new HashMap<>();
         for (Entry<? extends Partition, ? extends OffsetContext> entry : offsets) {
             if (entry.getValue() != null) {
@@ -197,7 +206,7 @@ public interface SchemaHistory {
      * @deprecated Use {@link #recover(Offsets, Tables, DdlParser)} instead.
      */
     @Deprecated
-    void recover(Map<Map<String, ?>, Map<String, ?>> offsets, Tables schema, DdlParser ddlParser);
+    void recover(Map<Map<String, ?>, Map<String, ?>> offsets, Tables schema, DdlParser ddlParser) throws InterruptedException;
 
     /**
      * Stop recording history and release any resources acquired since {@link #configure(Configuration, HistoryRecordComparator, SchemaHistoryListener, boolean)}.

--- a/debezium-core/src/main/java/io/debezium/schema/HistorizedDatabaseSchema.java
+++ b/debezium-core/src/main/java/io/debezium/schema/HistorizedDatabaseSchema.java
@@ -36,11 +36,11 @@ public interface HistorizedDatabaseSchema<I extends DataCollectionId> extends Da
 
     void applySchemaChange(SchemaChangeEvent schemaChange);
 
-    default void recover(Partition partition, OffsetContext offset) {
+    default void recover(Partition partition, OffsetContext offset) throws InterruptedException {
         recover(Offsets.of(partition, offset));
     }
 
-    void recover(Offsets<?, ?> offsets);
+    void recover(Offsets<?, ?> offsets) throws InterruptedException;
 
     void initializeStorage();
 

--- a/debezium-embedded/src/test/java/io/debezium/relational/history/AbstractSchemaHistoryTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/relational/history/AbstractSchemaHistoryTest.java
@@ -76,7 +76,7 @@ public abstract class AbstractSchemaHistoryTest extends AbstractConnectorTest {
         Arrays.stream(records).forEach(schemaHistory::storeRecord);
     }
 
-    protected Tables recoverHistory() {
+    protected Tables recoverHistory() throws InterruptedException {
         // Initialize history
         schemaHistory.configure(getHistoryConfiguration(), null, SchemaHistoryMetrics.NOOP, true);
         schemaHistory.start();

--- a/debezium-storage/debezium-storage-kafka/src/main/java/io/debezium/storage/kafka/history/KafkaSchemaHistory.java
+++ b/debezium-storage/debezium-storage-kafka/src/main/java/io/debezium/storage/kafka/history/KafkaSchemaHistory.java
@@ -323,7 +323,6 @@ public class KafkaSchemaHistory extends AbstractSchemaHistory {
                 LOGGER.debug("End offset of database schema history topic is {}", endOffset);
                 
                 checkForInterruption();
-                // DBZ-1361 not using poll(Duration) to keep compatibility with AK 1.x
                 ConsumerRecords<String, String> recoveredRecords = historyConsumer.poll(this.pollInterval);
                 int numRecordsProcessed = 0;
 
@@ -351,8 +350,6 @@ public class KafkaSchemaHistory extends AbstractSchemaHistory {
                             lastProcessedOffset = record.offset();
                             ++numRecordsProcessed;
                         }
-                        LOGGER.info("Sleeping for {} seconds !", config.getLong(SCHEMA_HISTORY_RECOVERY_DELAY_MS)/1000);
-                        Thread.sleep(config.getLong(SCHEMA_HISTORY_RECOVERY_DELAY_MS));
                     }
                     catch (final IOException e) {
                         Loggings.logErrorAndTraceRecord(LOGGER, record, "Error while deserializing history record", e);

--- a/debezium-storage/debezium-storage-kafka/src/main/java/io/debezium/storage/kafka/history/KafkaSchemaHistory.java
+++ b/debezium-storage/debezium-storage-kafka/src/main/java/io/debezium/storage/kafka/history/KafkaSchemaHistory.java
@@ -293,8 +293,14 @@ public class KafkaSchemaHistory extends AbstractSchemaHistory {
         }
     }
 
+    private void checkForInterruption() throws InterruptedException {
+        if (Thread.currentThread().isInterrupted()) {
+            throw new InterruptedException("Thread was interrupted during schema history recovery");
+        }
+    }
+
     @Override
-    protected void recoverRecords(Consumer<HistoryRecord> records) {
+    protected void recoverRecords(Consumer<HistoryRecord> records) throws InterruptedException {
         try (KafkaConsumer<String, String> historyConsumer = new KafkaConsumer<>(consumerConfig.asProperties())) {
             // Subscribe to the only partition for this topic, and seek to the beginning of that partition ...
             LOGGER.debug("Subscribing to database schema history topic '{}'", topicName);
@@ -312,13 +318,17 @@ public class KafkaSchemaHistory extends AbstractSchemaHistory {
                             "The database schema history couldn't be recovered. Consider to increase the value for " + RECOVERY_POLL_INTERVAL_MS.name());
                 }
 
+                checkForInterruption();
                 endOffset = getEndOffsetOfDbHistoryTopic(endOffset, historyConsumer);
                 LOGGER.debug("End offset of database schema history topic is {}", endOffset);
-
+                
+                checkForInterruption();
+                // DBZ-1361 not using poll(Duration) to keep compatibility with AK 1.x
                 ConsumerRecords<String, String> recoveredRecords = historyConsumer.poll(this.pollInterval);
                 int numRecordsProcessed = 0;
 
                 for (ConsumerRecord<String, String> record : recoveredRecords) {
+                    checkForInterruption();
                     try {
                         if (lastProcessedOffset < record.offset()) {
                             if (record.value() == null) {
@@ -341,6 +351,8 @@ public class KafkaSchemaHistory extends AbstractSchemaHistory {
                             lastProcessedOffset = record.offset();
                             ++numRecordsProcessed;
                         }
+                        LOGGER.info("Sleeping for {} seconds !", config.getLong(SCHEMA_HISTORY_RECOVERY_DELAY_MS)/1000);
+                        Thread.sleep(config.getLong(SCHEMA_HISTORY_RECOVERY_DELAY_MS));
                     }
                     catch (final IOException e) {
                         Loggings.logErrorAndTraceRecord(LOGGER, record, "Error while deserializing history record", e);
@@ -359,6 +371,10 @@ public class KafkaSchemaHistory extends AbstractSchemaHistory {
                     recoveryAttempts = 0;
                 }
             } while (lastProcessedOffset < endOffset - 1);
+        }
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw e;
         }
     }
 


### PR DESCRIPTION
### Problem/Solution

Described [here](https://confluentinc.atlassian.net/wiki/spaces/~635b68551cc605b1fd16afeb/pages/4364895962/WIP+Solutions+to+SH+problem#Solution-1)

TLDR;
The implemtnatation of `start` method from the `SourceTask` interface for the mysql cdc connector conditionally can take a lot of time. This time is accounted for the large schema history recovery time. In such cases, due to continuous operator restarts fatal symptoms like thread leaks, high cpu usage, zombie tasks are observed.

To solve this, we are moving the schema history recovery part after the `start` method is complete. By doing this, we are making the implementation of `start` lightweight, which follows the "unsaid" contract. Also the above mentioned issues would no more be present.

### Manual Test

https://confluentinc.atlassian.net/wiki/spaces/~635b68551cc605b1fd16afeb/pages/4323705070/Testing+CC-33244