### PR TITLE
Disable flaky tests to match v2.4.2-hotfix-x

### DIFF
--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/rest/DebeziumMySqlConnectorResourceIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/rest/DebeziumMySqlConnectorResourceIT.java
@@ -19,6 +19,7 @@ import org.junit.After;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import io.debezium.connector.mysql.Module;
@@ -29,6 +30,7 @@ import io.debezium.testing.testcontainers.ConnectorConfiguration;
 import io.debezium.testing.testcontainers.testhelper.RestExtensionTestInfrastructure;
 import io.restassured.http.ContentType;
 
+@Ignore
 public class DebeziumMySqlConnectorResourceIT {
 
     @BeforeClass

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/rest/DebeziumMySqlConnectorResourceNoDatabaseIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/rest/DebeziumMySqlConnectorResourceNoDatabaseIT.java
@@ -14,12 +14,14 @@ import org.junit.After;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import io.debezium.connector.mysql.Module;
 import io.debezium.connector.mysql.MySqlConnector;
 import io.debezium.testing.testcontainers.testhelper.RestExtensionTestInfrastructure;
 
+@Ignore
 public class DebeziumMySqlConnectorResourceNoDatabaseIT {
 
     @BeforeClass

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/rest/DebeziumPostgresConnectorResourceIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/rest/DebeziumPostgresConnectorResourceIT.java
@@ -18,6 +18,7 @@ import org.junit.After;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import io.debezium.connector.postgresql.Module;
@@ -27,6 +28,7 @@ import io.debezium.testing.testcontainers.ConnectorConfiguration;
 import io.debezium.testing.testcontainers.testhelper.RestExtensionTestInfrastructure;
 import io.restassured.http.ContentType;
 
+@Ignore
 public class DebeziumPostgresConnectorResourceIT {
 
     @BeforeClass

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/rest/DebeziumPostgresConnectorResourceNoDatabaseIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/rest/DebeziumPostgresConnectorResourceNoDatabaseIT.java
@@ -14,12 +14,14 @@ import org.junit.After;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import io.debezium.connector.postgresql.Module;
 import io.debezium.connector.postgresql.PostgresConnector;
 import io.debezium.testing.testcontainers.testhelper.RestExtensionTestInfrastructure;
 
+@Ignore
 public class DebeziumPostgresConnectorResourceNoDatabaseIT {
 
     @BeforeClass

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/transforms/timescaledb/TimescaleDbDatabaseTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/transforms/timescaledb/TimescaleDbDatabaseTest.java
@@ -11,6 +11,7 @@ import java.sql.SQLException;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -28,6 +29,7 @@ import io.debezium.embedded.AbstractConnectorTest;
 import io.debezium.testing.testcontainers.ImageNames;
 import io.debezium.util.Testing;
 
+@Ignore
 public class TimescaleDbDatabaseTest extends AbstractConnectorTest {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(TimescaleDbDatabaseTest.class);

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectorIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectorIT.java
@@ -2840,6 +2840,7 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
     }
 
     @Test
+    @Ignore
     public void shouldStopRetriableRestartsAtConfiguredMaximumDuringSnapshot() throws Exception {
         shouldStopRetriableRestartsAtConfiguredMaximum(() -> {
             connection.execute("ALTER DATABASE " + TestHelper.TEST_DATABASE_2 + " SET OFFLINE");
@@ -2848,6 +2849,7 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
     }
 
     @Test
+    @Ignore
     public void shouldStopRetriableRestartsAtConfiguredMaximumDuringStreaming() throws Exception {
         shouldStopRetriableRestartsAtConfiguredMaximum(() -> {
             TestHelper.waitForStreamingStarted();

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/rest/DebeziumSqlServerConnectorResourceIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/rest/DebeziumSqlServerConnectorResourceIT.java
@@ -20,6 +20,7 @@ import org.junit.After;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import io.debezium.connector.sqlserver.Module;
@@ -30,6 +31,7 @@ import io.debezium.testing.testcontainers.ConnectorConfiguration;
 import io.debezium.testing.testcontainers.testhelper.RestExtensionTestInfrastructure;
 import io.restassured.http.ContentType;
 
+@Ignore
 public class DebeziumSqlServerConnectorResourceIT {
 
     @BeforeClass

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/rest/DebeziumSqlServerConnectorResourceNoDatabaseIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/rest/DebeziumSqlServerConnectorResourceNoDatabaseIT.java
@@ -14,12 +14,14 @@ import org.junit.After;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import io.debezium.connector.sqlserver.Module;
 import io.debezium.connector.sqlserver.SqlServerConnector;
 import io.debezium.testing.testcontainers.testhelper.RestExtensionTestInfrastructure;
 
+@Ignore
 public class DebeziumSqlServerConnectorResourceNoDatabaseIT {
 
     @BeforeClass


### PR DESCRIPTION
## Summary
Adds `@Ignore` to flaky tests that fail in CI, matching what `v2.4.2-hotfix-x` already does. These tests fail due to testcontainers infrastructure issues unrelated to connector changes.

## Disabled tests

| File | Scope |
|---|---|
| `DebeziumMySqlConnectorResourceIT` | Class-level `@Ignore` |
| `DebeziumMySqlConnectorResourceNoDatabaseIT` | Class-level `@Ignore` |
| `DebeziumPostgresConnectorResourceIT` | Class-level `@Ignore` |
| `DebeziumPostgresConnectorResourceNoDatabaseIT` | Class-level `@Ignore` |
| `TimescaleDbDatabaseTest` | Class-level `@Ignore` |
| `DebeziumSqlServerConnectorResourceIT` | Class-level `@Ignore` |
| `DebeziumSqlServerConnectorResourceNoDatabaseIT` | Class-level `@Ignore` |
| `SqlServerConnectorIT` | Method-level `@Ignore` on `shouldStopRetriableRestartsAtConfiguredMaximumDuringSnapshot` and `shouldStopRetriableRestartsAtConfiguredMaximumDuringStreaming` |

## Test plan
- [ ] Verify Semaphore builds pass for all connector jobs after merge