### PR TITLE
Remove dependency:analyze from Semaphore test commands

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -38,25 +38,25 @@ blocks:
         - name: Mysql 8.0
           commands:
             - mvn -Dcloud -Passembly -pl debezium-connector-mysql -am -U -Dmysql.server.image.source=mysql/mysql-server -Dversion.mysql.server=8.0.13 -Dmaven.wagon.http.retryHandler.count=10 --batch-mode --no-transfer-progress
-              clean verify install dependency:analyze validate
+              clean verify install validate
             - . cve-scan
             - . cache-maven store
         - name: Mysql 8.4
           commands:
             - mvn -Dcloud -Passembly -pl debezium-connector-mysql -am -U -Dmysql.server.image.source=container-registry.oracle.com/mysql/community-server -Dversion.mysql.server=8.4 -Dmaven.wagon.http.retryHandler.count=10 --batch-mode --no-transfer-progress
-              clean verify install dependency:analyze validate
+              clean verify install validate
             - . cve-scan
             - . cache-maven store
         - name: Postgres
           commands:
             - mvn -Dcloud -Passembly -pl debezium-connector-postgres -am -U -Dmaven.wagon.http.retryHandler.count=10 --batch-mode --no-transfer-progress
-              clean verify install dependency:analyze validate
+              clean verify install validate
             - . cve-scan
             - . cache-maven store
         - name: SqlServer
           commands:
             - mvn -Dcloud -Passembly -pl debezium-connector-sqlserver -am -U -Dmaven.wagon.http.retryHandler.count=10 --batch-mode --no-transfer-progress
-              clean verify install dependency:analyze validate
+              clean verify install validate
             - . cve-scan
             - . cache-maven store
       env_vars:


### PR DESCRIPTION
## Summary
- Removes `dependency:analyze` from Maven test commands in Semaphore CI
- Fixes build failure: `Unsupported class file major version 55` caused by `maven-dependency-plugin:3.1.1` not supporting Java 11 class files
- Failed job: https://semaphore.ci.confluent.io/jobs/484473ef-6d0a-42a6-a769-857dc1f03a28

## Test plan
- [ ] Verify Semaphore builds pass after merge