### PR TITLE
MINOR: Update err msg when resume token is missing

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorTask.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorTask.java
@@ -331,7 +331,7 @@ public final class MongoDbConnectorTask extends BaseSourceTask<MongoDbPartition,
                         return;
                     }
 
-                    String sourceInfo = offset.getSourceInfo() != null ? offset.getSourceInfo().toString() : "unknown offset";
+                    String sourceInfo = offset.getOffset() != null ? offset.getOffset().toString() : "unknown offset";
                     throw new DebeziumException("The connector is trying to read change stream starting at " + sourceInfo + ", but this is no longer "
                              + "available on the server. Reconfigure the connector to use a snapshot mode when needed.");
                 }


### PR DESCRIPTION
## The Error

```
org.apache.kafka.connect.errors.DataException: Invalid value: null used for required field: "collection", schema type: STRING
    at org.apache.kafka.connect.data.Struct.put(Struct.java:216)
    at io.debezium.connector.v2.mongodb.MongoDbSourceInfoStructMaker.struct(MongoDbSourceInfoStructMaker.java:40)
    at io.debezium.connector.v2.mongodb.MongoDbConnectorTask.validate(MongoDbConnectorTask.java:334)
    at io.debezium.connector.v2.mongodb.MongoDbConnectorTask.start(MongoDbConnectorTask.java:142)
```

## When This Happens

This error occurs during **task startup** when ALL of the following are true:

1. The connector is **resuming from a stored offset** (not a first-time start)
2. The stored offset's **resume token is no longer available** on the MongoDB server (e.g., the oplog rolled past it)
3. The connector's snapshot mode **does not allow re-snapshotting on data error** (`shouldSnapshotOnDataError()` returns false)

The connector tries to throw a helpful `DebeziumException` with the offset details, but crashes while building the error message instead.

## Fix

Use `getOffset()`, which returns the raw `Map<String, ?> containing {sec, ord, resume_token, ...}` — the actual fields needed for the error message. This avoids Struct serialization entirely and produces a more useful error message for debugging expired resume tokens.