### PR TITLE
Add ad-hoc Semaphore task for creating tags on any branch

### DIFF
--- a/.semaphore/create-tag.yml
+++ b/.semaphore/create-tag.yml
@@ -1,0 +1,20 @@
+version: v1.0
+name: create-debezium-tag
+agent:
+  machine:
+    type: s1-prod-ubuntu24-04-amd64-1
+
+execution_time_limit:
+  hours: 1
+
+blocks:
+  - name: Create Tag
+    dependencies: []
+    task:
+      jobs:
+        - name: Create Tag
+          commands:
+            - checkout --use-cache
+            - git checkout $BRANCH_NAME
+            - ci-tools ci-update-version
+            - ci-tools ci-push-tag

--- a/service.yml
+++ b/service.yml
@@ -19,6 +19,14 @@ semaphore:
     - /v\d+\.\d+\.\d+\-hotfix\-x/
     - /v\d+\.\d+\.\d+\-orcl\-hotfix\-x/
     - /^gh-readonly-queue.*/
+  tasks:
+    - name: create-debezium-tag
+      branch: master
+      pipeline_file: .semaphore/create-tag.yml
+      parameters:
+        - name: BRANCH_NAME
+          required: true
+          description: 'Branch used to create a tag for CP-patched branches (for example 1.9.6.x,1.9.7.x,2.1.0.x). Not intended for v*-hotfix-x branches.'
 code_artifact:
   enable: true
   package_paths:


### PR DESCRIPTION
## Summary
- Adds a `create-debezium-tag` Semaphore UI task that accepts a `BRANCH_NAME` parameter
- Allows on-demand tag creation on any branch (e.g., `1.9.6.x`, `1.9.7.x`, `2.1.0.x`)
- Replaces auto-triggering Release block on `X.Y.Z.x` branches — tags are now created ad-hoc

## Changes
- `service.yml` — added `tasks` section with `create-debezium-tag` task
- `.semaphore/create-tag.yml` — new pipeline that checks out the specified branch and runs `ci-tools ci-update-version` + `ci-tools ci-push-tag`

## Usage
1. Go to Semaphore UI → debezium project → Schedulers
2. Select `create-debezium-tag`
3. Enter `BRANCH_NAME` (e.g., `1.9.7.x`)
4. Run

## Test plan
- [ ] Merge and verify task appears in Semaphore UI
- [ ] Run task with `BRANCH_NAME=1.9.7.x` and verify tag is created