### PR TITLE
CC-39706-Bump Protobuf Version for CVE Fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,9 +142,9 @@
         <version.cassandra4>4.0.2</version.cassandra4>
 
         <!-- Required in protoc plug-in config, too; can't be in BOM therefore -->
-        <version.com.google.protobuf>3.25.2</version.com.google.protobuf>
+        <version.com.google.protobuf>3.25.5</version.com.google.protobuf>
         <!-- The version is separate so different protoc can be used in product -->
-        <version.com.google.protobuf.protoc>3.25.2</version.com.google.protobuf.protoc>
+        <version.com.google.protobuf.protoc>3.25.5</version.com.google.protobuf.protoc>
 
         <!-- Infinispan version for Oracle and Debezium Server sink -->
         <version.infinispan>14.0.20.Final</version.infinispan>


### PR DESCRIPTION
# Problem    
[CC-39706](https://confluentinc.atlassian.net/browse/CC-39706) - Pin and bump protobuf-java version to 3.25.5 to fix CVE in Postgres Connector on 2.5.4 CP connector version
                                                                                                                                                                                              
# Solution                                                                                                                                                                                             
Bumped the protobuf-java version to 3.25.5 in Postgres Source Connector.


## Verification

  Confirmed resolution using `mvn dependency:tree`:
<img width="1712" height="856" alt="Screenshot 2026-04-09 at 5 31 24 PM" src="https://github.com/user-attachments/assets/e4a5b271-991f-4c1e-87f1-101990169582" />


[outfile3postgres.txt](https://github.com/user-attachments/files/26602189/outfile3postgres.txt)


## Testing
- Performed local CP tests on version 8.1.0


**Confluent Platform v8.1.0**
<details>
<summary>Logs</summary>

**Connector Kafka Version**
<img width="1707" height="925" alt="Screenshot 2026-04-09 at 5 45 45 PM" src="https://github.com/user-attachments/assets/cfd53f25-1c91-427f-913b-63692e1291ca" />



**Snapshot Completion and Streaming Phase**
<img width="1707" height="925" alt="Screenshot 2026-04-07 at 12 25 34 PM" src="https://github.com/user-attachments/assets/5b03d77e-6b28-4c13-9c43-c4f807c61578" />


<img width="1707" height="925" alt="Screenshot 2026-04-09 at 5 46 15 PM" src="https://github.com/user-attachments/assets/401d033d-a81b-4bb9-800b-50a80b504aba" />

<img width="1707" height="925" alt="Screenshot 2026-04-09 at 5 46 22 PM" src="https://github.com/user-attachments/assets/e4bc4f7e-c268-4229-8db2-e2a1e0de4b91" />




</details> 




[CC-39706]: https://confluentinc.atlassian.net/browse/CC-39706?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ