### PR TITLE
CC-34771 Add test for filtering out truncate from history topic

### DIFF
--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogStreamingChangeEventSource.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogStreamingChangeEventSource.java
@@ -92,7 +92,6 @@ import io.debezium.snapshot.mode.NeverSnapshotter;
 import io.debezium.time.Conversions;
 import io.debezium.util.Clock;
 import io.debezium.util.Metronome;
-import io.debezium.util.Strings;
 import io.debezium.util.Threads;
 
 /**
@@ -733,7 +732,7 @@ public abstract class BinlogStreamingChangeEventSource<P extends BinlogPartition
             return;
         }
 
-        String upperCasedStatementBegin = Strings.getBegin(removeSetStatement(sql), 7).toUpperCase();
+        String upperCasedStatementBegin = removeSetStatement(sql).toUpperCase();
 
         if (upperCasedStatementBegin.startsWith("XA ")) {
             // This is an XA transaction, and we currently ignore these and do nothing ...
@@ -973,7 +972,7 @@ public abstract class BinlogStreamingChangeEventSource<P extends BinlogPartition
      * @param value the value to initialize the set based upon
      */
     protected abstract void initializeGtidSet(String value);
-    
+
     private Predicate<String> getGtidDmlSourceFilter() {
         if (connectorConfig.getConfig().getBoolean(BinlogConnectorConfig.GTID_SOURCE_FILTER_DML_EVENTS)) {
             return connectorConfig.getGtidSourceFilter();

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlStreamingChangeEventSource.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlStreamingChangeEventSource.java
@@ -21,7 +21,6 @@ import com.github.shyiko.mysql.binlog.event.EventType;
 import com.github.shyiko.mysql.binlog.event.GtidEventData;
 import com.github.shyiko.mysql.binlog.event.RowsQueryEventData;
 import com.github.shyiko.mysql.binlog.network.SSLMode;
-import com.google.re2j.Pattern;
 
 import io.debezium.connector.binlog.BinlogConnectorConfig;
 import io.debezium.connector.binlog.BinlogStreamingChangeEventSource;
@@ -42,7 +41,7 @@ public class MySqlStreamingChangeEventSource extends BinlogStreamingChangeEventS
 
     private final MySqlConnectorConfig connectorConfig;
     private GtidSet gtidSet;
-    
+
     public MySqlStreamingChangeEventSource(MySqlConnectorConfig connectorConfig,
                                            BinlogConnectorConnection connection,
                                            EventDispatcher<MySqlPartition, TableId> dispatcher,


### PR DESCRIPTION
## What
This PR adds test to ensure that TRUNCATE events are not stored in the history topic. This should be true for both possible cases with `skipped.operations`. One which includes truncate and the other case where it doesn't include.

## Tests
✅ UTs/ITs