### PR TITLE
CC-34772: Connector failing to restart due to special table in Incremental snapshot

### DIFF
--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerIncrementalSnapshotContext.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerIncrementalSnapshotContext.java
@@ -7,11 +7,11 @@ package io.debezium.connector.sqlserver;
 
 import java.util.Map;
 
-import io.debezium.pipeline.source.snapshot.incremental.AbstractIncrementalSnapshotContext;
 import io.debezium.pipeline.source.snapshot.incremental.IncrementalSnapshotContext;
+import io.debezium.pipeline.source.snapshot.incremental.SignalBasedIncrementalSnapshotContext;
 import io.debezium.relational.TableId;
 
-public class SqlServerIncrementalSnapshotContext<T> extends AbstractIncrementalSnapshotContext<T> {
+public class SqlServerIncrementalSnapshotContext<T> extends SignalBasedIncrementalSnapshotContext<T> {
 
     public SqlServerIncrementalSnapshotContext() {
         this(true);

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerIncrementalSnapshotContext.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerIncrementalSnapshotContext.java
@@ -33,7 +33,7 @@ public class SqlServerIncrementalSnapshotContext<T> extends AbstractIncrementalS
 
     @Override
     public TableId getPredicateBasedTableIdForId(TableId id) {
-        return id.toUserQuote(SqlServerConnection.OPENING_QUOTING_CHARACTER, SqlServerConnection.CLOSING_QUOTING_CHARACTER);
+        return id.toBracketQuoted();
     }
 
     @Override

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerIncrementalSnapshotContext.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerIncrementalSnapshotContext.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.sqlserver;
+
+import java.util.Map;
+
+import io.debezium.pipeline.source.snapshot.incremental.AbstractIncrementalSnapshotContext;
+import io.debezium.pipeline.source.snapshot.incremental.IncrementalSnapshotContext;
+import io.debezium.relational.TableId;
+
+public class SqlServerIncrementalSnapshotContext<T> extends AbstractIncrementalSnapshotContext<T> {
+
+    public SqlServerIncrementalSnapshotContext() {
+        this(true);
+    }
+
+    public SqlServerIncrementalSnapshotContext(boolean useCatalogBeforeSchema) {
+        super(useCatalogBeforeSchema);
+    }
+
+    public static <U> IncrementalSnapshotContext<U> load(Map<String, ?> offsets) {
+        return load(offsets, true);
+    }
+
+    public static <U> SqlServerIncrementalSnapshotContext<U> load(Map<String, ?> offsets, boolean useCatalogBeforeSchema) {
+        final SqlServerIncrementalSnapshotContext<U> context = new SqlServerIncrementalSnapshotContext<>(useCatalogBeforeSchema);
+        init(context, offsets);
+        return context;
+    }
+
+    @Override
+    public TableId getPredicateBasedTableIdForId(TableId id) {
+        return id.toUserQuote(SqlServerConnection.OPENING_QUOTING_CHARACTER, SqlServerConnection.CLOSING_QUOTING_CHARACTER);
+    }
+
+    @Override
+    public TableId getPredicateBasedTableIdForString(String id) {
+        return TableId.parse(id, shouldUseCatalogBeforeSchema(), new SqlServerTableIdPredicates());
+    }
+}

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerOffsetContext.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerOffsetContext.java
@@ -15,7 +15,6 @@ import io.debezium.connector.SnapshotRecord;
 import io.debezium.connector.SnapshotType;
 import io.debezium.pipeline.CommonOffsetContext;
 import io.debezium.pipeline.source.snapshot.incremental.IncrementalSnapshotContext;
-import io.debezium.pipeline.source.snapshot.incremental.SignalBasedIncrementalSnapshotContext;
 import io.debezium.pipeline.spi.OffsetContext;
 import io.debezium.pipeline.txmetadata.TransactionContext;
 import io.debezium.relational.TableId;
@@ -55,7 +54,8 @@ public class SqlServerOffsetContext extends CommonOffsetContext<SourceInfo> {
     }
 
     public SqlServerOffsetContext(SqlServerConnectorConfig connectorConfig, TxLogPosition position, SnapshotType snapshot, boolean snapshotCompleted) {
-        this(connectorConfig, position, snapshot, snapshotCompleted, 1, new TransactionContext(), new SignalBasedIncrementalSnapshotContext<>());
+        this(connectorConfig, position, snapshot, snapshotCompleted, 1, new TransactionContext(),
+                new SqlServerIncrementalSnapshotContext<>());
     }
 
     @Override
@@ -126,7 +126,7 @@ public class SqlServerOffsetContext extends CommonOffsetContext<SourceInfo> {
             }
 
             return new SqlServerOffsetContext(connectorConfig, TxLogPosition.valueOf(commitLsn, changeLsn), snapshot, snapshotCompleted, eventSerialNo,
-                    TransactionContext.load(offset), SignalBasedIncrementalSnapshotContext.load(offset));
+                    TransactionContext.load(offset), SqlServerIncrementalSnapshotContext.load(offset));
         }
     }
 

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotContext.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotContext.java
@@ -136,6 +136,18 @@ public class AbstractIncrementalSnapshotContext<T> implements IncrementalSnapsho
         return paused.get();
     }
 
+    public boolean shouldUseCatalogBeforeSchema() {
+        return useCatalogBeforeSchema;
+    }
+
+    public TableId getPredicateBasedTableIdForId(TableId id) {
+        return id;
+    }
+
+    public TableId getPredicateBasedTableIdForString(String id) {
+        return TableId.parse(id, useCatalogBeforeSchema);
+    }
+
     /**
      * The snapshotting process can receive out-of-order windowing signals after connector restart
      * as depending on committed offset position some signals can be replayed.
@@ -190,13 +202,14 @@ public class AbstractIncrementalSnapshotContext<T> implements IncrementalSnapsho
         }
         offset.put(EVENT_PRIMARY_KEY, arrayToSerializedString(lastEventKeySent));
         offset.put(TABLE_MAXIMUM_KEY, arrayToSerializedString(maximumKey));
-        offset.put(SnapshotDataCollection.DATA_COLLECTIONS_TO_SNAPSHOT_KEY, snapshotDataCollection.dataCollectionsAsJsonString());
+        offset.put(SnapshotDataCollection.DATA_COLLECTIONS_TO_SNAPSHOT_KEY,
+                snapshotDataCollection.dataCollectionsAsJsonString(this));
         offset.put(CORRELATION_ID, correlationId);
         return offset;
     }
 
     private void addTablesIdsToSnapshot(List<DataCollection<T>> dataCollectionIds) {
-        snapshotDataCollection.add(dataCollectionIds);
+        snapshotDataCollection.add(dataCollectionIds, this);
     }
 
     @SuppressWarnings("unchecked")
@@ -248,7 +261,7 @@ public class AbstractIncrementalSnapshotContext<T> implements IncrementalSnapsho
     @SuppressWarnings("unchecked")
     public boolean removeDataCollectionFromSnapshot(String dataCollectionId) {
         final T collectionId = (T) TableId.parse(dataCollectionId, useCatalogBeforeSchema);
-        return snapshotDataCollection.remove(List.of(new DataCollection<>(collectionId)));
+        return snapshotDataCollection.remove(List.of(new DataCollection<>(collectionId)), this);
     }
 
     @Override
@@ -278,7 +291,7 @@ public class AbstractIncrementalSnapshotContext<T> implements IncrementalSnapsho
         final String dataCollectionsStr = (String) offsets.get(SnapshotDataCollection.DATA_COLLECTIONS_TO_SNAPSHOT_KEY);
         context.snapshotDataCollection.clear();
         if (dataCollectionsStr != null) {
-            context.addTablesIdsToSnapshot(context.snapshotDataCollection.stringToDataCollections(dataCollectionsStr, context.useCatalogBeforeSchema));
+            context.addTablesIdsToSnapshot(context.snapshotDataCollection.stringToDataCollections(dataCollectionsStr, context));
         }
         context.correlationId = (String) offsets.get(CORRELATION_ID);
         return context;
@@ -323,7 +336,7 @@ public class AbstractIncrementalSnapshotContext<T> implements IncrementalSnapsho
 
     public DataCollection<T> nextDataCollection() {
         resetChunk();
-        return snapshotDataCollection.getNext();
+        return snapshotDataCollection.getNext(this);
     }
 
     public void startNewChunk() {
@@ -392,14 +405,14 @@ public class AbstractIncrementalSnapshotContext<T> implements IncrementalSnapsho
         SnapshotDataCollection() {
         }
 
-        void add(List<DataCollection<T>> dataCollectionIds) {
+        void add(List<DataCollection<T>> dataCollectionIds, AbstractIncrementalSnapshotContext<T> context) {
             this.dataCollectionsToSnapshot.addAll(dataCollectionIds);
-            this.dataCollectionsToSnapshotJson = computeJsonString();
+            this.dataCollectionsToSnapshotJson = computeJsonString(context);
         }
 
-        DataCollection<T> getNext() {
+        DataCollection<T> getNext(AbstractIncrementalSnapshotContext<T> context) {
             DataCollection<T> nextDataCollection = this.dataCollectionsToSnapshot.poll();
-            this.dataCollectionsToSnapshotJson = computeJsonString();
+            this.dataCollectionsToSnapshotJson = computeJsonString(context);
             return nextDataCollection;
         }
 
@@ -420,13 +433,13 @@ public class AbstractIncrementalSnapshotContext<T> implements IncrementalSnapsho
             return this.dataCollectionsToSnapshot.isEmpty();
         }
 
-        public boolean remove(List<DataCollection<T>> toRemove) {
+        public boolean remove(List<DataCollection<T>> toRemove, AbstractIncrementalSnapshotContext<T> context) {
             boolean removed = this.dataCollectionsToSnapshot.removeAll(toRemove);
-            this.dataCollectionsToSnapshotJson = computeJsonString();
+            this.dataCollectionsToSnapshotJson = computeJsonString(context);
             return removed;
         }
 
-        public String dataCollectionsAsJsonString() {
+        public String dataCollectionsAsJsonString(AbstractIncrementalSnapshotContext<T> context) {
 
             if (!Strings.isNullOrEmpty(dataCollectionsToSnapshotJson)) {
                 // A cached value to improve performance since this method is called in the "store"
@@ -434,21 +447,21 @@ public class AbstractIncrementalSnapshotContext<T> implements IncrementalSnapsho
                 return dataCollectionsToSnapshotJson;
             }
 
-            return computeJsonString();
+            return computeJsonString(context);
         }
 
         public Queue<DataCollection<T>> getDataCollectionsToSnapshot() {
             return this.dataCollectionsToSnapshot;
         }
 
-        private String computeJsonString() {
+        private String computeJsonString(AbstractIncrementalSnapshotContext<T> context) {
             // TODO Handle non-standard table ids containing dots, commas etc.
 
             try {
                 List<LinkedHashMap<String, String>> dataCollectionsMap = dataCollectionsToSnapshot.stream()
                         .map(x -> {
                             LinkedHashMap<String, String> map = new LinkedHashMap<>();
-                            map.put(DATA_COLLECTIONS_TO_SNAPSHOT_KEY_ID, x.getId().toString());
+                            map.put(DATA_COLLECTIONS_TO_SNAPSHOT_KEY_ID, getStringFromId(x.getId(), context));
                             map.put(DATA_COLLECTIONS_TO_SNAPSHOT_KEY_ADDITIONAL_CONDITION, x.getAdditionalCondition().orElse(null));
                             map.put(DATA_COLLECTIONS_TO_SNAPSHOT_KEY_SURROGATE_KEY, x.getSurrogateKey().orElse(null));
                             return map;
@@ -462,11 +475,11 @@ public class AbstractIncrementalSnapshotContext<T> implements IncrementalSnapsho
             }
         }
 
-        private List<DataCollection<T>> stringToDataCollections(String dataCollectionsStr, boolean useCatalogBeforeSchema) {
+        private List<DataCollection<T>> stringToDataCollections(String dataCollectionsStr, AbstractIncrementalSnapshotContext context) {
             try {
                 List<LinkedHashMap<String, String>> dataCollections = mapper.readValue(dataCollectionsStr, mapperTypeRef);
                 return dataCollections.stream()
-                        .map(x -> new DataCollection<>((T) TableId.parse(x.get(DATA_COLLECTIONS_TO_SNAPSHOT_KEY_ID), useCatalogBeforeSchema),
+                        .map(x -> new DataCollection<>((T) context.getPredicateBasedTableIdForString(x.get(DATA_COLLECTIONS_TO_SNAPSHOT_KEY_ID)),
                                 Optional.ofNullable(x.get(DATA_COLLECTIONS_TO_SNAPSHOT_KEY_ADDITIONAL_CONDITION)).orElse(""),
                                 Optional.ofNullable(x.get(DATA_COLLECTIONS_TO_SNAPSHOT_KEY_SURROGATE_KEY)).orElse("")))
                         .collect(Collectors.toList());
@@ -475,5 +488,13 @@ public class AbstractIncrementalSnapshotContext<T> implements IncrementalSnapsho
                 throw new DebeziumException("Cannot de-serialize dataCollectionsToSnapshot information");
             }
         }
+
+        private String getStringFromId(T id, AbstractIncrementalSnapshotContext context) {
+            if (id instanceof TableId) {
+                return context.getPredicateBasedTableIdForId((TableId) id).toString();
+            }
+            return id.toString(); // Assuming T is not a TableId, return as is
+        }
+
     }
 }

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotContext.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotContext.java
@@ -462,7 +462,7 @@ public class AbstractIncrementalSnapshotContext<T> implements IncrementalSnapsho
                 List<LinkedHashMap<String, String>> dataCollectionsMap = dataCollectionsToSnapshot.stream()
                         .map(x -> {
                             LinkedHashMap<String, String> map = new LinkedHashMap<>();
-                            map.put(DATA_COLLECTIONS_TO_SNAPSHOT_KEY_ID, getStringFromId(x.getId()));
+                            map.put(DATA_COLLECTIONS_TO_SNAPSHOT_KEY_ID, context.getPredicateBasedTableIdForId((TableId) x.getId()).toString());
                             map.put(DATA_COLLECTIONS_TO_SNAPSHOT_KEY_ADDITIONAL_CONDITION, x.getAdditionalCondition().orElse(null));
                             map.put(DATA_COLLECTIONS_TO_SNAPSHOT_KEY_SURROGATE_KEY, x.getSurrogateKey().orElse(null));
                             return map;
@@ -489,13 +489,5 @@ public class AbstractIncrementalSnapshotContext<T> implements IncrementalSnapsho
                 throw new DebeziumException("Cannot de-serialize dataCollectionsToSnapshot information");
             }
         }
-
-        private String getStringFromId(T id) {
-            if (id instanceof TableId) {
-                return context.getPredicateBasedTableIdForId((TableId) id).toString();
-            }
-            return id.toString(); // Assuming T is not a TableId, return as is
-        }
-
     }
 }

--- a/debezium-core/src/main/java/io/debezium/relational/TableId.java
+++ b/debezium-core/src/main/java/io/debezium/relational/TableId.java
@@ -249,6 +249,27 @@ public final class TableId implements DataCollectionId, Comparable<TableId> {
     }
 
     /**
+     * Returns a new {@link TableId} with all parts of the identifier in user provided quoting
+     * characters
+     *
+     * @param openingQuote the string to be used to open the identifier.
+     * @param closingQuote the string to be used to close the identifier.
+     */
+    public TableId toUserQuote(String openingQuote, String closingQuote) {
+        String catalogName = null;
+        if (this.catalogName != null && !this.catalogName.isEmpty()) {
+            catalogName = quote(this.catalogName, openingQuote, closingQuote);
+        }
+
+        String schemaName = null;
+        if (this.schemaName != null && !this.schemaName.isEmpty()) {
+            schemaName = quote(this.schemaName, openingQuote, closingQuote);
+        }
+
+        return new TableId(catalogName, schemaName, quote(this.tableName, openingQuote, closingQuote));
+    }
+
+    /**
      * Returns a new {@link TableId} that has all parts of the identifier quoted.
      *
      * @param quotingChar the character to be used to quote the identifier parts.
@@ -315,6 +336,25 @@ public final class TableId implements DataCollectionId, Comparable<TableId> {
         if (identifierPart.charAt(0) != quotingChar && identifierPart.charAt(identifierPart.length() - 1) != quotingChar) {
             identifierPart = identifierPart.replace(quotingChar + "", repeat(quotingChar));
             identifierPart = quotingChar + identifierPart + quotingChar;
+        }
+
+        return identifierPart;
+    }
+
+    /**
+     * Quotes the given identifier part, e.g. schema or table name in openingQuote and closingQuote.
+     */
+    private static String quote(String identifierPart, String openingQuote, String closingQuote) {
+        if (identifierPart == null) {
+            return null;
+        }
+
+        if (identifierPart.isEmpty()) {
+            return openingQuote + closingQuote;
+        }
+
+        if (!identifierPart.startsWith(openingQuote) && !identifierPart.endsWith(closingQuote)) {
+            identifierPart = openingQuote + identifierPart + closingQuote;
         }
 
         return identifierPart;

--- a/debezium-core/src/main/java/io/debezium/relational/TableId.java
+++ b/debezium-core/src/main/java/io/debezium/relational/TableId.java
@@ -323,7 +323,7 @@ public final class TableId implements DataCollectionId, Comparable<TableId> {
 
         if (identifierPart.charAt(0) != openingChar && identifierPart.charAt(identifierPart.length() - 1) != closingChar) {
             if (openingChar == closingChar) {
-                identifierPart = identifierPart.replace(openingChar + "", repeat(openingChar));
+                identifierPart = identifierPart.replace(String.valueOf(openingChar), repeat(openingChar));
             }
             identifierPart = openingChar + identifierPart + closingChar;
         }

--- a/debezium-core/src/main/java/io/debezium/relational/TableId.java
+++ b/debezium-core/src/main/java/io/debezium/relational/TableId.java
@@ -245,47 +245,35 @@ public final class TableId implements DataCollectionId, Comparable<TableId> {
      * Returns a new {@link TableId} with all parts of the identifier using {@code "} character.
      */
     public TableId toDoubleQuoted() {
-        return toQuoted('"');
+        return toQuoted('"', '"');
     }
 
     /**
-     * Returns a new {@link TableId} with all parts of the identifier in user provided quoting
-     * characters
-     *
-     * @param openingQuote the string to be used to open the identifier.
-     * @param closingQuote the string to be used to close the identifier.
+     * Returns a new {@link TableId} with all parts of the identifier enclosed in {@code [}
+     * and {@code ]} character.
      */
-    public TableId toUserQuote(String openingQuote, String closingQuote) {
-        String catalogName = null;
-        if (this.catalogName != null && !this.catalogName.isEmpty()) {
-            catalogName = quote(this.catalogName, openingQuote, closingQuote);
-        }
-
-        String schemaName = null;
-        if (this.schemaName != null && !this.schemaName.isEmpty()) {
-            schemaName = quote(this.schemaName, openingQuote, closingQuote);
-        }
-
-        return new TableId(catalogName, schemaName, quote(this.tableName, openingQuote, closingQuote));
+    public TableId toBracketQuoted() {
+        return toQuoted('[', ']');
     }
 
     /**
      * Returns a new {@link TableId} that has all parts of the identifier quoted.
      *
-     * @param quotingChar the character to be used to quote the identifier parts.
+     * @param openingChar the character to be used to quote the opening of the identifier.
+     * @param closingChar the character to be used to quote the closing of the identifier.
      */
-    public TableId toQuoted(char quotingChar) {
+    public TableId toQuoted(char openingChar, char closingChar) {
         String catalogName = null;
         if (this.catalogName != null && !this.catalogName.isEmpty()) {
-            catalogName = quote(this.catalogName, quotingChar);
+            catalogName = quote(this.catalogName, openingChar, closingChar);
         }
 
         String schemaName = null;
         if (this.schemaName != null && !this.schemaName.isEmpty()) {
-            schemaName = quote(this.schemaName, quotingChar);
+            schemaName = quote(this.schemaName, openingChar, closingChar);
         }
 
-        return new TableId(catalogName, schemaName, quote(this.tableName, quotingChar));
+        return new TableId(catalogName, schemaName, quote(this.tableName, openingChar, closingChar));
     }
 
     /**
@@ -296,14 +284,14 @@ public final class TableId implements DataCollectionId, Comparable<TableId> {
         StringBuilder quoted = new StringBuilder();
 
         if (catalogName != null && !catalogName.isEmpty()) {
-            quoted.append(quote(catalogName, quotingChar)).append(".");
+            quoted.append(quote(catalogName, quotingChar, quotingChar)).append(".");
         }
 
         if (schemaName != null && !schemaName.isEmpty()) {
-            quoted.append(quote(schemaName, quotingChar)).append(".");
+            quoted.append(quote(schemaName, quotingChar, quotingChar)).append(".");
         }
 
-        quoted.append(quote(tableName, quotingChar));
+        quoted.append(quote(tableName, quotingChar, quotingChar));
 
         return quoted.toString();
     }
@@ -322,46 +310,26 @@ public final class TableId implements DataCollectionId, Comparable<TableId> {
     }
 
     /**
-     * Quotes the given identifier part, e.g. schema or table name.
+     * Quotes the given identifier part, e.g. schema or table name in openingChar and closingChar.
      */
-    private static String quote(String identifierPart, char quotingChar) {
+    private static String quote(String identifierPart, char openingChar, char closingChar) {
         if (identifierPart == null) {
             return null;
         }
 
         if (identifierPart.isEmpty()) {
-            return repeat(quotingChar);
+            return String.valueOf(openingChar) + closingChar;
         }
 
-        if (identifierPart.charAt(0) != quotingChar && identifierPart.charAt(identifierPart.length() - 1) != quotingChar) {
-            identifierPart = identifierPart.replace(quotingChar + "", repeat(quotingChar));
-            identifierPart = quotingChar + identifierPart + quotingChar;
-        }
-
-        return identifierPart;
-    }
-
-    /**
-     * Quotes the given identifier part, e.g. schema or table name in openingQuote and closingQuote.
-     */
-    private static String quote(String identifierPart, String openingQuote, String closingQuote) {
-        if (identifierPart == null) {
-            return null;
-        }
-
-        if (identifierPart.isEmpty()) {
-            return openingQuote + closingQuote;
-        }
-
-        if (!identifierPart.startsWith(openingQuote) && !identifierPart.endsWith(closingQuote)) {
-            identifierPart = openingQuote + identifierPart + closingQuote;
+        if (identifierPart.charAt(0) != openingChar && identifierPart.charAt(identifierPart.length() - 1) != closingChar) {
+            identifierPart = identifierPart.replace(String.valueOf(openingChar), "");
+            if (openingChar != closingChar) {
+                identifierPart = identifierPart.replace(String.valueOf(closingChar), "");
+            }
+            identifierPart = openingChar + identifierPart + closingChar;
         }
 
         return identifierPart;
-    }
-
-    private static String repeat(char quotingChar) {
-        return new StringBuilder().append(quotingChar).append(quotingChar).toString();
     }
 
     public TableId toLowercase() {

--- a/debezium-core/src/main/java/io/debezium/relational/TableId.java
+++ b/debezium-core/src/main/java/io/debezium/relational/TableId.java
@@ -322,14 +322,17 @@ public final class TableId implements DataCollectionId, Comparable<TableId> {
         }
 
         if (identifierPart.charAt(0) != openingChar && identifierPart.charAt(identifierPart.length() - 1) != closingChar) {
-            identifierPart = identifierPart.replace(String.valueOf(openingChar), "");
-            if (openingChar != closingChar) {
-                identifierPart = identifierPart.replace(String.valueOf(closingChar), "");
+            if (openingChar == closingChar) {
+                identifierPart = identifierPart.replace(openingChar + "", repeat(openingChar));
             }
             identifierPart = openingChar + identifierPart + closingChar;
         }
 
         return identifierPart;
+    }
+
+    private static String repeat(char quotingChar) {
+        return new StringBuilder().append(quotingChar).append(quotingChar).toString();
     }
 
     public TableId toLowercase() {

--- a/debezium-core/src/test/java/io/debezium/relational/TableIdTest.java
+++ b/debezium-core/src/test/java/io/debezium/relational/TableIdTest.java
@@ -72,4 +72,19 @@ public class TableIdTest {
         quoted = id.toBracketQuoted();
         assertThat(quoted).isEqualTo(id);
     }
+
+    @Test
+    public void shouldQuoteTableWithApostrophe() {
+        TableId id = new TableId("special_characters_test_1vxxglz", "", "special\"[`]$']");
+
+        String quoted = id.toQuotedString('`');
+
+        assertThat(quoted).isEqualTo("`special_characters_test_1vxxglz`.`special\"[``]$']`");
+
+        // Quoted table-id
+        id = new TableId("`special_characters_test_1vxxglz`", "", "`special\"[``]$']`");
+
+        quoted = id.toQuotedString('`');
+        assertThat(quoted).isEqualTo(id.toString());
+    }
 }

--- a/debezium-core/src/test/java/io/debezium/relational/TableIdTest.java
+++ b/debezium-core/src/test/java/io/debezium/relational/TableIdTest.java
@@ -39,7 +39,7 @@ public class TableIdTest {
         // Non-quoted quoted table-id
         TableId id = new TableId("catalog", "schema", "table");
 
-        TableId quoted = id.toQuoted('\'');
+        TableId quoted = id.toQuoted('\'', '\'');
         assertThat(quoted.catalog()).isEqualTo("'catalog'");
         assertThat(quoted.schema()).isEqualTo("'schema'");
         assertThat(quoted.table()).isEqualTo("'table'");
@@ -49,7 +49,27 @@ public class TableIdTest {
         // Quoted table-id
         id = new TableId("'catalog'", "'schema'", "'table'");
 
-        quoted = id.toQuoted('\'');
+        quoted = id.toQuoted('\'', '\'');
+        assertThat(quoted).isEqualTo(id);
+    }
+
+    @Test
+    public void shouldQuoteTableIdWithBracket() {
+        // Non-quoted quoted table-id
+        TableId id = new TableId("cata log", "sch ema", "ta b$le");
+
+        TableId quoted = id.toBracketQuoted();
+        assertThat(quoted.catalog()).isEqualTo("[cata log]");
+        assertThat(quoted.schema()).isEqualTo("[sch ema]");
+        assertThat(quoted.table()).isEqualTo("[ta b$le]");
+        assertThat(quoted.toString()).isEqualTo("[cata log].[sch ema].[ta b$le]");
+        assertThat(quoted.toDoubleQuotedString()).isEqualTo("\"[cata log]\".\"[sch ema]\".\"[ta "
+                + "b$le]\"");
+
+        // Quoted table-id
+        id = new TableId("[cata log]", "[sch ema]", "[ta b$le]");
+
+        quoted = id.toBracketQuoted();
         assertThat(quoted).isEqualTo(id);
     }
 }


### PR DESCRIPTION
This PR cherry-picks changes done as part of [DBZ-9209](https://issues.redhat.com/browse/DBZ-9209)
Upstream PR: https://github.com/debezium/debezium/pull/6581
Currently, the incremental snapshot updates the offsets such that the table name is stored as well in the offsets. If the tablename contains a special character, there is a chance the task fails to parse the tablename post restart and is unable to recover.
 In order to fix that, the SQL Server incremental snapshot context is overridden to wrap the `catalogName.schemaName.tableName` written to and read from the offsets in brackets i.e. `[catalogName].[schemaName].[tableName]`. Large brackets `[` ,`] `are acceptable start and end delimiters in SQL Server. Hence, the DBZ already has support for these characters for SQL server. After this change, these delimiters would be used to allow tables with special characters such `$`,`  ` to be parsed correctly when storing and reading from offsets. 

The other DBZ connectors can override the introduced methods as per the allowed delimiters in the corresponding source system.
 
 JIRA: https://confluentinc.atlassian.net/browse/CC-34772

 Existing sample Offset record
```
[
  {
    "partition": {
      "database": "bgoyal_test",
      "server": "testinc_snap"
    },
    "offset": {
      "change_lsn": "000004d3:00013d98:0002",
      "commit_lsn": "000004d3:00013d98:0003",
      "event_serial_no": 1,
      "incremental_snapshot_collections": "[{\"incremental_snapshot_collections_id\":\"bgoyal_test.dbo.MET Romania$Taget\",\"incremental_snapshot_collections_additional_condition\":null,\"incremental_snapshot_collections_surrogate_key\":null}]",
      "incremental_snapshot_correlation_id": "a4",
      "incremental_snapshot_maximum_key": "aced0005757200135b4c6a6176612e6c616e672e4f626a6563743b90ce589f1073296c020000787000000001737200116a6176612e6c616e672e496e746567657212e2a0a4f781873802000149000576616c7565787200106a6176612e6c616e672e4e756d62657286ac951d0b94e08b020000787000b71b01",
      "incremental_snapshot_primary_key": "aced0005757200135b4c6a6176612e6c616e672e4f626a6563743b90ce589f1073296c020000787000000001737200116a6176612e6c616e672e496e746567657212e2a0a4f781873802000149000576616c7565787200106a6176612e6c616e672e4e756d62657286ac951d0b94e08b0200007870000047fa"
    }
  }
]
```
After this change, the offset would be of below format (observe the `incremental_snapshot_collections_id`)
```
[
  {
    "partition": {
      "database": "bgoyal_test",
      "server": "testinc_snap"
    },
    "offset": {
      "change_lsn": "000004d3:00013d98:0002",
      "commit_lsn": "000004d3:00013d98:0003",
      "event_serial_no": 1,
      "incremental_snapshot_collections": "[{\"incremental_snapshot_collections_id\":\"[bgoyal_test].[dbo].[MET Romania$Taget]\",\"incremental_snapshot_collections_additional_condition\":null,\"incremental_snapshot_collections_surrogate_key\":null}]",
      "incremental_snapshot_correlation_id": "a4",
      "incremental_snapshot_maximum_key": "aced0005757200135b4c6a6176612e6c616e672e4f626a6563743b90ce589f1073296c020000787000000001737200116a6176612e6c616e672e496e746567657212e2a0a4f781873802000149000576616c7565787200106a6176612e6c616e672e4e756d62657286ac951d0b94e08b020000787000b71b01",
      "incremental_snapshot_primary_key": "aced0005757200135b4c6a6176612e6c616e672e4f626a6563743b90ce589f1073296c020000787000000001737200116a6176612e6c616e672e496e746567657212e2a0a4f781873802000149000576616c7565787200106a6176612e6c616e672e4e756d62657286ac951d0b94e08b0200007870000047fa"
    }
  }
]
```

## Steps to test
1. Create a connector with signal table and relevant table.include.list. 
2. Make an insert into the DBZ signaling table requesting incremental snapshot of table with special characters in its name
`INSERT INTO dbz_signaling (id, type, data)  values ('a4',   'execute-snapshot',  '{"data-collections": ["bgoyal_test.dbo.\"MET Romania$Taget\""]}');` 
3. Connector starts taking the incremental snapshot. Observe the offsets, once the offsets reflect the incremental_snapshot related fields, restart the connector with tasks (can use Cloud UI). 
4. The restart would fail if the connector is unable to parse the special table.
5. Post fix, such steps would not lead to task failure.

## Testing
Tested on canary-4