### PR TITLE
Add explicit lower bound predicate for direct mode CDC queries

### DIFF
--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnection.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnection.java
@@ -194,6 +194,10 @@ public class SqlServerConnection extends JdbcConnection {
                 "OR ([__$start_lsn] > ?))");
         where.add("[__$start_lsn] <= ?");
 
+        if (dataQueryMode == SqlServerConnectorConfig.DataQueryMode.DIRECT) {
+            where.add("[__$start_lsn] >= ?");
+        }
+
         if (hasSkippedOperations(skippedOperations)) {
             Set<String> skippedOps = new HashSet<>();
             skippedOperations.forEach((Envelope.Operation operation) -> {
@@ -427,6 +431,10 @@ public class SqlServerConnection extends JdbcConnection {
         statement.setBytes(paramIndex++, seqvalFromLsn.getBinary());
         statement.setBytes(paramIndex++, fromLsn.getBinary());
         statement.setBytes(paramIndex++, intervalToLsn.getBinary());
+
+        if (config.getDataQueryMode() == SqlServerConnectorConfig.DataQueryMode.DIRECT) {
+            statement.setBytes(paramIndex++, fromLsn.getBinary());
+        }
 
         return statement.executeQuery();
     }


### PR DESCRIPTION
## Problem                                                                                                                                                
                                                                                                                                                            
  When using `data.query.mode=direct`, the SQL Server CDC connector's streaming throughput degrades over time. The connector gets progressively slower as it processes more data, even when no new changes are arriving.                                                                                              
                                                                                                                                                            
  ### Root Cause  

  Each CDC change table has a clustered index on `(__$start_lsn, __$command_id, __$seqval, __$operation)`. When the connector queries for new changes, it needs to read rows within a specific LSN range — from `fromLsn` (where it last left off) to `toLsn` (the next batch boundary).
                                                                                                                                                            
  **Function mode** uses `fn_cdc_get_all_changes_*`, which receives both bounds as function parameters. SQL Server generates an efficient range scan — it jumps directly to `fromLsn` in the index and stops at `toLsn`, reading only the relevant pages.
                                                                                                                                                            
  **Direct mode** queries the CDC change table directly with a WHERE clause that expresses the lower bound as three OR conditions:                          
   
  ```sql                                                                                                                                                    
  WHERE ((__$start_lsn = ? AND __$seqval = ? AND __$operation > ?)
      OR (__$start_lsn = ? AND __$seqval > ?)                                                                                                               
      OR (__$start_lsn > ?))                                                                                                                                
  AND __$start_lsn <= ?                                                                                                                                     
  ```                                                                                                                                                       
                                                                                                                                                            
  SQL Server's query planner cannot extract a lower bound from this OR structure. It only uses the upper bound (`<= toLsn`) for index navigation, so every query **scans from the beginning of the index** up to `toLsn`. As the connector advances through the table, `toLsn` moves forward, and each scan covers more pages — causing throughput to degrade over time.                                                                                                     
                  
  ### Evidence                                                                                                                                              
   
  - **Execution plans** confirm one-sided seek (direct) vs two-sided seek (function)                                                                        
  - **Logical reads per query:** 3,144 (direct) vs 4 (function) — **~800x overhead**
  - **Per-query time increased 70%** in just 30 minutes as `toLsn` advanced further                                                                         
  - **With 200 tables:** ~628,800 logical reads per polling cycle (direct) vs ~800 (function)                                                               
                                                                                                                                                            
  ## Fix                                                                                                                                                    
                                                                                                                                                            
  Add an explicit `AND [__$start_lsn] >= ?` predicate to the direct mode query. This is logically redundant — the OR conditions already imply `__$start_lsn   >= fromLsn` — but it gives the query planner the simple predicate it needs to navigate the index from both ends.
                                                                                                                                                            
  **After fix:** logical reads drop from 3,144 to 4 per query, matching function mode exactly. The fix is guarded to direct mode only; function mode is  unchanged.
                                                                                                                                                            
  ## Testing      

  - Validated on Confluent Cloud (devel) with 200 CDC-tracked tables and ~7 GB of change data                                                               
  - `SET STATISTICS IO` before/after: 3,144 → 4 logical reads
  - `SET SHOWPLAN_TEXT` confirms two-sided index seek after fix                                                                                             
  - Detailed RCA with full SQL benchmarks, execution plans, and connector log analysis available here: https://confluentinc.atlassian.net/wiki/spaces/~63450f5048be855a65ec5804/pages/5389289208/RCA+for+throughout+degradation+in+direct+data+query+mode         

Throughput  Before -                                             
<img width="1187" height="574" alt="Screenshot 2026-03-31 at 7 12 35 PM" src="https://github.com/user-attachments/assets/2fffb880-a360-4649-805f-b5cecd0f7ca1" />
Throughput After - 
<img width="328" height="574" alt="Screenshot 2026-03-31 at 7 13 06 PM" src="https://github.com/user-attachments/assets/71fc3986-b157-403a-b795-dbbe2333575c" />

                                                                                                     