### PR TITLE
Fix memory leak bug (set running false outside lock)

### DIFF
--- a/debezium-core/src/main/java/io/debezium/connector/base/ChangeEventQueue.java
+++ b/debezium-core/src/main/java/io/debezium/connector/base/ChangeEventQueue.java
@@ -217,9 +217,9 @@ public class ChangeEventQueue<T extends Sizeable> implements ChangeEventQueueMet
      * Shutdown the queue, causing any blocked enqueue operations to be interrupted
      */
     public void shutdown() {
+        running = false;
         try {
             this.lock.lock();
-            running = false;
             this.isNotFull.signalAll();
             this.isFull.signalAll();
         }
@@ -245,6 +245,10 @@ public class ChangeEventQueue<T extends Sizeable> implements ChangeEventQueueMet
                 this.isFull.signalAll();
                 // queue size or queue sizeInBytes threshold reached, so wait a bit
                 this.isNotFull.await(pollInterval.toMillis(), TimeUnit.MILLISECONDS);
+            }
+
+            if (!running) {
+                throw new InterruptedException("Queue has been shut down");
             }
 
             queue.add(record);


### PR DESCRIPTION
Memory leak fix earlier was having a small issue, as the `running = false` was happening inside lock, but at the same time 
```
 this.lock.lock();

            while (queue.size() >= maxQueueSize || (maxQueueSizeInBytes > 0 && currentQueueSizeInBytes >= maxQueueSizeInBytes)) {
                if (!running) {
                    throw new InterruptedException("Queue has been shut down");
                }

                // signal poll() to drain queue
                this.isFull.signalAll();
                // queue size or queue sizeInBytes threshold reached, so wait a bit
                this.isNotFull.await(pollInterval.toMillis(), TimeUnit.MILLISECONDS);
            }
```

this block was acquiring lock, and the it was never able to unlock from the above code base, because `while (queue.size() >= maxQueueSize || (maxQueueSizeInBytes > 0 && currentQueueSizeInBytes >= maxQueueSizeInBytes)) ` was being evaluated to true. To mitigate this, we have moved `running = false` outside lock, and its `volatile`, so it should be safe.


Also
```
if (!running) {
                throw new InterruptedException("Queue has been shut down");
            }
```
is added outside loop as well, in order to ensure, enqueuing stops even when queue gets shutdown signal, irrespective of the fact whether we reach queue full stage. This will help in managing memory leak, when connector restarts during snapshot repeatedly, but the memory never reaches to queue full stage.