### PR TITLE
Restrict Release block to pom.xml changes only

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -82,7 +82,7 @@ blocks:
   - name: Release
     dependencies: []
     run:
-      when: "branch =~ '[0-9]+\\.[0-9]+\\.[0-9]+\\.x' or branch =~ '[0-9]+\\.[0-9]+\\.x'"
+      when: "branch =~ '[0-9]+\\.[0-9]+\\.[0-9]+\\.x' and change_in('/**/pom.xml')"
     task:
       jobs:
         - name: Release


### PR DESCRIPTION
## Summary
- Only trigger tag generation when `pom.xml` files are changed (via `change_in('/**/pom.xml')`)
- Remove unnecessary `X.Y.x` branch pattern from Release condition

## Test plan
- [ ] Verify Release block triggers on pom.xml changes to `1.9.7.x`
- [ ] Verify Release block does NOT trigger on non-pom changes (e.g., semaphore config updates)