### PR TITLE
CC-34585 Fix usage of cached prepared statement in `emitWindowOpen`

### DIFF
--- a/debezium-core/src/main/java/io/debezium/jdbc/JdbcConnection.java
+++ b/debezium-core/src/main/java/io/debezium/jdbc/JdbcConnection.java
@@ -808,7 +808,7 @@ public class JdbcConnection implements AutoCloseable {
      * Checks if the exception indicates a connection issue.
      */
     private boolean isConnectionException(SQLException e) {
-        return (e.getMessage() != null && e.getMessage().contains("connection closed"));
+        return (e.getMessage() != null && e.getMessage().contains("No operations allowed after connection closed."));
     }
 
     /**

--- a/debezium-core/src/main/java/io/debezium/jdbc/JdbcConnection.java
+++ b/debezium-core/src/main/java/io/debezium/jdbc/JdbcConnection.java
@@ -808,7 +808,15 @@ public class JdbcConnection implements AutoCloseable {
      * Checks if the exception indicates a connection issue.
      */
     private boolean isConnectionException(SQLException e) {
-        return (e.getMessage() != null && e.getMessage().contains("connection closed"));
+        // Check SQL state for connection exceptions (08xxx)
+        String sqlState = e.getSQLState();
+        if (sqlState != null && sqlState.startsWith("08")) {
+            return true;
+        }
+
+        // Check for common connection exception types
+        return e instanceof java.sql.SQLNonTransientConnectionException ||
+                e instanceof java.sql.SQLRecoverableException;
     }
 
     /**

--- a/debezium-core/src/main/java/io/debezium/jdbc/JdbcConnection.java
+++ b/debezium-core/src/main/java/io/debezium/jdbc/JdbcConnection.java
@@ -773,7 +773,7 @@ public class JdbcConnection implements AutoCloseable {
      * @see #execute(Operations)
      */
     public JdbcConnection prepareUpdate(String stmt, StatementPreparer preparer) throws SQLException {
-        final PreparedStatement statement = createPreparedStatement(stmt);
+        PreparedStatement statement = createPreparedStatement(stmt);
         if (preparer != null) {
             preparer.accept(statement);
         }
@@ -781,8 +781,56 @@ public class JdbcConnection implements AutoCloseable {
         if (LOGGER.isTraceEnabled()) {
             LOGGER.trace("Executing statement '{}' with {}s timeout", stmt, queryTimeout);
         }
-        statement.execute();
+        
+        try {
+            statement.execute();
+        } catch (SQLException e) {
+            // Check if this is a connection-related error that warrants retry
+            if (isConnectionException(e) && !isValid()) {
+                LOGGER.warn("Connection was closed, reconnecting and retrying", e);
+                
+                // Invalidate cached statements and reconnect
+                invalidateStatementCache();
+                reconnect();
+                
+                // Create new statement with fresh connection and retry
+                statement = createPreparedStatement(stmt);
+                if (preparer != null) {
+                    preparer.accept(statement);
+                }
+                statement.setQueryTimeout(queryTimeout);
+                if (LOGGER.isTraceEnabled()) {
+                    LOGGER.trace("Retrying statement '{}' with {}s timeout", stmt, queryTimeout);
+                }
+                statement.execute();
+            } else {
+                throw e;
+            }
+        }
         return this;
+    }
+
+    /**
+     * Checks if the exception indicates a connection issue.
+     */
+    private boolean isConnectionException(SQLException e) {
+        // Check SQL state for connection exceptions (08xxx)
+        String sqlState = e.getSQLState();
+        if (sqlState != null && sqlState.startsWith("08")) {
+            return true;
+        }
+        
+        // Check for common connection exception types
+        return e instanceof java.sql.SQLNonTransientConnectionException ||
+               e instanceof java.sql.SQLRecoverableException;
+    }
+
+    /**
+     * Invalidates all cached prepared statements.
+     */
+    private void invalidateStatementCache() {
+        statementCache.values().forEach(this::cleanupPreparedStatement);
+        statementCache.clear();
     }
 
     /**

--- a/debezium-core/src/main/java/io/debezium/jdbc/JdbcConnection.java
+++ b/debezium-core/src/main/java/io/debezium/jdbc/JdbcConnection.java
@@ -808,15 +808,7 @@ public class JdbcConnection implements AutoCloseable {
      * Checks if the exception indicates a connection issue.
      */
     private boolean isConnectionException(SQLException e) {
-        // Check SQL state for connection exceptions (08xxx)
-        String sqlState = e.getSQLState();
-        if (sqlState != null && sqlState.startsWith("08")) {
-            return true;
-        }
-
-        // Check for common connection exception types
-        return e instanceof java.sql.SQLNonTransientConnectionException ||
-                e instanceof java.sql.SQLRecoverableException;
+        return (e.getMessage() != null && e.getMessage().contains("connection closed"));
     }
 
     /**

--- a/debezium-core/src/main/java/io/debezium/jdbc/JdbcConnection.java
+++ b/debezium-core/src/main/java/io/debezium/jdbc/JdbcConnection.java
@@ -786,21 +786,15 @@ public class JdbcConnection implements AutoCloseable {
             statement.execute();
         } catch (SQLException e) {
             // Check if this is a connection-related error that warrants retry
-            if (isConnectionException(e) && !isValid()) {
+            if (isConnectionException(e))  {
                 LOGGER.warn("Connection was closed, reconnecting and retrying", e);
-                
-                // Invalidate cached statements and reconnect
-                invalidateStatementCache();
-                reconnect();
-                
-                // Create new statement with fresh connection and retry
+
+                close();
+                connect();
+
                 statement = createPreparedStatement(stmt);
                 if (preparer != null) {
                     preparer.accept(statement);
-                }
-                statement.setQueryTimeout(queryTimeout);
-                if (LOGGER.isTraceEnabled()) {
-                    LOGGER.trace("Retrying statement '{}' with {}s timeout", stmt, queryTimeout);
                 }
                 statement.execute();
             } else {
@@ -814,23 +808,7 @@ public class JdbcConnection implements AutoCloseable {
      * Checks if the exception indicates a connection issue.
      */
     private boolean isConnectionException(SQLException e) {
-        // Check SQL state for connection exceptions (08xxx)
-        String sqlState = e.getSQLState();
-        if (sqlState != null && sqlState.startsWith("08")) {
-            return true;
-        }
-        
-        // Check for common connection exception types
-        return e instanceof java.sql.SQLNonTransientConnectionException ||
-               e instanceof java.sql.SQLRecoverableException;
-    }
-
-    /**
-     * Invalidates all cached prepared statements.
-     */
-    private void invalidateStatementCache() {
-        statementCache.values().forEach(this::cleanupPreparedStatement);
-        statementCache.clear();
+        return (e.getMessage() != null && e.getMessage().contains("connection closed"));
     }
 
     /**


### PR DESCRIPTION
### **Issue Description:**
In incremental screenshots, if TCP connection gets broken in between connector pod and MySQL source for any reason, the connector would fail throwing SQL exception. Although there was a logic for connection validation before statement execute, but if during execute, the connection would break, the end user would get exception, making there connector stop. They needed to manually restart it to get it processing. Ref: #inc-2918_neema-mysqlcdcsourcev2-snapshot-system-stops-working-after-the-db-

### **Solution Proposed**
We are just proposing a single retry to re-establish connection, and execute statement if statement execution fails with `SQLRecoverableException` or `SQLNonTransientConnectionException`.

### **Validation of the approach**
https://confluent.slack.com/archives/C090HS8C0M7/p1753084485125149


