### PR TITLE
CC-34744 Remove redundancy in intializing DataTypeResolver

### DIFF
--- a/debezium-connector-mariadb/src/main/java/io/debezium/connector/mariadb/antlr/MariaDbAntlrDdlParser.java
+++ b/debezium-connector-mariadb/src/main/java/io/debezium/connector/mariadb/antlr/MariaDbAntlrDdlParser.java
@@ -48,6 +48,7 @@ public class MariaDbAntlrDdlParser extends AntlrDdlParser<MariaDBLexer, MariaDBP
     private final ConcurrentHashMap<String, String> charsetNameForDatabase = new ConcurrentHashMap<>();
     private final Tables.TableFilter tableFilter;
     private final BinlogCharsetRegistry charsetRegistry;
+    private static final DataTypeResolver dataTypeResolver = initializeDataTypeResolver();
 
     @VisibleForTesting
     public MariaDbAntlrDdlParser() {
@@ -98,7 +99,11 @@ public class MariaDbAntlrDdlParser extends AntlrDdlParser<MariaDBLexer, MariaDBP
     }
 
     @Override
-    protected DataTypeResolver initializeDataTypeResolver() {
+    public DataTypeResolver dataTypeResolver() {
+        return dataTypeResolver;
+    }
+
+    private static DataTypeResolver initializeDataTypeResolver() {
         DataTypeResolver.Builder dataTypeResolverBuilder = new DataTypeResolver.Builder();
         dataTypeResolverBuilder.registerDataTypes(MariaDBParser.StringDataTypeContext.class.getCanonicalName(), Arrays.asList(
                 new DataTypeResolver.DataTypeEntry(Types.CHAR, MariaDBParser.CHAR),

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/antlr/MySqlAntlrDdlParser.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/antlr/MySqlAntlrDdlParser.java
@@ -50,6 +50,7 @@ public class MySqlAntlrDdlParser extends AntlrDdlParser<MySqlLexer, MySqlParser>
     private final ConcurrentMap<String, String> charsetNameForDatabase = new ConcurrentHashMap<>();
     private final TableFilter tableFilter;
     private final BinlogCharsetRegistry charsetRegistry;
+    private static final DataTypeResolver dataTypeResolver = initializeDataTypeResolver();
 
     @VisibleForTesting
     public MySqlAntlrDdlParser() {
@@ -100,7 +101,11 @@ public class MySqlAntlrDdlParser extends AntlrDdlParser<MySqlLexer, MySqlParser>
     }
 
     @Override
-    protected DataTypeResolver initializeDataTypeResolver() {
+    public DataTypeResolver dataTypeResolver() {
+        return dataTypeResolver;
+    }
+
+    private static DataTypeResolver initializeDataTypeResolver() {
         DataTypeResolver.Builder dataTypeResolverBuilder = new DataTypeResolver.Builder();
 
         dataTypeResolverBuilder.registerDataTypes(MySqlParser.StringDataTypeContext.class.getCanonicalName(), Arrays.asList(

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/antlr/OracleDdlParser.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/antlr/OracleDdlParser.java
@@ -33,6 +33,7 @@ public class OracleDdlParser extends AntlrDdlParser<PlSqlLexer, PlSqlParser> {
 
     private final TableFilter tableFilter;
     private final OracleValueConverters converters;
+    private static final DataTypeResolver dataTypeResolver = initializeDataTypeResolver();
 
     private String catalogName;
     private String schemaName;
@@ -95,7 +96,11 @@ public class OracleDdlParser extends AntlrDdlParser<PlSqlLexer, PlSqlParser> {
     }
 
     @Override
-    protected DataTypeResolver initializeDataTypeResolver() {
+    public DataTypeResolver dataTypeResolver() {
+        return dataTypeResolver;
+    }
+
+    private static DataTypeResolver initializeDataTypeResolver() {
         // todo, register all and use in ColumnDefinitionParserListener
         DataTypeResolver.Builder dataTypeResolverBuilder = new DataTypeResolver.Builder();
 

--- a/debezium-ddl-parser/src/main/java/io/debezium/antlr/AntlrDdlParser.java
+++ b/debezium-ddl-parser/src/main/java/io/debezium/antlr/AntlrDdlParser.java
@@ -50,7 +50,6 @@ public abstract class AntlrDdlParser<L extends Lexer, P extends Parser> extends 
     private AntlrDdlParserListener antlrDdlParserListener;
 
     protected Tables databaseTables;
-    protected DataTypeResolver dataTypeResolver;
 
     public AntlrDdlParser(boolean throwErrorsFromTreeWalk, boolean includeViews, boolean includeComments) {
         super(includeViews, includeComments);
@@ -64,8 +63,6 @@ public abstract class AntlrDdlParser<L extends Lexer, P extends Parser> extends 
         CodePointCharStream ddlContentCharStream = CharStreams.fromString(ddlContent);
         L lexer = createNewLexerInstance(new CaseChangingCharStream(ddlContentCharStream, isGrammarInUpperCase()));
         P parser = createNewParserInstance(new CommonTokenStream(lexer));
-
-        dataTypeResolver = initializeDataTypeResolver();
 
         // remove default console output printing error listener
         parser.removeErrorListener(ConsoleErrorListener.INSTANCE);
@@ -138,9 +135,10 @@ public abstract class AntlrDdlParser<L extends Lexer, P extends Parser> extends 
     protected abstract boolean isGrammarInUpperCase();
 
     /**
-     * Initialize DB to JDBC data types mapping for resolver.
+     * Return DB to JDBC data types mapping resolver.
+     * @return DataTypeResolver instance
      */
-    protected abstract DataTypeResolver initializeDataTypeResolver();
+    public abstract DataTypeResolver dataTypeResolver();
 
     /**
      * Returns actual tables schema.
@@ -149,15 +147,6 @@ public abstract class AntlrDdlParser<L extends Lexer, P extends Parser> extends 
      */
     public Tables databaseTables() {
         return databaseTables;
-    }
-
-    /**
-     * Returns a data type resolver component.
-     *
-     * @return data type resolver.
-     */
-    public DataTypeResolver dataTypeResolver() {
-        return dataTypeResolver;
     }
 
     /**


### PR DESCRIPTION
## What
This one is implementing [this](https://confluentinc.atlassian.net/wiki/spaces/~635b68551cc605b1fd16afeb/pages/4483842738/Database+Schema+History+Recovery+Optimization+Analysis#Optimization-2-%E2%80%93-DataTypeResolver-instantiation-in-every-parse-path) optimization for the schema history recovery codepath.

We saw that the recovery time for our repro decreased from 20 seconds to 16 seconds after this change.

## Tests
✅ UTs/ITs pass
