### PR TITLE
CC-39707: Upgrade postgresql driver to 42.7.2 for CVE fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
         <version.apicurio>2.1.5.Final</version.apicurio>
 
         <!-- Database drivers, should align with databases -->
-        <version.postgresql.driver>42.3.5</version.postgresql.driver>
+        <version.postgresql.driver>42.7.2</version.postgresql.driver>
         <version.mysql.driver>8.0.28</version.mysql.driver>
         <version.mysql.binlog>0.27.2</version.mysql.binlog>
         <version.mongo.driver>4.3.3</version.mongo.driver>


### PR DESCRIPTION
## Summary
- Upgrades `org.postgresql:postgresql` from `42.3.5` to `42.7.2` in debezium-connector-postgresql
- Fixes CVE-2022-41946, CVE-2022-31197, and CVE-2024-1597
- Jira: https://confluentinc.atlassian.net/browse/CC-39707

## Test Results (kafka-docker-playground)

**Test:** `debezium-postgres-source.sh` with `--connector-zip` using patched connector
**Result:** SUCCESS (53 seconds)

```
Connector version: 1.9.7
CP version: 8.1.1
Connector status: RUNNING
Records consumed: 21 from asgard.public.customers-raw
postgresql driver: 42.7.2.jar (upgraded from 42.3.5)
```

```
debezium-postgres-source       RUNNING  0: RUNNING[connect]
RESULT: SUCCESS for debezium-postgres-source.sh (took: 0min 53sec)
```

## Test plan
- [x] Build Postgres connector zip — verified `postgresql-42.7.2.jar` included
- [x] Run kafka-docker-playground `debezium-postgres-source.sh` — PASSED
- [x] Connector starts, reads 21 records, produces to Kafka topic with Avro