### PR TITLE
Expose threadIds of the new threads created in Debezium CDC Source Connectors

### DIFF
--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogConnector.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogConnector.java
@@ -82,7 +82,8 @@ public abstract class BinlogConnector<T extends BinlogConnectorConfig> extends R
                 catch (SQLException e) {
                     LOGGER.error("Unexpected error shutting down the database connection", e);
                 }
-            }, timeout, connectorConfig.getLogicalName(), "connection-validation");
+            }, timeout, connectorConfig.getLogicalName(), "connection-validation", connectorConfig.connectorName(),
+                    connectorConfig.getConnectorThreadNamePattern(), connectorConfig.getTaskId());
         }
         catch (TimeoutException e) {
             hostnameValue.addErrorMessage("Connection validation timed out after " + timeout.toMillis() + " ms");

--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogStreamingChangeEventSource.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogStreamingChangeEventSource.java
@@ -392,6 +392,9 @@ public abstract class BinlogStreamingChangeEventSource<P extends BinlogPartition
                         getConnectorClass(),
                         connectorConfig.getLogicalName(),
                         "binlog-client",
+                        connectorConfig.connectorName(),
+                        connectorConfig.getConnectorThreadNamePattern(),
+                        connectorConfig.getTaskId(),
                         false,
                         false,
                         x -> clientThreads.put(x.getName(), x)));

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbSnapshotChangeEventSource.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbSnapshotChangeEventSource.java
@@ -222,7 +222,7 @@ public class MongoDbSnapshotChangeEventSource extends AbstractSnapshotChangeEven
 
         LOGGER.info("Creating snapshot worker pool with {} worker thread(s)", numThreads);
         final ExecutorService executorService = Threads.newFixedThreadPool(MongoDbConnector.class, taskContext.getServerName(), "snapshot-main",
-                connectorConfig.getSnapshotMaxThreads());
+                connectorConfig.connectorName(), connectorConfig.getConnectorThreadNamePattern(), connectorConfig.getTaskId(), connectorConfig.getSnapshotMaxThreads());
 
         final AtomicBoolean aborted = new AtomicBoolean(false);
         final AtomicInteger threadCounter = new AtomicInteger(0);

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/snapshot/MongoDbIncrementalSnapshotChangeEventSource.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/snapshot/MongoDbIncrementalSnapshotChangeEventSource.java
@@ -119,8 +119,8 @@ public class MongoDbIncrementalSnapshotChangeEventSource
                 : CollectionId.parse(connectorConfig.getSignalingDataCollectionId());
         this.notificationService = notificationService;
         this.incrementalSnapshotThreadPool = Threads.newFixedThreadPool(MongoDbConnector.class, config.getConnectorName(),
-                "incremental-snapshot", connectorConfig.getSnapshotMaxThreads());
-    }
+                "incremental-snapshot", connectorConfig.connectorName(),
+         connectorConfig.getConnectorThreadNamePattern(), connectorConfig.getTaskId(), connectorConfig.getSnapshotMaxThreads());
 
     @Override
     @SuppressWarnings("unchecked")

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnector.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnector.java
@@ -103,7 +103,7 @@ public class PostgresConnector extends RelationalBaseSourceConnector {
         // Try to connect to the database ...
         try {
             Threads.runWithTimeout(PostgresConnector.class, () -> {
-                try (PostgresConnection connection = new PostgresConnection(postgresConfig.getJdbcConfig(), PostgresConnection.CONNECTION_VALIDATE_CONNECTION)) {
+                try (PostgresConnection connection = new PostgresConnection(postgresConfig.getJdbcConfig(), PostgresConnection.CONNECTION_VALIDATE_CONNECTION, postgresConfig.getConnectorName(), postgresConfig.getConnectorThreadNamePattern(), postgresConfig.getTaskId())) {
                     try {
                         // Prepare connection without initial statement execution
                         connection.connection(false);
@@ -130,7 +130,8 @@ public class PostgresConnector extends RelationalBaseSourceConnector {
                         passwordValue.addErrorMessage("Error while validating connector config: " + e.getMessage());
                     }
                 }
-            }, timeout, postgresConfig.getLogicalName(), "connection-validation");
+            }, timeout, postgresConfig.getLogicalName(), "connection-validation", postgresConfig.connectorName(),
+             postgresConfig.getConnectorThreadNamePattern(), postgresConfig.getTaskId());
         }
         catch (TimeoutException e) {
             hostnameValue.addErrorMessage("Connection validation timed out after " + timeout.toMillis() + " ms");
@@ -214,7 +215,7 @@ public class PostgresConnector extends RelationalBaseSourceConnector {
     @Override
     public List<TableId> getMatchingCollections(Configuration config) {
         PostgresConnectorConfig connectorConfig = new PostgresConnectorConfig(config);
-        try (PostgresConnection connection = new PostgresConnection(connectorConfig.getJdbcConfig(), PostgresConnection.CONNECTION_GENERAL)) {
+        try (PostgresConnection connection = new PostgresConnection(connectorConfig.getJdbcConfig(), PostgresConnection.CONNECTION_GENERAL, connectorConfig.getLogicalName(), connectorConfig.getConnectorThreadNamePattern(), connectorConfig.getTaskId())) {
             return connection.readTableNames(connectorConfig.databaseName(), null, null, new String[]{ "TABLE" }).stream()
                     .filter(tableId -> connectorConfig.getTableFilters().dataCollectionFilter().isIncluded(tableId))
                     .collect(Collectors.toList());

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
@@ -87,7 +87,7 @@ public class PostgresConnectorTask extends BaseSourceTask<PostgresPartition, Pos
         final SchemaNameAdjuster schemaNameAdjuster = connectorConfig.schemaNameAdjuster();
 
         final Charset databaseCharset;
-        try (PostgresConnection tempConnection = new PostgresConnection(connectorConfig.getJdbcConfig(), PostgresConnection.CONNECTION_GENERAL)) {
+        try (PostgresConnection tempConnection = new PostgresConnection(connectorConfig.getJdbcConfig(), PostgresConnection.CONNECTION_GENERAL, connectorConfig.getConnectorName(), connectorConfig.getConnectorThreadNamePattern(), connectorConfig.getTaskId())) {
             databaseCharset = tempConnection.getDatabaseCharset();
         }
 
@@ -97,7 +97,7 @@ public class PostgresConnectorTask extends BaseSourceTask<PostgresPartition, Pos
                 typeRegistry);
 
         MainConnectionProvidingConnectionFactory<PostgresConnection> connectionFactory = new DefaultMainConnectionProvidingConnectionFactory<>(
-                () -> new PostgresConnection(connectorConfig.getJdbcConfig(), valueConverterBuilder, PostgresConnection.CONNECTION_GENERAL));
+                () -> new PostgresConnection(connectorConfig.getJdbcConfig(), valueConverterBuilder, PostgresConnection.CONNECTION_GENERAL, connectorConfig.getConnectorName(), connectorConfig.getConnectorThreadNamePattern(), connectorConfig.getTaskId()));
         // Global JDBC connection used both for snapshotting and streaming.
         // Must be able to resolve datatypes.
         jdbcConnection = connectionFactory.mainConnection();
@@ -198,7 +198,7 @@ public class PostgresConnectorTask extends BaseSourceTask<PostgresPartition, Pos
                     connectorConfig.createHeartbeat(
                             topicNamingStrategy,
                             schemaNameAdjuster,
-                            () -> new PostgresConnection(connectorConfig.getJdbcConfig(), PostgresConnection.CONNECTION_GENERAL),
+                            () -> new PostgresConnection(connectorConfig.getJdbcConfig(), PostgresConnection.CONNECTION_GENERAL, connectorConfig.getConnectorName(), connectorConfig.getConnectorThreadNamePattern(), connectorConfig.getTaskId()),
                             exception -> {
                                 String sqlErrorId = exception.getSQLState();
                                 switch (sqlErrorId) {

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
@@ -107,8 +107,8 @@ public class PostgresConnection extends JdbcConnection {
      * @param valueConverterBuilder supplies a configured {@link PostgresValueConverter} for a given {@link TypeRegistry}
      * @param connectionUsage a symbolic name of the connection to be tracked in monitoring tools
      */
-    public PostgresConnection(JdbcConfiguration config, PostgresValueConverterBuilder valueConverterBuilder, String connectionUsage) {
-        super(addDefaultSettings(config, connectionUsage), FACTORY, PostgresConnection::validateServerVersion, "\"", "\"");
+    public PostgresConnection(JdbcConfiguration config, PostgresValueConverterBuilder valueConverterBuilder, String connectionUsage, String connectorName, String threadNamePattern, String taskName) {
+        super(addDefaultSettings(config, connectionUsage), FACTORY, PostgresConnection::validateServerVersion, "\"", "\"", connectorName, threadNamePattern, taskName);
 
         if (Objects.isNull(valueConverterBuilder)) {
             this.typeRegistry = null;
@@ -132,7 +132,7 @@ public class PostgresConnection extends JdbcConnection {
         super(addDefaultSettings(config.getJdbcConfig(), connectionUsage),
                 FACTORY,
                 PostgresConnection::validateServerVersion,
-                "\"", "\"");
+                "\"", "\"", config.connectorName(), config.getConnectorThreadNamePattern(), config.getTaskId());
 
         if (Objects.isNull(typeRegistry)) {
             this.typeRegistry = null;
@@ -152,8 +152,8 @@ public class PostgresConnection extends JdbcConnection {
      * @param config {@link Configuration} instance, may not be null.
      * @param connectionUsage a symbolic name of the connection to be tracked in monitoring tools
      */
-    public PostgresConnection(JdbcConfiguration config, String connectionUsage) {
-        this(config, null, connectionUsage);
+    public PostgresConnection(JdbcConfiguration config, String connectionUsage, String connectorName, String threadNamePattern, String taskName) {
+        this(config, null, connectionUsage, connectorName, threadNamePattern, taskName);
     }
 
     static JdbcConfiguration addDefaultSettings(JdbcConfiguration configuration, String connectionUsage) {

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
@@ -144,7 +144,7 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
     }
 
     private ServerInfo.ReplicationSlot getSlotInfo() throws SQLException, InterruptedException {
-        try (PostgresConnection connection = new PostgresConnection(connectorConfig.getJdbcConfig(), PostgresConnection.CONNECTION_SLOT_INFO)) {
+        try (PostgresConnection connection = new PostgresConnection(connectorConfig.getJdbcConfig(), PostgresConnection.CONNECTION_SLOT_INFO, connectorConfig.getConnectorName(), connectorConfig.getConnectorThreadNamePattern(), connectorConfig.getTaskId())) {
             return connection.readReplicationSlotInfo(slotName, plugin.getPostgresPluginName());
         }
     }
@@ -857,7 +857,7 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
         }
         if (dropSlotOnClose && dropSlot) {
             // we're dropping the replication slot via a regular - i.e. not a replication - connection
-            try (PostgresConnection connection = new PostgresConnection(connectorConfig.getJdbcConfig(), PostgresConnection.CONNECTION_DROP_SLOT)) {
+            try (PostgresConnection connection = new PostgresConnection(connectorConfig.getJdbcConfig(), PostgresConnection.CONNECTION_DROP_SLOT, connectorConfig.getConnectorName(), connectorConfig.getConnectorThreadNamePattern(), connectorConfig.getTaskId())) {
                 connection.dropReplicationSlot(slotName);
             }
             catch (Throwable e) {

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/transforms/timescaledb/QueryInformationSchemaMetadata.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/transforms/timescaledb/QueryInformationSchemaMetadata.java
@@ -1,4 +1,4 @@
-/*
+Times/*
  * Copyright Debezium Authors.
  *
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
@@ -52,7 +52,7 @@ public class QueryInformationSchemaMetadata extends AbstractTimescaleDbMetadata 
         connection = new PostgresConnection(
                 JdbcConfiguration.adapt(config.subset(CommonConnectorConfig.DATABASE_CONFIG_PREFIX, true)
                         .merge(config.subset(CommonConnectorConfig.DRIVER_CONFIG_PREFIX, true))),
-                "Debezium TimescaleDB metadata");
+                "Debezium TimescaleDB metadata", "", "", "");
     }
 
     @Override

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnector.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnector.java
@@ -154,7 +154,8 @@ public class SqlServerConnector extends RelationalBaseSourceConnector {
                     hostnameValue.addErrorMessage("Unable to connect. Check this and other connection properties. Error: "
                             + e.getMessage());
                 }
-            }, timeout, sqlServerConfig.getLogicalName(), "connection-validation");
+            }, timeout, sqlServerConfig.getLogicalName(), "connection-validation", sqlServerConfig.connectorName(),
+             sqlServerConfig.getConnectorThreadNamePattern(), sqlServerConfig.getTaskId());
         }
         catch (TimeoutException e) {
             hostnameValue.addErrorMessage("Connection validation timed out after " + timeout.toMillis() + " ms");

--- a/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java
+++ b/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java
@@ -22,6 +22,7 @@ import java.util.function.Supplier;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.Importance;
 import org.apache.kafka.common.config.ConfigDef.Type;
@@ -65,7 +66,7 @@ import io.debezium.util.Strings;
  *
  * @author Gunnar Morling
  */
-public abstract class CommonConnectorConfig {
+public abstract class CommonConnectorConfig extends AbstractConfig {
     public static final String TASK_ID = "task.id";
     public static final Pattern TOPIC_NAME_PATTERN = Pattern.compile("^[a-zA-Z0-9_.\\-]+$");
     public static final String MULTI_PARTITION_MODE = "multi.partition.mode";
@@ -84,6 +85,7 @@ public abstract class CommonConnectorConfig {
     protected final boolean isLogPositionCheckEnabled;
     protected final boolean isAdvancedMetricsEnabled;
     protected final boolean failOnNoTables;
+    protected final String connectorThreadNamePattern;
 
     /**
      * The set of predefined versions e.g. for source struct maker version
@@ -1109,6 +1111,19 @@ public abstract class CommonConnectorConfig {
             .withDescription("Fail if no tables are found that match the configured filters.")
             .withDefault(true);
 
+    public static final Field CONNECTOR_THREAD_NAME_PATTERN = Field.createInternal("connector.thread.name.pattern")
+            .withDisplayName("Connector Thread Name Pattern")
+            .withType(Type.STRING)
+            .withGroup(Field.createGroupEntry(Field.Group.ADVANCED, 32))
+            .withWidth(Width.MEDIUM)
+            .withImportance(Importance.LOW)
+            .optional()
+            .withDefault("${debezium-prefix}-${connector.class.simple}-${topic.prefix}-${functionality}")
+            .withDescription("The pattern used to name the connector threads. "
+                    + "The default value is '${debezium-prefix}-${connector.class.simple}-${topic.prefix}-${functionality}'. "
+                    + "The following variables are available: ${debezium-prefix}, ${connector.class.simple}, ${topic.prefix}, ${functionality}. "
+                    + "The value can be configured with any value but to have the default value as suffix.");
+
     protected static final ConfigDefinition CONFIG_DEFINITION = ConfigDefinition.editor()
             .connector(
                     EVENT_PROCESSING_FAILURE_HANDLING_MODE,
@@ -1136,7 +1151,8 @@ public abstract class CommonConnectorConfig {
                     LOG_POSITION_CHECK_ENABLED,
                     ADVANCED_METRICS_ENABLE,
                     FAIL_ON_NO_TABLES,
-                    CONNECTION_VALIDATION_TIMEOUT_MS)
+                    CONNECTION_VALIDATION_TIMEOUT_MS,
+                    CONNECTOR_THREAD_NAME_PATTERN)
             .events(
                     CUSTOM_CONVERTERS,
                     CUSTOM_POST_PROCESSORS,
@@ -1201,6 +1217,7 @@ public abstract class CommonConnectorConfig {
     protected final DefaultServiceRegistry serviceRegistry;
 
     protected CommonConnectorConfig(Configuration config, int defaultSnapshotFetchSize) {
+        super(CONFIG_DEFINITION.configDef(), config.asProperties());
         this.beanRegistry = new DefaultBeanRegistry();
         this.serviceRegistry = new DefaultServiceRegistry(config, beanRegistry);
         this.config = config;
@@ -1252,6 +1269,7 @@ public abstract class CommonConnectorConfig {
         this.isLogPositionCheckEnabled = config.getBoolean(LOG_POSITION_CHECK_ENABLED);
         this.isAdvancedMetricsEnabled = config.getBoolean(ADVANCED_METRICS_ENABLE);
         this.failOnNoTables = config.getBoolean(FAIL_ON_NO_TABLES);
+        this.connectorThreadNamePattern = config.getString(CONNECTOR_THREAD_NAME_PATTERN);
 
         this.signalingDataCollectionId = !Strings.isNullOrBlank(this.signalingDataCollection)
                 ? TableId.parse(this.signalingDataCollection)
@@ -1325,6 +1343,14 @@ public abstract class CommonConnectorConfig {
 
     public String getLogicalName() {
         return logicalName;
+    }
+
+    public String connectorName() {
+        return originalsStrings().get("name");
+    }
+
+    public String getConnectorThreadNamePattern() {
+        return connectorThreadNamePattern;
     }
 
     public abstract String getContextName();

--- a/debezium-core/src/main/java/io/debezium/jdbc/JdbcConnection.java
+++ b/debezium-core/src/main/java/io/debezium/jdbc/JdbcConnection.java
@@ -323,6 +323,9 @@ public class JdbcConnection implements AutoCloseable {
     private final Operations initialOps;
     private final String openingQuoteCharacter;
     private final String closingQuoteCharacter;
+    private final String connectorName;
+    private final String connectorThreadNamePattern;
+    private final String taskName;
     private volatile Connection conn;
     private final int queryTimeout;
 
@@ -333,7 +336,7 @@ public class JdbcConnection implements AutoCloseable {
      * @param connectionFactory the connection factory; may not be null
      */
     public JdbcConnection(JdbcConfiguration config, ConnectionFactory connectionFactory, String openingQuoteCharacter, String closingQuoteCharacter) {
-        this(config, connectionFactory, null, openingQuoteCharacter, closingQuoteCharacter);
+        this(config, connectionFactory, null, openingQuoteCharacter, closingQuoteCharacter, null, null, null);
     }
 
     /**
@@ -347,12 +350,15 @@ public class JdbcConnection implements AutoCloseable {
      * @param closingQuotingChar the closing quoting character
      */
     protected JdbcConnection(JdbcConfiguration config, ConnectionFactory connectionFactory, Operations initialOperations,
-                             String openingQuotingChar, String closingQuotingChar) {
+                             String openingQuotingChar, String closingQuotingChar, String connectorName, String connectorThreadNamePattern, String taskName) {
         this.config = config;
         this.factory = new ConnectionFactoryDecorator(connectionFactory);
         this.initialOps = initialOperations;
         this.openingQuoteCharacter = openingQuotingChar;
         this.closingQuoteCharacter = closingQuotingChar;
+        this.connectorName = connectorName;
+        this.connectorThreadNamePattern = connectorThreadNamePattern;
+        this.taskName = taskName;
         this.conn = null;
         this.queryTimeout = (int) config.getQueryTimeout().toSeconds();
     }
@@ -983,7 +989,8 @@ public class JdbcConnection implements AutoCloseable {
                 catch (SQLException e) {
                     throw new RuntimeException(e);
                 }
-            }, Duration.ofSeconds(WAIT_FOR_CLOSE_SECONDS), JdbcConnection.class.getSimpleName(), "jdbc-connection-close");
+            }, Duration.ofSeconds(WAIT_FOR_CLOSE_SECONDS), JdbcConnection.class.getSimpleName(), "jdbc-connection-close", connectorName, connectorThreadNamePattern,
+                    taskName);
         }
         catch (TimeoutException | InterruptedException e) {
             LOGGER.warn("Failed to close database connection by calling close(), attempting abort()");

--- a/debezium-core/src/main/java/io/debezium/pipeline/ChangeEventSourceCoordinator.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/ChangeEventSourceCoordinator.java
@@ -110,8 +110,12 @@ public class ChangeEventSourceCoordinator<P extends Partition, O extends OffsetC
         this.changeEventSourceFactory = changeEventSourceFactory;
         this.changeEventSourceMetricsFactory = changeEventSourceMetricsFactory;
         this.snapshotterService = snapshotterService;
-        this.executor = Threads.newSingleThreadExecutor(connectorType, connectorConfig.getLogicalName(), "change-event-source-coordinator");
-        this.blockingSnapshotExecutor = Threads.newSingleThreadExecutor(connectorType, connectorConfig.getLogicalName(), "blocking-snapshot");
+        this.executor = Threads.newSingleThreadExecutor(connectorType, connectorConfig.getLogicalName(), "change-event-source-coordinator",
+                connectorConfig.connectorName(),
+                connectorConfig.getConnectorThreadNamePattern(), connectorConfig.getTaskId());
+        this.blockingSnapshotExecutor = Threads.newSingleThreadExecutor(connectorType, connectorConfig.getLogicalName(), "blocking-snapshot",
+                connectorConfig.connectorName(),
+                connectorConfig.getConnectorThreadNamePattern(), connectorConfig.getTaskId());
         this.eventDispatcher = eventDispatcher;
         this.schema = schema;
         this.signalProcessor = signalProcessor;

--- a/debezium-core/src/main/java/io/debezium/pipeline/signal/SignalProcessor.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/signal/SignalProcessor.java
@@ -75,7 +75,8 @@ public class SignalProcessor<P extends Partition, O extends OffsetContext> {
         this.signalChannelReaders = signalChannelReaders;
         this.documentReader = documentReader;
         this.previousOffsets = previousOffsets;
-        this.signalProcessorExecutor = Threads.newSingleThreadScheduledExecutor(connector, config.getLogicalName(), SignalProcessor.class.getSimpleName(), false);
+        this.signalProcessorExecutor = Threads.newSingleThreadScheduledExecutor(connector, config.getLogicalName(), SignalProcessor.class.getSimpleName(),
+                config.connectorName(), config.getConnectorThreadNamePattern(), config.getTaskId(), false);
 
         // filter single channel reader based on configuration
         this.enabledChannelReaders = getEnabledChannelReaders();

--- a/debezium-core/src/main/java/io/debezium/relational/HistorizedRelationalDatabaseConnectorConfig.java
+++ b/debezium-core/src/main/java/io/debezium/relational/HistorizedRelationalDatabaseConnectorConfig.java
@@ -132,6 +132,9 @@ public abstract class HistorizedRelationalDatabaseConnectorConfig extends Relati
                 .withDefault(SchemaHistory.NAME, getLogicalName() + "-schemahistory")
                 .withDefault(SchemaHistory.INTERNAL_CONNECTOR_CLASS, connectorClass.getName())
                 .withDefault(SchemaHistory.INTERNAL_CONNECTOR_ID, logicalName)
+                .withDefault(SchemaHistory.CONNECTOR_NAME, connectorName())
+                .withDefault(SchemaHistory.CONNECTOR_THREAD_NAME_PATTERN, getConnectorThreadNamePattern())
+                .withDefault(SchemaHistory.TASK_NAME, getTaskId())
                 .build();
 
         HistoryRecordComparator historyComparator = getHistoryRecordComparator();

--- a/debezium-core/src/main/java/io/debezium/relational/history/AbstractSchemaHistory.java
+++ b/debezium-core/src/main/java/io/debezium/relational/history/AbstractSchemaHistory.java
@@ -39,7 +39,7 @@ public abstract class AbstractSchemaHistory implements SchemaHistory {
 
     protected final Logger logger = LoggerFactory.getLogger(getClass());
 
-    public static Field.Set ALL_FIELDS = Field.setOf(NAME, INTERNAL_CONNECTOR_CLASS, INTERNAL_CONNECTOR_ID);
+    public static Field.Set ALL_FIELDS = Field.setOf(NAME, INTERNAL_CONNECTOR_CLASS, INTERNAL_CONNECTOR_ID, CONNECTOR_NAME, CONNECTOR_THREAD_NAME_PATTERN);
 
     protected Configuration config;
     private HistoryRecordComparator comparator = HistoryRecordComparator.INSTANCE;

--- a/debezium-core/src/main/java/io/debezium/relational/history/SchemaHistory.java
+++ b/debezium-core/src/main/java/io/debezium/relational/history/SchemaHistory.java
@@ -126,6 +126,30 @@ public interface SchemaHistory {
             .withDescription("The unique identifier of the Debezium connector")
             .withNoValidation();
 
+    Field CONNECTOR_NAME = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + "connector.name")
+            .withDisplayName("Debezium connector name")
+            .withType(Type.STRING)
+            .withWidth(Width.SHORT)
+            .withImportance(Importance.HIGH)
+            .withDescription("The unique name of the Debezium connector")
+            .withNoValidation();
+
+    Field CONNECTOR_THREAD_NAME_PATTERN = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + "connector.thread.name.pattern")
+            .withDisplayName("Debezium Connector Thread Name Pattern")
+            .withType(Type.STRING)
+            .withWidth(Width.SHORT)
+            .withImportance(Importance.HIGH)
+            .withDescription("The pattern name of the Debezium connector threads")
+            .withNoValidation();
+
+    Field TASK_NAME = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + "task.name")
+            .withDisplayName("Debezium Connector Task Name")
+            .withType(Type.STRING)
+            .withWidth(Width.SHORT)
+            .withImportance(Importance.HIGH)
+            .withDescription("The Task Name of Debezium connector")
+            .withNoValidation();
+
     // Temporary preference for DDL over logical schema due to DBZ-32
     Field INTERNAL_PREFER_DDL = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + "prefer.ddl")
             .withDisplayName("Prefer DDL for schema recovery")

--- a/debezium-core/src/main/java/io/debezium/util/Threads.java
+++ b/debezium-core/src/main/java/io/debezium/util/Threads.java
@@ -241,8 +241,8 @@ public class Threads {
     }
 
     /**
-     * Returns a thread factory that creates threads conforming to Debezium thread naming
-     * pattern {@code debezium-<component class>-<component-id>-<thread-name>}.
+     * Returns a thread factory that creates threads conforming to Debezium thread naming pattern
+     * {@code debezium-<component class>-<component-id>-<thread-name>}.
      *
      * @param component - the source connector or sink change consumer class
      * @param componentId - the identifier to differentiate between component instances
@@ -251,13 +251,30 @@ public class Threads {
      * @param daemon - true if the thread should be a daemon thread
      * @return the thread factory setting the correct name
      */
-    public static ThreadFactory threadFactory(Class<?> component, String componentId, String name, boolean indexed, boolean daemon) {
-        return threadFactory(component, componentId, name, indexed, daemon, null);
+    public static ThreadFactory threadFactory(
+                                              Class<?> component,
+                                              String componentId,
+                                              String name,
+                                              String connectorName,
+                                              String threadNamePattern,
+                                              String taskId,
+                                              boolean indexed,
+                                              boolean daemon) {
+        return threadFactory(
+                component,
+                componentId,
+                name,
+                connectorName,
+                threadNamePattern,
+                taskId,
+                indexed,
+                daemon,
+                null);
     }
 
     /**
-     * Returns a thread factory that creates threads conforming to Debezium thread naming
-     * pattern {@code debezium-<component class>-<component-id>-<thread-name>}.
+     * Returns a thread factory that creates threads conforming to Debezium thread naming pattern
+     * {@code debezium-<component class>-<component-id>-<thread-name>}.
      *
      * @param component - the source or sink component class
      * @param componentId - the identifier to differentiate between componentId instances
@@ -267,10 +284,22 @@ public class Threads {
      * @param callback - a callback called on every thread created
      * @return the thread factory setting the correct name
      */
-    public static ThreadFactory threadFactory(Class<?> component, String componentId, String name, boolean indexed, boolean daemon,
+    public static ThreadFactory threadFactory(
+                                              Class<?> component,
+                                              String componentId,
+                                              String name,
+                                              String connectorName,
+                                              String threadNamePattern,
+                                              String taskId,
+                                              boolean indexed,
+                                              boolean daemon,
                                               Consumer<Thread> callback) {
         if (LOGGER.isInfoEnabled()) {
-            LOGGER.info("Requested thread factory for component {}, id = {} named = {}", component.getSimpleName(), componentId, name);
+            LOGGER.info(
+                    "Requested thread factory for component {}, id = {} named = {}",
+                    component.getSimpleName(),
+                    componentId,
+                    name);
         }
 
         return new ThreadFactory() {
@@ -278,14 +307,21 @@ public class Threads {
 
             @Override
             public Thread newThread(Runnable r) {
-                StringBuilder threadName = new StringBuilder(DEBEZIUM_THREAD_NAME_PREFIX)
-                        .append(component.getSimpleName().toLowerCase())
-                        .append('-')
-                        .append(componentId)
-                        .append('-')
-                        .append(name);
+                String threadName = threadNamePattern
+                        .replace("${debezium-prefix}", DEBEZIUM_THREAD_NAME_PREFIX)
+                        .replace("${connector.class.simple}", component.getSimpleName().toLowerCase())
+                        .replace("${topic.prefix}", componentId)
+                        .replace("${functionality}", name);
+
+                // Replace optional placeholder if present
+                if (threadName.contains("${connector.name}")) {
+                    threadName = threadName.replace("${connector.name}", connectorName);
+                }
+                if (threadName.contains("${task.id}")) {
+                    threadName = threadName.replace("${task.id}", taskId);
+                }
                 if (indexed) {
-                    threadName.append('-').append(index.getAndIncrement());
+                    threadName += "-" + index.getAndIncrement();
                 }
                 LOGGER.info("Creating thread {}", threadName);
                 final Thread t = new Thread(r, threadName.toString());
@@ -298,20 +334,52 @@ public class Threads {
         };
     }
 
-    public static ExecutorService newSingleThreadExecutor(Class<?> component, String componentId, String name, boolean daemon) {
-        return Executors.newSingleThreadExecutor(threadFactory(component, componentId, name, false, daemon));
+    public static ExecutorService newSingleThreadExecutor(
+                                                          Class<?> component,
+                                                          String componentId,
+                                                          String name,
+                                                          String connectorName,
+                                                          String threadNamePattern,
+                                                          String taskId,
+                                                          boolean daemon) {
+        return Executors.newSingleThreadExecutor(
+                threadFactory(component, componentId, name, connectorName, threadNamePattern, taskId, false, daemon));
     }
 
-    public static ExecutorService newFixedThreadPool(Class<?> component, String componentId, String name, int threadCount) {
-        return Executors.newFixedThreadPool(threadCount, threadFactory(component, componentId, name, true, false));
+    public static ExecutorService newFixedThreadPool(
+                                                     Class<?> component,
+                                                     String componentId,
+                                                     String name,
+                                                     String connectorName,
+                                                     String threadNamePattern,
+                                                     String taskId,
+                                                     int threadCount) {
+        return Executors.newFixedThreadPool(
+                threadCount,
+                threadFactory(
+                        component, componentId, name, connectorName, threadNamePattern, taskId, true, false));
     }
 
-    public static ExecutorService newSingleThreadExecutor(Class<?> component, String componentId, String name) {
-        return newSingleThreadExecutor(component, componentId, name, false);
+    public static ExecutorService newSingleThreadExecutor(
+                                                          Class<?> component,
+                                                          String componentId,
+                                                          String name,
+                                                          String connectorName,
+                                                          String threadNamePattern,
+                                                          String taskId) {
+        return newSingleThreadExecutor(component, componentId, name, connectorName, threadNamePattern, taskId, false);
     }
 
-    public static ScheduledExecutorService newSingleThreadScheduledExecutor(Class<?> component, String componentId, String name, boolean daemon) {
-        return Executors.newSingleThreadScheduledExecutor(threadFactory(component, componentId, name, false, daemon));
+    public static ScheduledExecutorService newSingleThreadScheduledExecutor(
+                                                                            Class<?> component,
+                                                                            String componentId,
+                                                                            String name,
+                                                                            String connectorName,
+                                                                            String threadNamePattern,
+                                                                            String taskId,
+                                                                            boolean daemon) {
+        return Executors.newSingleThreadScheduledExecutor(
+                threadFactory(component, componentId, name, connectorName, threadNamePattern, taskId, false, daemon));
     }
 
     /**
@@ -324,8 +392,18 @@ public class Threads {
      * @param operationName the name of the operation being executed with timeout
      * @throws Exception if the operation fails or times out
      */
-    public static void runWithTimeout(Class<?> componentClass, Runnable operation, Duration timeout, String componentName, String operationName) throws Exception {
-        ExecutorService executor = newSingleThreadExecutor(componentClass, componentName, operationName);
+    public static void runWithTimeout(
+                                      Class<?> componentClass,
+                                      Runnable operation,
+                                      Duration timeout,
+                                      String componentName,
+                                      String operationName,
+                                      String connectorName,
+                                      String threadNamePattern,
+                                      String taskId)
+            throws Exception {
+        ExecutorService executor = newSingleThreadExecutor(
+                componentClass, componentName, operationName, connectorName, threadNamePattern, taskId);
         Future<?> future = executor.submit(operation);
         try {
             future.get(timeout.toMillis(), TimeUnit.MILLISECONDS);

--- a/debezium-core/src/test/java/io/debezium/util/ThreadsTest.java
+++ b/debezium-core/src/test/java/io/debezium/util/ThreadsTest.java
@@ -35,7 +35,7 @@ public class ThreadsTest {
                 operation,
                 Duration.ofMillis(1000),
                 "test-connector",
-                "test-operation");
+                "test-operation", "test-connector", "test-connector-thread", "test-1");
 
         assertTrue(taskCompleted.get());
     }
@@ -56,7 +56,7 @@ public class ThreadsTest {
                 operation,
                 Duration.ofMillis(500),
                 "test-connector",
-                "test-operation"));
+                "test-operation", "test-connector", "test-connector-thread", "test-1"));
     }
 
     @Test
@@ -70,7 +70,7 @@ public class ThreadsTest {
                 operation,
                 Duration.ofMillis(1000),
                 "test-connector",
-                "test-operation"));
+                "test-operation", "test-connector", "test-connector-thread", "test-1"));
 
         assertTrue(exception.getCause() instanceof RuntimeException);
         assertTrue(exception.getCause().getMessage().contains("Test exception"));
@@ -88,7 +88,7 @@ public class ThreadsTest {
                 operation,
                 Duration.ofMillis(1000),
                 "test-connector",
-                "test-operation"));
+                "test-operation", "test-connector", "test-connector-thread", "test-1"));
 
         assertTrue(exception instanceof Exception);
         assertTrue(exception.getCause() instanceof RuntimeException);
@@ -108,6 +108,6 @@ public class ThreadsTest {
                 operation,
                 Duration.ofMillis(1000),
                 "test-connector",
-                "test-operation"));
+                "test-operation", "test-connector", "test-connector-thread", "test-1"));
     }
 }

--- a/debezium-storage/debezium-storage-kafka/src/main/java/io/debezium/storage/kafka/history/KafkaSchemaHistory.java
+++ b/debezium-storage/debezium-storage-kafka/src/main/java/io/debezium/storage/kafka/history/KafkaSchemaHistory.java
@@ -248,8 +248,14 @@ public class KafkaSchemaHistory extends AbstractSchemaHistory {
         try {
             final String connectorClassname = config.getString(INTERNAL_CONNECTOR_CLASS);
             if (connectorClassname != null) {
-                checkTopicSettingsExecutor = Threads.newSingleThreadExecutor((Class<? extends SourceConnector>) Class.forName(connectorClassname),
-                        config.getString(INTERNAL_CONNECTOR_ID), "db-history-config-check", true);
+                checkTopicSettingsExecutor = Threads.newSingleThreadExecutor(
+                        (Class<? extends SourceConnector>) Class.forName(connectorClassname),
+                        config.getString(INTERNAL_CONNECTOR_ID),
+                        "db-history-config-check",
+                        config.getString(CONNECTOR_NAME),
+                        config.getString(CONNECTOR_THREAD_NAME_PATTERN),
+                        config.getString(TASK_NAME),
+                        true);
             }
         }
         catch (ClassNotFoundException e) {


### PR DESCRIPTION
[CC-32755](https://confluentinc.atlassian.net/browse/CC-32755) - Expose threadIds of the new threads created in Debezium PostgreSQL CDC Source

[CC-32768](https://confluentinc.atlassian.net/browse/CC-32768) - Expose threadIds of the new threads created in Debezium MySQL CDC Source

This PR aims to update the Thread Naming Pattern of the threads created apart from the Source Task. Added a new config, which would dynamically take the thread naming pattern from users if required, but here we are applying the default value in CCloud as per our naming standard which would include the connectorName, TaskId in the threadName.