### PR TITLE
CC-35215: Fixes `Found a not connector specific implementation`warn

### DIFF
--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/snapshot/lock/ExclusiveSnapshotLock.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/snapshot/lock/ExclusiveSnapshotLock.java
@@ -10,11 +10,11 @@ import java.util.Map;
 import java.util.Optional;
 
 import io.debezium.annotation.ConnectorSpecific;
-import io.debezium.connector.sqlserver.SqlServerConnector;
 import io.debezium.connector.sqlserver.SqlServerConnectorConfig;
+import io.debezium.connector.sqlserver.SqlServerConnectorV2;
 import io.debezium.snapshot.spi.SnapshotLock;
 
-@ConnectorSpecific(connector = SqlServerConnector.class)
+@ConnectorSpecific(connector = SqlServerConnectorV2.class)
 public class ExclusiveSnapshotLock implements SnapshotLock {
 
     @Override

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/snapshot/lock/NoSnapshotLock.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/snapshot/lock/NoSnapshotLock.java
@@ -10,11 +10,11 @@ import java.util.Map;
 import java.util.Optional;
 
 import io.debezium.annotation.ConnectorSpecific;
-import io.debezium.connector.sqlserver.SqlServerConnector;
 import io.debezium.connector.sqlserver.SqlServerConnectorConfig;
+import io.debezium.connector.sqlserver.SqlServerConnectorV2;
 import io.debezium.snapshot.spi.SnapshotLock;
 
-@ConnectorSpecific(connector = SqlServerConnector.class)
+@ConnectorSpecific(connector = SqlServerConnectorV2.class)
 public class NoSnapshotLock implements SnapshotLock {
 
     @Override

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/snapshot/query/SelectAllSnapshotQuery.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/snapshot/query/SelectAllSnapshotQuery.java
@@ -11,10 +11,10 @@ import java.util.Optional;
 
 import io.debezium.annotation.ConnectorSpecific;
 import io.debezium.config.CommonConnectorConfig;
-import io.debezium.connector.sqlserver.SqlServerConnector;
+import io.debezium.connector.sqlserver.SqlServerConnectorV2;
 import io.debezium.snapshot.spi.SnapshotQuery;
 
-@ConnectorSpecific(connector = SqlServerConnector.class)
+@ConnectorSpecific(connector = SqlServerConnectorV2.class)
 public class SelectAllSnapshotQuery implements SnapshotQuery {
 
     @Override


### PR DESCRIPTION
Post DBZ v3 upgrade, the SQL Server connectors have started to log below warning
```
Found a not connector specific implementation io.debezium.connector.v2.sqlserver.snapshot.lock.ExclusiveSnapshotLock for lock mode exclusive
```
In v3, the connector uses ServiceLoader to load all available `SnapshotQuery` and `SnapshotLock` implementations during runtime. There are following checks 
- Confirm if the value in the configuration matches the name in the known implementations as well as the `connector.class` in the configuration matches the connector class the implementation is annotated with `@ConnectorSpecific`.
- Confirm if the name of the configured value (`snapshot.locking.mode=exclusive`) matches the name in the known implementations (`ExclusiveSnapshotLock.java`) (fallback check)

The connector class in annotation is `SqlServerConnector.java` while we use `SqlServerConnectorV2` when configuring the connector. This difference made the first check fail and the warn being logged. As the value of the field in the configuration is same, the connector continued to work fine with the fallback check.  

The current impact because of the failing check is the warning log only. There is no other functional impact (see logs).
After the fix, the behaviour would remain the same. The warning which is getting logged because of non-connector-specific implementation, would no longer happen.

Before the change
```
[2025-08-05 18:19:06,818] WARN [ss_05|task-0] Found a not connector specific implementation io.debezium.connector.v2.sqlserver.snapshot.query.SelectAllSnapshotQuery for query mode select_all (io.debezium.snapshot.SnapshotQueryProvider:83)
[2025-08-05 18:19:06,818] WARN [ss_05|task-0] Found a not connector specific implementation io.debezium.connector.v2.sqlserver.snapshot.lock.ExclusiveSnapshotLock for lock mode exclusive (io.debezium.snapshot.SnapshotLockProvider:82)

[2025-08-05 18:19:09,653] INFO [ss_05|task-0] Executing schema locking (io.debezium.connector.v2.sqlserver.SqlServerSnapshotChangeEventSource:114)
[2025-08-05 18:19:09,653] INFO [ss_05|task-0] Locking table bgoyal_test.dbo.CUSTOMERS (io.debezium.connector.v2.sqlserver.SqlServerSnapshotChangeEventSource:125)
[2025-08-05 18:19:09,907] INFO [ss_05|task-0] Locking table bgoyal_test.dbo.test_heartbeat_table (io.debezium.connector.v2.sqlserver.SqlServerSnapshotChangeEventSource:125)

[2025-08-05 18:19:12,979] INFO [ss_05|task-0] For table 'bgoyal_test.dbo.CUSTOMERS' using select statement: 'SELECT [ID], [Name], [COUNTRY], [verified] FROM [bgoyal_test].[dbo].[CUSTOMERS]' (io.debezium.relational.RelationalSnapshotChangeEventSource:490) 
```
after the change 

```

[2025-08-05 19:17:26,635] INFO [ss_06|task-0] Executing schema locking (io.debezium.connector.v2.sqlserver.SqlServerSnapshotChangeEventSource:114)
[2025-08-05 19:17:26,636] INFO [ss_06|task-0] Locking table bgoyal_test.dbo.CUSTOMERS (io.debezium.connector.v2.sqlserver.SqlServerSnapshotChangeEventSource:125)
[2025-08-05 19:17:26,895] INFO [ss_06|task-0] Locking table bgoyal_test.dbo.test_heartbeat_table (io.debezium.connector.v2.sqlserver.SqlServerSnapshotChangeEventSource:125)

[2025-08-05 19:17:30,023] INFO [ss_06|task-0] For table 'bgoyal_test.dbo.CUSTOMERS' using select statement: 'SELECT [ID], [Name], [COUNTRY], [verified] FROM [bgoyal_test].[dbo].[CUSTOMERS]' (io.debezium.relational.RelationalSnapshotChangeEventSource:490)
[2025-08-05 19:17:30,023] INFO [ss_06|task-0] For table 'bgoyal_test.dbo.test_heartbeat_table' using select statement: 'SELECT [text] FROM [bgoyal_test].[dbo].[test_heartbeat_table]' (io.debezium.relational.RelationalSnapshotChangeEventSource:490)
[2025-08-05 19:17:30,026] INFO [ss_06|task-0] Exporting data from table 'bgoyal_test.dbo.CUSTOMERS' (1 of 2 tables) (io.debezium.relational.RelationalSnapshotChangeEventSource:615)```