### PR TITLE
Upgrade mssql-jdbc from 9.4.1.jre8 to 10.2.4.jre11 to fix CVE-2025-59250

### DIFF
--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorConfig.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorConfig.java
@@ -26,6 +26,7 @@ import io.debezium.config.Field;
 import io.debezium.connector.AbstractSourceInfo;
 import io.debezium.connector.SourceInfoStructMaker;
 import io.debezium.document.Document;
+import io.debezium.jdbc.JdbcConfiguration;
 import io.debezium.relational.ColumnFilterMode;
 import io.debezium.relational.HistorizedRelationalDatabaseConnectorConfig;
 import io.debezium.relational.RelationalDatabaseConnectorConfig;
@@ -540,5 +541,18 @@ public class SqlServerConnectorConfig extends HistorizedRelationalDatabaseConnec
         }
 
         return count;
+    }
+
+    /**
+     * mssql-jdbc 10.2+ changed the default value of {@code encrypt} from {@code false} to {@code true},
+     * breaking existing connectors that rely on the driver default. These defaults preserve the 9.x
+     * behavior so that the driver upgrade (CVE-2025-59250) is backward-compatible.
+     */
+    @Override
+    public JdbcConfiguration getJdbcConfig() {
+        return JdbcConfiguration.copy(super.getJdbcConfig())
+                .withDefault("encrypt", "false")
+                .withDefault("trustServerCertificate", "true")
+                .build();
     }
 }

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/util/TestHelper.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/util/TestHelper.java
@@ -109,6 +109,8 @@ public class TestHelper {
                 .withDefault(JdbcConfiguration.PORT, 1433)
                 .withDefault(JdbcConfiguration.USER, "sa")
                 .withDefault(JdbcConfiguration.PASSWORD, "Password!")
+                .withDefault("encrypt", "false")
+                .withDefault("trustServerCertificate", "true")
                 .build();
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
         <version.mysql.driver>8.0.28</version.mysql.driver>
         <version.mysql.binlog>0.27.2</version.mysql.binlog>
         <version.mongo.driver>4.3.3</version.mongo.driver>
-        <version.sqlserver.driver>9.4.1.jre8</version.sqlserver.driver>
+        <version.sqlserver.driver>10.2.4.jre11</version.sqlserver.driver>
         <version.oracle.driver>21.1.0.0</version.oracle.driver>
         <version.db2.driver>11.5.0.0</version.db2.driver>
         <version.cassandra.driver>4.14.0</version.cassandra.driver>


### PR DESCRIPTION
## Summary

  Upgrades mssql-jdbc driver from 9.4.1.jre8 to 10.2.4.jre11 to fix CVE-2025-59250.

  ## Changes

  - Updated `version.sqlserver.driver` property in root `pom.xml` from `9.4.1.jre8` to `10.2.4.jre11`
  - Added `getJdbcConfig()` override in `SqlServerConnectorConfig` with `encrypt=false` and `trustServerCertificate=true` defaults for backward compatibility with mssql-jdbc 10.2+ default `encrypt=true` behavior
  - Added `encrypt=false` and `trustServerCertificate=true` to test config (`TestHelper.java`) for test infrastructure connections that bypass `SqlServerConnectorConfig`

  ## Breaking Change

  mssql-jdbc 10.2+ changed the default value of `encrypt` from `false` to `true`. Additionally, even when `encrypt=false`, if the server forces encryption, the driver now validates the server certificate based on `trustServerCertificate` (previously it did not validate at all).

  To preserve backward compatibility, `SqlServerConnectorConfig.getJdbcConfig()` is overridden to default `encrypt=false` and `trustServerCertificate=true`, matching the 9.x driver behavior. Users who explicitly set `database.encrypt=true` are unaffected as `withDefault()` only applies when the key is not already present.

  ## Local Testing

  Tested with mssql-jdbc 10.2.4 against two Docker SQL Server 2019 instances:

  | Case | Server Config | Without configs | With `database.encrypt=false` + `database.trustServerCertificate=true` |
  |---|---|---|---|
  | Plain (no TLS) | Default | Fails — driver defaults `encrypt=true`, SSL handshake fails | Works — plain text connection |
  | Forced encryption | `forceencryption=1`, self-signed cert | Fails — PKIX cert validation fails | Works — cert validation skipped |

  Both connectors successfully snapshotted and streamed CDC events after adding the configs. Records verified via `kafka-avro-console-consumer`.
Verified from DEBUG logs that user configs for the configs would work 
```
DEBUG Connected to jdbc:sqlserver://3.148.211.203:1433;databaseName=bgoyal_test with {responseBuffering=adaptive, fetchSize=10000, server.name=topic27_encrypted12, trustServerCertificate=true, password=***, encrypt=true, user=bgoyal_test_login} (io.debezium.jdbc.JdbcConnection:250)
```
