### PR TITLE
CC-39707: Upgrade postgresql driver to 42.6.1 for CVE fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
         <version.apicurio>2.1.5.Final</version.apicurio>
 
         <!-- Database drivers, should align with databases -->
-        <version.postgresql.driver>42.7.2</version.postgresql.driver>
+        <version.postgresql.driver>42.6.1</version.postgresql.driver>
         <version.mysql.driver>8.0.28</version.mysql.driver>
         <version.mysql.binlog>0.27.2</version.mysql.binlog>
         <version.mongo.driver>4.3.3</version.mongo.driver>


### PR DESCRIPTION
## Summary
- Upgrades `org.postgresql:postgresql` from `42.7.2` to `42.6.1` for testing tag generation
- Jira: https://confluentinc.atlassian.net/browse/CC-39707

## Test plan
- [ ] Verify tag is generated after merge to 1.9.6.x