### PR TITLE
CC-39702: Upgrade mysql-connector-j to 8.2.0 for CVE fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
 
         <!-- Database drivers, should align with databases -->
         <version.postgresql.driver>42.6.0</version.postgresql.driver>
-        <version.mysql.driver>8.0.33</version.mysql.driver>
+        <version.mysql.driver>8.2.0</version.mysql.driver>
         <version.mysql.binlog>0.28.1</version.mysql.binlog>
         <version.mongo.driver>4.7.1</version.mongo.driver>
         <version.sqlserver.driver>10.2.1.jre8</version.sqlserver.driver>


### PR DESCRIPTION
## Summary
- Upgrades `com.mysql:mysql-connector-j` from `8.0.33` to `8.2.0` in debezium-connector-mysql
- Fixes CVE-2023-22102
- Jira: https://confluentinc.atlassian.net/browse/CC-39702

## Breaking Change Analysis

| Change in 8.2.0 | Impact on Debezium | Risk |
|---|---|---|
| DATETIME returns `LocalDateTime` via `getObject()` | Debezium uses `rs.getTimestamp()` for DATETIME, not `getObject()` — primary path unaffected. Fallback `getObject()` only used in error cases. | Low |
| `autoDeserialize` removed for BLOBs | Not used by Debezium | None |
| Connection pool autocommit behavior | Not relevant for Debezium's connection usage | None |
| Internal APIs (`CharsetMapping`, `NativeConstants`) | Still present in 8.2.0 — build compiles cleanly | None |

## Test Results (kafka-docker-playground)

**Test:** `debezium-mysql-source.sh` with `--connector-zip` using patched connector
**CP version:** 7.9.0
**Result:** SUCCESS (1min 3sec)

```
Connector version: 2.4.2
CP version: 7.9.0
Connector status: RUNNING
Records consumed: 2 from server1.mydb.team
mysql-connector-j driver: 8.2.0 (upgraded from 8.0.33)
```

```
debezium-mysql-source          RUNNING  0: RUNNING[connect]
RESULT: SUCCESS for debezium-mysql-source.sh (took: 1min 3sec)
```

### Connector Zip Used for Testing

**Contents:**
```
debezium-debezium-connector-mysql/
├── manifest.json
├── lib/
│   ├── debezium-connector-mysql-2.4.2.jar
│   ├── debezium-core-2.4.2.jar
│   ├── debezium-api-2.4.2.jar
│   ├── debezium-ddl-parser-2.4.2.jar
│   ├── debezium-storage-kafka-2.4.2.jar
│   ├── debezium-storage-file-2.4.2.jar
│   ├── mysql-connector-j-8.2.0.jar          ← upgraded from 8.0.33
│   ├── mysql-binlog-connector-java-0.28.1.jar
│   ├── antlr4-runtime-4.10.1.jar
│   └── zstd-jni-1.5.0-2.jar
├── etc/
└── doc/
```

## Test plan
- [x] Build compiles with no errors
- [x] Verified `mysql-connector-j-8.2.0.jar` in connector zip
- [x] KDP test `debezium-mysql-source.sh` — PASSED (CP 7.9.0)
- [ ] Run Semaphore CI tests (MySQL 8.0 / 8.4)