### PR TITLE
CC-33244 - Recover history only if it exists

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlDatabaseSchema.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlDatabaseSchema.java
@@ -359,14 +359,7 @@ public class MySqlDatabaseSchema extends HistorizedRelationalDatabaseSchema {
     protected DdlParser getDdlParser() {
         return ddlParser;
     }
-
-    /**
-     * Return true if the database schema history entity exists
-     */
-    public boolean historyExists() {
-        return schemaHistory.exists();
-    }
-
+    
     /**
      * Assign the given table number to the table with the specified {@link TableId table ID}.
      *

--- a/debezium-core/src/main/java/io/debezium/pipeline/ChangeEventSourceCoordinator.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/ChangeEventSourceCoordinator.java
@@ -139,7 +139,7 @@ public class ChangeEventSourceCoordinator<P extends Partition, O extends OffsetC
                     context = new ChangeEventSourceContextImpl();
                     LOGGER.info("Context created");
 
-                    if (schema.isHistorized()) {
+                    if (schema.isHistorized() && ((HistorizedDatabaseSchema) schema).historyExists()) {
                         ((HistorizedDatabaseSchema<?>) schema).recover(previousOffsets);
                     }
 

--- a/debezium-core/src/main/java/io/debezium/relational/HistorizedRelationalDatabaseSchema.java
+++ b/debezium-core/src/main/java/io/debezium/relational/HistorizedRelationalDatabaseSchema.java
@@ -138,4 +138,11 @@ public abstract class HistorizedRelationalDatabaseSchema extends RelationalDatab
         }
         return false;
     }
+
+    /**
+     * Return true if the database schema history entity exists
+     */
+    public boolean historyExists() {
+        return schemaHistory.exists();
+    }
 }

--- a/debezium-core/src/main/java/io/debezium/schema/HistorizedDatabaseSchema.java
+++ b/debezium-core/src/main/java/io/debezium/schema/HistorizedDatabaseSchema.java
@@ -51,4 +51,6 @@ public interface HistorizedDatabaseSchema<I extends DataCollectionId> extends Da
     boolean storeOnlyCapturedTables();
 
     boolean storeOnlyCapturedDatabases();
+    
+    boolean historyExists();
 }


### PR DESCRIPTION
This is a follow up to https://github.com/confluentinc/debezium/pull/140.
Although, there is no functional gap in [the above PR](https://github.com/confluentinc/debezium/pull/140), but for cases where 
schema history doesn't exist, the recovery need not be performed.

At present, the recovery is triggered for every case, but is actually a no-op
for cases like these. We don't want to trigger the recovery for such cases.