### PR TITLE
Fix lint and formatting

### DIFF
--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogStreamingChangeEventSource.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogStreamingChangeEventSource.java
@@ -352,9 +352,9 @@ public abstract class BinlogStreamingChangeEventSource<P extends BinlogPartition
 
     static AuthenticationException sanitizeAuthenticationException(AuthenticationException e) {
         String sanitizedError = e.getMessage()
-            .replaceAll("[^\\P{Cc}\t\r\n]", "");
+                .replaceAll("[^\\P{Cc}\t\r\n]", "");
         AuthenticationException sanitized = new AuthenticationException(sanitizedError,
-            e.getErrorCode(), e.getSqlState());
+                e.getErrorCode(), e.getSqlState());
         sanitized.setStackTrace(e.getStackTrace());
         return sanitized;
     }

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogConvertingFailureIT.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogConvertingFailureIT.java
@@ -14,7 +14,6 @@ import java.sql.SQLException;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
-import io.debezium.config.CommonConnectorConfig;
 import org.apache.kafka.connect.source.SourceConnector;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.junit.After;
@@ -22,6 +21,7 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.CommonConnectorConfig.EventConvertingFailureHandlingMode;
 import io.debezium.config.Configuration;
 import io.debezium.connector.binlog.BinlogConnectorConfig.SnapshotMode;

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogReaderSanitizeAuthenticationExceptionTest.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogReaderSanitizeAuthenticationExceptionTest.java
@@ -18,34 +18,34 @@ import com.github.shyiko.mysql.binlog.network.AuthenticationException;
 @RunWith(Parameterized.class)
 public class BinlogReaderSanitizeAuthenticationExceptionTest {
 
-  @Parameterized.Parameters(name = "unsanitized: {0}, sanitized: {1}")
-  public static Iterable<Object[]> parameters() {
-    return Arrays.asList(
-        new Object[][]{
-            { new String(new byte[]{ 0, 1, 2 }), "" },
-            { new String(new byte[]{ 'a', 0 }), "a" },
-            { new String(new byte[]{ 'a', 0, 0, '1' }), "a1" },
-            { "An ascii string", "An ascii string" },
-            { "中文。" + new String(new byte[]{ 0, 0, 0 }), "中文。" },
-            { "Punctuations.Are,preserved;right?", "Punctuations.Are,preserved;right?" },
-            { "New line \n and tabs \t too ?", "New line \n and tabs \t too ?" },
-        });
-  }
+    @Parameterized.Parameters(name = "unsanitized: {0}, sanitized: {1}")
+    public static Iterable<Object[]> parameters() {
+        return Arrays.asList(
+                new Object[][]{
+                        { new String(new byte[]{ 0, 1, 2 }), "" },
+                        { new String(new byte[]{ 'a', 0 }), "a" },
+                        { new String(new byte[]{ 'a', 0, 0, '1' }), "a1" },
+                        { "An ascii string", "An ascii string" },
+                        { "中文。" + new String(new byte[]{ 0, 0, 0 }), "中文。" },
+                        { "Punctuations.Are,preserved;right?", "Punctuations.Are,preserved;right?" },
+                        { "New line \n and tabs \t too ?", "New line \n and tabs \t too ?" },
+                });
+    }
 
-  @Parameterized.Parameter(0)
-  public String unsanitizedString;
+    @Parameterized.Parameter(0)
+    public String unsanitizedString;
 
-  @Parameterized.Parameter(1)
-  public String sanitizedString;
+    @Parameterized.Parameter(1)
+    public String sanitizedString;
 
-  @Test
-  public void sanitizeAuthenticationException() {
-    AuthenticationException e = new AuthenticationException(unsanitizedString);
-    AuthenticationException sanitized = BinlogStreamingChangeEventSource.sanitizeAuthenticationException(e);
-    assertEquals(sanitizedString, sanitized.getMessage());
-    assertEquals(e.getErrorCode(), sanitized.getErrorCode());
-    assertEquals(e.getSqlState(), sanitized.getSqlState());
-    assertEquals(e.getCause(), sanitized.getCause());
-    assertEquals(e.getStackTrace(), sanitized.getStackTrace());
-  }
+    @Test
+    public void sanitizeAuthenticationException() {
+        AuthenticationException e = new AuthenticationException(unsanitizedString);
+        AuthenticationException sanitized = BinlogStreamingChangeEventSource.sanitizeAuthenticationException(e);
+        assertEquals(sanitizedString, sanitized.getMessage());
+        assertEquals(e.getErrorCode(), sanitized.getErrorCode());
+        assertEquals(e.getSqlState(), sanitized.getSqlState());
+        assertEquals(e.getCause(), sanitized.getCause());
+        assertEquals(e.getStackTrace(), sanitized.getStackTrace());
+    }
 }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnector.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnector.java
@@ -183,11 +183,11 @@ public class PostgresConnector extends RelationalBaseSourceConnector {
     private static int checkPostgresVersionForPgoutputSupport(PostgresConnection connection, PostgresConnectorConfig postgresConfig) throws SQLException {
         // check for DB version and LogicalDecoder compatibility
         final Version dbVersion = ServerVersion.from(
-            connection.queryAndMap(
-                "SHOW server_version",
-                connection.singleResultMapper(
-                    rs -> rs.getString("server_version"),
-                    "Could not fetch db version")));
+                connection.queryAndMap(
+                        "SHOW server_version",
+                        connection.singleResultMapper(
+                                rs -> rs.getString("server_version"),
+                                "Could not fetch db version")));
         return dbVersion.getVersionNum();
     }
 

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
@@ -181,8 +181,8 @@ public class PostgresConnectorIT extends AbstractAsyncEngineConnectorTest {
     public void shouldCaptureErrorForInvalidPgoutputDecoder() {
         assumeTrue(ServerVersion.v10.getVersionNum() > TestHelper.getServerVersion().getVersionNum());
         Configuration config = TestHelper.defaultConfig()
-            .with(PostgresConnectorConfig.PLUGIN_NAME, "pgoutput")
-            .build();
+                .with(PostgresConnectorConfig.PLUGIN_NAME, "pgoutput")
+                .build();
         Config validatedConfig = new PostgresConnector().validate(config.asMap());
 
         assertConfigurationErrors(validatedConfig, PostgresConnectorConfig.HOSTNAME, 1);
@@ -2100,10 +2100,11 @@ public class PostgresConnectorIT extends AbstractAsyncEngineConnectorTest {
                     // Required due to DBZ-3158, creates empty transaction
                     TestHelper.create().execute("vacuum full").close();
                     Object attribute = ManagementFactory.getPlatformMBeanServer()
-                        .getAttribute(getSnapshotMetricsObjectName("postgres", TestHelper.TEST_SERVER), "SnapshotCompleted");
+                            .getAttribute(getSnapshotMetricsObjectName("postgres", TestHelper.TEST_SERVER), "SnapshotCompleted");
                     if (attribute instanceof Long) {
                         return (Long) attribute == 1L;
-                    } else {
+                    }
+                    else {
                         return (Boolean) attribute;
                     }
                 });
@@ -3652,8 +3653,8 @@ public class PostgresConnectorIT extends AbstractAsyncEngineConnectorTest {
         TestHelper.dropPublication("cdc");
 
         Configuration.Builder configBuilder = TestHelper.defaultConfig()
-            .with(PostgresConnectorConfig.PUBLICATION_NAME, "cdc")
-            .with(PostgresConnectorConfig.PUBLICATION_AUTOCREATE_MODE, PostgresConnectorConfig.AutoCreateMode.NO_TABLES.getValue());
+                .with(PostgresConnectorConfig.PUBLICATION_NAME, "cdc")
+                .with(PostgresConnectorConfig.PUBLICATION_AUTOCREATE_MODE, PostgresConnectorConfig.AutoCreateMode.NO_TABLES.getValue());
 
         start(PostgresConnector.class, configBuilder.build());
         assertConnectorIsRunning();

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorTest.java
@@ -18,29 +18,29 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class PostgresConnectorTest {
-  PostgresConnector connector;
+    PostgresConnector connector;
 
-  @Before
-  public void before() {
-    connector = new PostgresConnector();
-  }
-
-  @Test
-  public void testValidateUnableToConnectNoThrow() {
-    Map<String, String> config = new HashMap<>();
-    config.put(PostgresConnectorConfig.HOSTNAME.name(), "narnia");
-    config.put(PostgresConnectorConfig.PORT.name(), "1234");
-    config.put(PostgresConnectorConfig.DATABASE_NAME.name(), "postgres");
-    config.put(PostgresConnectorConfig.USER.name(), "pikachu");
-    config.put(PostgresConnectorConfig.PASSWORD.name(), "pika");
-    config.put(PostgresConnectorConfig.TOPIC_PREFIX.name(), "topic-prefix");
-
-    Config validated = connector.validate(config);
-    for (ConfigValue value : validated.configValues()) {
-      if (config.containsKey(value.name())
-          && !value.name().equals(PostgresConnectorConfig.TOPIC_PREFIX.name())) {
-        assertThat(value.errorMessages().get(0), is("Error while validating connector config: The connection attempt failed."));
-      }
+    @Before
+    public void before() {
+        connector = new PostgresConnector();
     }
-  }
+
+    @Test
+    public void testValidateUnableToConnectNoThrow() {
+        Map<String, String> config = new HashMap<>();
+        config.put(PostgresConnectorConfig.HOSTNAME.name(), "narnia");
+        config.put(PostgresConnectorConfig.PORT.name(), "1234");
+        config.put(PostgresConnectorConfig.DATABASE_NAME.name(), "postgres");
+        config.put(PostgresConnectorConfig.USER.name(), "pikachu");
+        config.put(PostgresConnectorConfig.PASSWORD.name(), "pika");
+        config.put(PostgresConnectorConfig.TOPIC_PREFIX.name(), "topic-prefix");
+
+        Config validated = connector.validate(config);
+        for (ConfigValue value : validated.configValues()) {
+            if (config.containsKey(value.name())
+                    && !value.name().equals(PostgresConnectorConfig.TOPIC_PREFIX.name())) {
+                assertThat(value.errorMessages().get(0), is("Error while validating connector config: The connection attempt failed."));
+            }
+        }
+    }
 }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresDefaultValueConverterIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresDefaultValueConverterIT.java
@@ -13,7 +13,6 @@ import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
 
-import io.debezium.config.CommonConnectorConfig;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
@@ -23,6 +22,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
 import io.debezium.connector.postgresql.PostgresConnectorConfig.SnapshotMode;
 import io.debezium.connector.postgresql.connection.PostgresDefaultValueConverter;

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/TestHelper.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/TestHelper.java
@@ -292,11 +292,11 @@ public final class TestHelper {
         final PostgresConnectorConfig config = new PostgresConnectorConfig(defaultConfig().build());
         try (PostgresConnection connection = new PostgresConnection(config.getJdbcConfig(), getPostgresValueConverterBuilder(config), CONNECTION_TEST)) {
             return ServerVersion.from(
-                connection.queryAndMap(
-                    "SHOW server_version",
-                    connection.singleResultMapper(
-                        rs -> rs.getString("server_version"),
-                        "Could not fetch db version")));
+                    connection.queryAndMap(
+                            "SHOW server_version",
+                            connection.singleResultMapper(
+                                    rs -> rs.getString("server_version"),
+                                    "Could not fetch db version")));
         }
         catch (SQLException e) {
             e.printStackTrace();

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/util/TestHelper.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/util/TestHelper.java
@@ -465,7 +465,8 @@ public class TestHelper {
                     Object attribute = mbeanServer.getAttribute(objectName, "SnapshotCompleted");
                     if (attribute instanceof Long) {
                         return (Long) attribute == 1L;
-                    } else {
+                    }
+                    else {
                         return (Boolean) attribute;
                     }
                 }

--- a/debezium-core/src/main/java/io/debezium/config/Configuration.java
+++ b/debezium-core/src/main/java/io/debezium/config/Configuration.java
@@ -65,7 +65,8 @@ public interface Configuration {
 
     Logger CONFIGURATION_LOGGER = LoggerFactory.getLogger(Configuration.class);
 
-    Pattern PASSWORD_PATTERN = Pattern.compile(".*secret$|.*password$|.*sasl\\.jaas\\.config$|.*\\.api\\.(key|secret)$|.*basic\\.auth\\.user\\.info|.*registry\\.auth\\.client-secret",
+    Pattern PASSWORD_PATTERN = Pattern.compile(
+            ".*secret$|.*password$|.*sasl\\.jaas\\.config$|.*\\.api\\.(key|secret)$|.*basic\\.auth\\.user\\.info|.*registry\\.auth\\.client-secret",
             Pattern.CASE_INSENSITIVE);
 
     /**

--- a/debezium-core/src/main/java/io/debezium/connector/common/RelationalBaseSourceConnector.java
+++ b/debezium-core/src/main/java/io/debezium/connector/common/RelationalBaseSourceConnector.java
@@ -8,7 +8,6 @@ package io.debezium.connector.common;
 import java.util.ArrayList;
 import java.util.Map;
 
-import io.debezium.schema.AbstractTopicNamingStrategy;
 import org.apache.kafka.common.config.Config;
 import org.apache.kafka.common.config.ConfigValue;
 import org.slf4j.Logger;
@@ -16,6 +15,7 @@ import org.slf4j.LoggerFactory;
 
 import io.debezium.config.Configuration;
 import io.debezium.relational.RelationalDatabaseConnectorConfig;
+import io.debezium.schema.AbstractTopicNamingStrategy;
 import io.debezium.util.Strings;
 
 /**
@@ -43,12 +43,11 @@ public abstract class RelationalBaseSourceConnector extends BaseSourceConnector 
                 .forEach(configValue -> LOGGER.warn("ConfigValue '{}' has errors: {}", configValue.name(), configValue.errorMessages()));
         // Only if there are no config errors ...
         if (results.values().stream()
-            .filter(
-                configValue -> !(configValue.name().equals(RelationalDatabaseConnectorConfig.TOPIC_PREFIX.name())
-                    || configValue.name().equals(AbstractTopicNamingStrategy.TOPIC_HEARTBEAT_PREFIX.name())
-                    || configValue.name().equals(SERVER_ID))
-            )
-            .allMatch(configValue -> configValue.errorMessages().isEmpty())) {
+                .filter(
+                        configValue -> !(configValue.name().equals(RelationalDatabaseConnectorConfig.TOPIC_PREFIX.name())
+                                || configValue.name().equals(AbstractTopicNamingStrategy.TOPIC_HEARTBEAT_PREFIX.name())
+                                || configValue.name().equals(SERVER_ID)))
+                .allMatch(configValue -> configValue.errorMessages().isEmpty())) {
             // ... validate the connection too
             validateConnection(results, config);
         }

--- a/debezium-core/src/main/java/io/debezium/pipeline/meters/SnapshotMeter.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/meters/SnapshotMeter.java
@@ -11,7 +11,6 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 

--- a/debezium-core/src/main/java/io/debezium/relational/history/SchemaHistoryMetrics.java
+++ b/debezium-core/src/main/java/io/debezium/relational/history/SchemaHistoryMetrics.java
@@ -60,9 +60,11 @@ public class SchemaHistoryMetrics extends Metrics implements SchemaHistoryListen
     public long getStatus() {
         if (status == SchemaHistoryStatus.STOPPED) {
             return 0;
-        } else if (status == SchemaHistoryStatus.RECOVERING) {
+        }
+        else if (status == SchemaHistoryStatus.RECOVERING) {
             return 1;
-        } else {
+        }
+        else {
             return 2;
         }
     }

--- a/debezium-core/src/main/java/io/debezium/transforms/outbox/EventRouterDelegate.java
+++ b/debezium-core/src/main/java/io/debezium/transforms/outbox/EventRouterDelegate.java
@@ -248,12 +248,12 @@ public class EventRouterDelegate<R extends ConnectRecord<R>> {
         if (matcher.matches()) {
             final String topic = matcher.replaceFirst(routTopicReplacement);
             return newRecord.newRecord(topic,
-                newRecord.kafkaPartition(),
-                newRecord.keySchema(),
-                newRecord.key(),
-                newRecord.valueSchema(),
-                newRecord.value(),
-                newRecord.timestamp());
+                    newRecord.kafkaPartition(),
+                    newRecord.keySchema(),
+                    newRecord.key(),
+                    newRecord.valueSchema(),
+                    newRecord.value(),
+                    newRecord.timestamp());
         }
 
         return newRecord;

--- a/debezium-embedded/src/test/java/io/debezium/embedded/AbstractConnectorTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/embedded/AbstractConnectorTest.java
@@ -1342,7 +1342,8 @@ public abstract class AbstractConnectorTest implements Testing {
                     Object attribute = mbeanServer.getAttribute(getSnapshotMetricsObjectName(connector, server, props), "SnapshotCompleted");
                     if (attribute instanceof Long) {
                         return (Long) attribute == 1L;
-                    } else {
+                    }
+                    else {
                         return (Boolean) attribute;
                     }
                 });
@@ -1361,7 +1362,8 @@ public abstract class AbstractConnectorTest implements Testing {
                     Object attribute = mbeanServer.getAttribute(getSnapshotMetricsObjectName(connector, server, task, database, props), "SnapshotCompleted");
                     if (attribute instanceof Long) {
                         return (Long) attribute == 1L;
-                    } else {
+                    }
+                    else {
                         return (Boolean) attribute;
                     }
                 });
@@ -1379,7 +1381,8 @@ public abstract class AbstractConnectorTest implements Testing {
                     Object attribute = mbeanServer.getAttribute(getSnapshotMetricsObjectName(connector, server, task, database), event);
                     if (attribute instanceof Long) {
                         return (Long) attribute == 1L;
-                    } else {
+                    }
+                    else {
                         return (Boolean) attribute;
                     }
                 });


### PR DESCRIPTION
## Problem
maven commands usually run formatting and linting by default. This leads to some unknown files getting changed which leads to productivity loss. Developer has to manually rollback those changes since they are always unrelated to the change.

This PR is about committing those changes in the branch so that in future only relevant lint and formatting changes are applied on using maven commands.