### PR TITLE
CC-39478: debezium/dbz#1724: Fix duplicate END transaction records for MongoDB

### DIFF
--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/TransactionMetadataIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/TransactionMetadataIT.java
@@ -128,4 +128,66 @@ public class TransactionMetadataIT extends AbstractMongoConnectorIT {
 
         stopConnector();
     }
+
+    @Test
+    public void shouldNotEmitDuplicateEndRecordsForMultipleNonTransactionalEvents() throws Exception {
+        // Testing.Print.enable();
+        config = TestHelper.getConfiguration(mongo)
+                .edit()
+                .with(MongoDbConnectorConfig.COLLECTION_INCLUDE_LIST, "dbA.c1")
+                .with(MongoDbConnectorConfig.SNAPSHOT_MODE, SnapshotMode.INITIAL)
+                .with(MongoDbConnectorConfig.PROVIDE_TRANSACTION_METADATA, true)
+                .build();
+
+        context = new MongoDbTaskContext(config);
+
+        TestHelper.cleanDatabase(mongo, "dbA");
+
+        if (!TestHelper.transactionsSupported()) {
+            return;
+        }
+
+        start(MongoDbConnector.class, config);
+        assertConnectorIsRunning();
+
+        // Wait for snapshot completion
+        waitForSnapshotToBeCompleted("mongodb", "mongo1");
+
+        // Insert 2 documents in a transaction
+        insertDocumentsInTx("dbA", "c1",
+                new Document("_id", 1).append("data", "txn-doc-1"),
+                new Document("_id", 2).append("data", "txn-doc-2"));
+
+        // Insert first non-transactional document - this should trigger END
+        insertDocuments("dbA", "c1", new Document("_id", 3).append("data", "non-txn-doc-1"));
+
+        // Insert second non-transactional document - this should NOT trigger another END
+        insertDocuments("dbA", "c1", new Document("_id", 4).append("data", "non-txn-doc-2"));
+
+        // Insert third non-transactional document - this should NOT trigger another END
+        insertDocuments("dbA", "c1", new Document("_id", 5).append("data", "non-txn-doc-3"));
+
+        // Expected records:
+        // - BEGIN (1 transaction record)
+        // - 2 data events from transaction
+        // - END (1 transaction record) - triggered by first non-txn event
+        // - 3 data events from non-transactional inserts
+        // Total: 1 + 2 + 1 + 3 = 7 records, with exactly 2 transaction records
+        final SourceRecords records = consumeRecordsByTopic(1 + 2 + 1 + 3);
+        final List<SourceRecord> dataRecords = records.recordsForTopic("mongo1.dbA.c1");
+        final List<SourceRecord> txRecords = records.recordsForTopic("mongo1.transaction");
+
+        // Verify we have exactly 5 data records (2 from txn + 3 non-txn)
+        assertThat(dataRecords).hasSize(5);
+
+        // Critical assertion: we should have exactly 2 transaction records (1 BEGIN + 1 END)
+        // Before the fix, this would fail with 4 records (1 BEGIN + 3 ENDs)
+        assertThat(txRecords).hasSize(2);
+
+        final List<SourceRecord> all = records.allRecordsInOrder();
+        final String txId = assertBeginTransaction(all.get(0));
+        assertEndTransaction(all.get(3), txId, 2, Collect.hashMapOf("dbA.c1", 2));
+
+        stopConnector();
+    }
 }

--- a/debezium-core/src/main/java/io/debezium/pipeline/txmetadata/TransactionMonitor.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/txmetadata/TransactionMonitor.java
@@ -90,6 +90,7 @@ public class TransactionMonitor {
             if (transactionContext.isTransactionInProgress()) {
                 LOGGER.trace("Transaction was in progress, executing implicit transaction commit");
                 endTransaction(partition, offset, eventMetadataProvider.getEventTimestamp(source, offset, key, value));
+                transactionContext.endTransaction();
             }
             return;
         }


### PR DESCRIPTION
## Summary

This PR cherry-picks the fix for duplicate END transaction records in MongoDB connector.

**Upstream PR:** https://github.com/debezium/debezium/pull/7207
**Upstream Issue:** https://github.com/debezium/dbz/issues/1724

## Problem

When a non-transactional event arrives while a transaction is marked as "in progress", the `TransactionMonitor` correctly emits an END record to close the transaction. However, it failed to reset the transaction state by calling `transactionContext.endTransaction()`.

This caused `isTransactionInProgress()` to remain `true`, resulting in duplicate END records being emitted for every subsequent non-transactional event.

### Steps to reproduce

1. Insert documents in a MongoDB transaction (e.g., 2 inserts)
2. Insert a non-transactional document → END record emitted (correct)
3. Insert another non-transactional document → **Duplicate END record emitted (bug)**

## Fix

Added the missing `transactionContext.endTransaction()` call to reset the transaction state after emitting the END record.

## Test plan

- [x] Integration test `shouldNotEmitDuplicateEndRecordsForMultipleNonTransactionalEvents` added
- [x] Manual testing verified on devel environment