### PR TITLE
Adds a null check to prevent NPE while adding quotes to table id

### DIFF
--- a/debezium-core/src/main/java/io/debezium/jdbc/JdbcConnection.java
+++ b/debezium-core/src/main/java/io/debezium/jdbc/JdbcConnection.java
@@ -1763,7 +1763,7 @@ public class JdbcConnection implements AutoCloseable {
      * Returns an SQL identifier representing the given database object name.
      */
     public String quoteIdentifier(String name) {
-        if (name.contains(closingQuoteCharacter)) {
+        if (name != null && name.contains(closingQuoteCharacter)) {
             name = name.replace(closingQuoteCharacter, closingQuoteCharacter + closingQuoteCharacter);
         }
 


### PR DESCRIPTION
The connector was earlier using null value as [null] but the new change did not add a null check and causing NPE for signal tables which are missing database names.

<img width="1776" height="247" alt="Screenshot 2026-04-02 at 11 14 13 AM" src="https://github.com/user-attachments/assets/cac8c2bd-ef0f-456b-8093-2c5f7f603604" />
