### PR TITLE
Parameterize MySQL Docker image source to match v2.4.2-hotfix-x

### DIFF
--- a/debezium-connector-mysql/pom.xml
+++ b/debezium-connector-mysql/pom.xml
@@ -220,7 +220,7 @@
                                 </wait>
                             </run>
                             <build>
-                                <from>mysql/mysql-server:${version.mysql.server}</from>
+                                <from>${mysql.server.image.source}:${version.mysql.server}</from>
                                 <runCmds>
                                     <run>${docker.initimage}</run>
                                 </runCmds>
@@ -279,7 +279,7 @@
                                 </wait>
                             </run>
                             <build>
-                                <from>mysql/mysql-server:${version.mysql.server}</from>
+                                <from>${mysql.server.image.source}:${version.mysql.server}</from>
                                 <runCmds>
                                     <run>${docker.initimage}</run>
                                 </runCmds>
@@ -337,7 +337,7 @@
                                 </wait>
                             </run>
                             <build>
-                                <from>mysql/mysql-server:${version.mysql.server}</from>
+                                <from>${mysql.server.image.source}:${version.mysql.server}</from>
                                 <runCmds>
                                     <run>${docker.initimage}</run>
                                 </runCmds>
@@ -395,7 +395,7 @@
                                 </wait>
                             </run>
                             <build>
-                                <from>mysql/mysql-server:${version.mysql.server}</from>
+                                <from>${mysql.server.image.source}:${version.mysql.server}</from>
                                 <runCmds>
                                     <run>${docker.initimage}</run>
                                 </runCmds>

--- a/pom.xml
+++ b/pom.xml
@@ -148,6 +148,9 @@
 
         <!-- RocketMQ version for RocketMQ storage and Server sink -->
         <version.rocketmq>4.9.4</version.rocketmq>
+
+         <!-- MySQL server image name -->
+         <mysql.server.image.source>container-registry.oracle.com/mysql/community-server</mysql.server.image.source>
     </properties>
 
     <modules>


### PR DESCRIPTION
## Summary
- Replaces hardcoded `mysql/mysql-server` with `${mysql.server.image.source}` in `debezium-connector-mysql/pom.xml` docker-maven-plugin config
- Adds `mysql.server.image.source` property with default `container-registry.oracle.com/mysql/community-server` in root `pom.xml`
- Matches what `v2.4.2-hotfix-x` already does

## Problem
The Semaphore MySQL 8.4 job passes `-Dmysql.server.image.source=container-registry.oracle.com/mysql/community-server` but the pom.xml had `mysql/mysql-server` hardcoded in `<from>` tags, ignoring the property. Image `mysql/mysql-server:8.4` doesn't exist on Docker Hub.

## Test plan
- [ ] Verify MySQL 8.0 job passes (uses `-Dmysql.server.image.source=mysql/mysql-server` override)
- [ ] Verify MySQL 8.4 job passes (uses Oracle registry)