### PR TITLE
Fix lang_version type in service.yml

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -1,6 +1,6 @@
 name: debezium
 lang: java
-lang_version: 11
+lang_version: "11"
 git:
   enable: true
 codeowners:


### PR DESCRIPTION
## Summary
- Quotes `lang_version: 11` → `lang_version: "11"` in service.yml
- YAML parses bare `11` as an integer, but ServiceBot's pydantic model expects a string
- This was causing the ServiceBot nightly run to fail with: `lang_version: Input should be a valid string [type=string_type, input_value=11, input_type=int]`
- Failed job: https://semaphore.ci.confluent.io/jobs/53181a33-72c1-4603-b8c7-220790e5d2eb

## Test plan
- [ ] Verify ServiceBot nightly run succeeds after merge