### PR TITLE
CC-35228: Add Credential Provider support for Postgres

### DIFF
--- a/debezium-connector-postgres/pom.xml
+++ b/debezium-connector-postgres/pom.xml
@@ -76,6 +76,12 @@
             <groupId>io.confluent</groupId>
             <artifactId>credential-providers</artifactId>
             <version>${credential.providers.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-reload4j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Testing -->


### PR DESCRIPTION
Add support for custom credential provider in Postgres to support `Google cloud service account impersonation` ( GCP Provider Integration) in Postgres cdc source V2 connector.

Jira: https://confluentinc.atlassian.net/browse/CC-35228

Test details: https://confluentinc.atlassian.net/wiki/spaces/OAAC/pages/4581985353/Bug+Bash+-+Provider+Integration+GCP#Postgres-cdc-source-V2