### PR TITLE
CC-39686: Simplify version to 3.2.6 and add Semaphore CI configuration

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*	@confluentinc/Connect

--- a/.semaphore/project.yml
+++ b/.semaphore/project.yml
@@ -1,0 +1,45 @@
+# This file is managed by ServiceBot plugin - Semaphore. The content in this file is created using a common
+# template and configurations in service.yml.
+# Modifications in this file will be overwritten by generated content in the nightly run.
+# For more information, please refer to the page:
+# https://confluentinc.atlassian.net/wiki/spaces/Foundations/pages/2871296194/Add+SemaphoreCI
+apiVersion: v1alpha
+kind: Project
+metadata:
+  name: debezium
+  description: ""
+spec:
+  visibility: private
+  repository:
+    url: git@github.com:confluentinc/debezium.git
+    run_on:
+    - branches
+    - pull_requests
+    pipeline_file: .semaphore/semaphore.yml
+    integration_type: github_app
+    status:
+      pipeline_files:
+      - path: .semaphore/semaphore.yml
+        level: pipeline
+    whitelist:
+      branches:
+      - master
+      - main
+      - /^\d+\.\d+\.x$/
+      - /^\d+\.\d+\.\d+\.x$/
+      - /v\d+\.\d+\.\d+\-hotfix\-x/
+      - /^gh-readonly-queue.*/
+  custom_permissions: true
+  debug_permissions:
+  - empty
+  - default_branch
+  - non_default_branch
+  - pull_request
+  - forked_pull_request
+  - tag
+  attach_permissions:
+  - default_branch
+  - non_default_branch
+  - pull_request
+  - forked_pull_request
+  - tag

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -24,7 +24,7 @@ global_job_config:
   prologue:
     commands:
       - checkout
-      - sem-version java 11
+      - sem-version java 21
       - . cache-maven restore
 
 blocks:
@@ -83,5 +83,5 @@ after_pipeline:
       - name: SonarQube
         commands:
           - checkout
-          - sem-version java 11
+          - sem-version java 21
           - emit-sonarqube-data -a test-results

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,0 +1,87 @@
+# This file is managed by ServiceBot plugin - Semaphore. The content in this file is created using a common
+# template and configurations in service.yml.
+# Any modifications made to ths file will be overwritten by the generated content in nightly runs.
+# For more information, please refer to the page:
+# https://confluentinc.atlassian.net/wiki/spaces/Foundations/pages/2871296194/Add+SemaphoreCI
+version: v1.0
+name: build-test-release
+agent:
+  machine:
+    type: s1-prod-ubuntu24-04-amd64-1
+
+fail_fast:
+  cancel:
+    when: "true"
+
+execution_time_limit:
+  hours: 4
+
+queue:
+  - when: "branch != 'master' and branch !~ '[0-9]+\\.[0-9]+\\.x' and branch !~ '[0-9]+\\.[0-9]+\\.[0-9]+\\.x' and branch !~ 'v[0-9]+\\.[0-9]+\\.[0-9]+\\-hotfix\\-x'"
+    processing: parallel
+
+global_job_config:
+  prologue:
+    commands:
+      - checkout
+      - sem-version java 11
+      - . cache-maven restore
+
+blocks:
+  - name: Test
+    dependencies: []
+    run:
+      # don't run the tests on non-functional changes...
+      when: "change_in('/', {exclude: ['/.deployed-versions/', '.github/']})"
+    task:
+      jobs:
+        - name: Mysql 8.0
+          commands:
+            - mvn -Dcloud -Passembly -pl debezium-connector-mysql -am -U -Dmysql.server.image.source=mysql/mysql-server -Dversion.mysql.server=8.0.13 -Dformat.skip=true -Dmaven.wagon.http.retryHandler.count=10 --batch-mode --no-transfer-progress
+              clean verify install validate
+            - . cve-scan
+            - . cache-maven store
+        - name: Mysql 8.4
+          commands:
+            - mvn -Dcloud -Passembly -pl debezium-connector-mysql -am -U -Dmysql.server.image.source=container-registry.oracle.com/mysql/community-server -Dversion.mysql.server=8.4 -Dformat.skip=true -Dmaven.wagon.http.retryHandler.count=10 --batch-mode --no-transfer-progress
+              clean verify install validate
+            - . cve-scan
+            - . cache-maven store
+        - name: Postgres
+          commands:
+            - mvn -Dcloud -Passembly -pl debezium-connector-postgres -am -U -Dformat.skip=true -Dmaven.wagon.http.retryHandler.count=10 --batch-mode --no-transfer-progress
+              clean verify install validate
+            - . cve-scan
+            - . cache-maven store
+        - name: SqlServer
+          commands:
+            - mvn -Dcloud -Passembly -pl debezium-connector-sqlserver -am -U -Dformat.skip=true -Dmaven.wagon.http.retryHandler.count=10 --batch-mode --no-transfer-progress
+              clean verify install validate
+            - . cve-scan
+            - . cache-maven store
+      env_vars:
+        - name: SEMAPHORE_AGENT_UPLOAD_JOB_LOGS
+          value: when-trimmed
+      epilogue:
+        always:
+          commands:
+            - . publish-test-results
+            - artifact push workflow target/test-results
+
+after_pipeline:
+  task:
+    agent:
+      machine:
+        type: s1-prod-ubuntu24-04-arm64-0
+    jobs:
+      - name: Metrics
+        commands:
+          - emit-ci-metrics -p -a test-results
+      - name: Publish Test Results
+        commands:
+          - test-results gen-pipeline-report
+      - name: SonarQube
+        commands:
+          - checkout
+          - sem-version java 11
+          - emit-sonarqube-data -a test-results

--- a/debezium-ai/debezium-ai-embeddings-hugging-face/pom.xml
+++ b/debezium-ai/debezium-ai-embeddings-hugging-face/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-ai</artifactId>
-        <version>3.2.6.Final</version>
+        <version>3.2.6</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-ai/debezium-ai-embeddings-minilm/pom.xml
+++ b/debezium-ai/debezium-ai-embeddings-minilm/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-ai</artifactId>
-        <version>3.2.6.Final</version>
+        <version>3.2.6</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-ai/debezium-ai-embeddings-ollama/pom.xml
+++ b/debezium-ai/debezium-ai-embeddings-ollama/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-ai</artifactId>
-        <version>3.2.6.Final</version>
+        <version>3.2.6</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-ai/debezium-ai-embeddings-voyage-ai/pom.xml
+++ b/debezium-ai/debezium-ai-embeddings-voyage-ai/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-ai</artifactId>
-        <version>3.2.6.Final</version>
+        <version>3.2.6</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-ai/debezium-ai-embeddings/pom.xml
+++ b/debezium-ai/debezium-ai-embeddings/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-ai</artifactId>
-        <version>3.2.6.Final</version>
+        <version>3.2.6</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-ai/pom.xml
+++ b/debezium-ai/pom.xml
@@ -3,12 +3,12 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>3.2.6.Final</version>
+        <version>3.2.6</version>
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>debezium-ai</artifactId>
-    <version>3.2.6.Final</version>
+    <version>3.2.6</version>
     <name>Debezium AI</name>
     <packaging>pom</packaging>
 

--- a/debezium-api/pom.xml
+++ b/debezium-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>3.2.6.Final</version>
+        <version>3.2.6</version>
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-assembly-descriptors/pom.xml
+++ b/debezium-assembly-descriptors/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>3.2.6.Final</version>
+        <version>3.2.6</version>
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-bom/pom.xml
+++ b/debezium-bom/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-build-parent</artifactId>
-        <version>3.2.6.Final</version>
+        <version>3.2.6</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-common/pom.xml
+++ b/debezium-common/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>3.2.6.Final</version>
+        <version>3.2.6</version>
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
 

--- a/debezium-connector-binlog/pom.xml
+++ b/debezium-connector-binlog/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>3.2.6.Final</version>
+        <version>3.2.6</version>
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-connector-jdbc/pom.xml
+++ b/debezium-connector-jdbc/pom.xml
@@ -4,13 +4,13 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>3.2.6.Final</version>
+        <version>3.2.6</version>
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>debezium-connector-jdbc</artifactId>
-    <version>3.2.6.Final</version>
+    <version>3.2.6</version>
     <name>Debezium JDBC Sink Connector</name>
     <packaging>jar</packaging>
 

--- a/debezium-connector-mariadb/pom.xml
+++ b/debezium-connector-mariadb/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>3.2.6.Final</version>
+        <version>3.2.6</version>
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-connector-mongodb/pom.xml
+++ b/debezium-connector-mongodb/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>3.2.6.Final</version>
+        <version>3.2.6</version>
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-connector-mysql/pom.xml
+++ b/debezium-connector-mysql/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>3.2.6.Final</version>
+        <version>3.2.6</version>
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-connector-oracle/pom.xml
+++ b/debezium-connector-oracle/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>3.2.6.Final</version>
+        <version>3.2.6</version>
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-connector-postgres/pom.xml
+++ b/debezium-connector-postgres/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>3.2.6.Final</version>
+        <version>3.2.6</version>
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-connector-sqlserver/pom.xml
+++ b/debezium-connector-sqlserver/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>3.2.6.Final</version>
+        <version>3.2.6</version>
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-core/pom.xml
+++ b/debezium-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>3.2.6.Final</version>
+        <version>3.2.6</version>
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
 

--- a/debezium-ddl-parser/pom.xml
+++ b/debezium-ddl-parser/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>3.2.6.Final</version>
+        <version>3.2.6</version>
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-embedded/pom.xml
+++ b/debezium-embedded/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>3.2.6.Final</version>
+        <version>3.2.6</version>
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-interceptor/pom.xml
+++ b/debezium-interceptor/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>3.2.6.Final</version>
+        <version>3.2.6</version>
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-microbenchmark-engine/pom.xml
+++ b/debezium-microbenchmark-engine/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>3.2.6.Final</version>
+        <version>3.2.6</version>
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-microbenchmark-oracle/pom.xml
+++ b/debezium-microbenchmark-oracle/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>3.2.6.Final</version>
+        <version>3.2.6</version>
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-microbenchmark/pom.xml
+++ b/debezium-microbenchmark/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>3.2.6.Final</version>
+        <version>3.2.6</version>
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-openlineage/debezium-openlineage-api/pom.xml
+++ b/debezium-openlineage/debezium-openlineage-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-openlineage</artifactId>
-        <version>3.2.6.Final</version>
+        <version>3.2.6</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/debezium-openlineage/debezium-openlineage-core/pom.xml
+++ b/debezium-openlineage/debezium-openlineage-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-openlineage</artifactId>
-        <version>3.2.6.Final</version>
+        <version>3.2.6</version>
     </parent>
 
     <artifactId>debezium-openlineage-core</artifactId>

--- a/debezium-openlineage/pom.xml
+++ b/debezium-openlineage/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>3.2.6.Final</version>
+        <version>3.2.6</version>
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-parent/pom.xml
+++ b/debezium-parent/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.debezium</groupId>
     <artifactId>debezium-build-parent</artifactId>
-    <version>3.2.6.Final</version>
+    <version>3.2.6</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/debezium-quarkus-outbox-common/deployment/pom.xml
+++ b/debezium-quarkus-outbox-common/deployment/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-quarkus-outbox-common-parent</artifactId>
-        <version>3.2.6.Final</version>
+        <version>3.2.6</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/debezium-quarkus-outbox-common/pom.xml
+++ b/debezium-quarkus-outbox-common/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>3.2.6.Final</version>
+        <version>3.2.6</version>
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
 

--- a/debezium-quarkus-outbox-common/runtime/pom.xml
+++ b/debezium-quarkus-outbox-common/runtime/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-quarkus-outbox-common-parent</artifactId>
-        <version>3.2.6.Final</version>
+        <version>3.2.6</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/debezium-quarkus-outbox-reactive/deployment/pom.xml
+++ b/debezium-quarkus-outbox-reactive/deployment/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-quarkus-outbox-reactive-parent</artifactId>
-        <version>3.2.6.Final</version>
+        <version>3.2.6</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/debezium-quarkus-outbox-reactive/integration-tests/pom.xml
+++ b/debezium-quarkus-outbox-reactive/integration-tests/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-quarkus-outbox-reactive-parent</artifactId>
-        <version>3.2.6.Final</version>
+        <version>3.2.6</version>
 	<relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/debezium-quarkus-outbox-reactive/pom.xml
+++ b/debezium-quarkus-outbox-reactive/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>3.2.6.Final</version>
+        <version>3.2.6</version>
 	<relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
 

--- a/debezium-quarkus-outbox-reactive/runtime/pom.xml
+++ b/debezium-quarkus-outbox-reactive/runtime/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-quarkus-outbox-reactive-parent</artifactId>
-        <version>3.2.6.Final</version>
+        <version>3.2.6</version>
 	<relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/debezium-quarkus-outbox/deployment/pom.xml
+++ b/debezium-quarkus-outbox/deployment/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-quarkus-outbox-parent</artifactId>
-        <version>3.2.6.Final</version>
+        <version>3.2.6</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/debezium-quarkus-outbox/integration-tests/pom.xml
+++ b/debezium-quarkus-outbox/integration-tests/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-quarkus-outbox-parent</artifactId>
-        <version>3.2.6.Final</version>
+        <version>3.2.6</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/debezium-quarkus-outbox/pom.xml
+++ b/debezium-quarkus-outbox/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>3.2.6.Final</version>
+        <version>3.2.6</version>
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
 

--- a/debezium-quarkus-outbox/runtime/pom.xml
+++ b/debezium-quarkus-outbox/runtime/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-quarkus-outbox-parent</artifactId>
-        <version>3.2.6.Final</version>
+        <version>3.2.6</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/debezium-schema-generator/pom.xml
+++ b/debezium-schema-generator/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.debezium</groupId>
     <artifactId>debezium-parent</artifactId>
-    <version>3.2.6.Final</version>
+    <version>3.2.6</version>
     <relativePath>../debezium-parent/pom.xml</relativePath>
   </parent>
 

--- a/debezium-scripting/debezium-scripting-languages/pom.xml
+++ b/debezium-scripting/debezium-scripting-languages/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-scripting-parent</artifactId>
-        <version>3.2.6.Final</version>
+        <version>3.2.6</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-scripting/debezium-scripting/pom.xml
+++ b/debezium-scripting/debezium-scripting/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-scripting-parent</artifactId>
-        <version>3.2.6.Final</version>
+        <version>3.2.6</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-scripting/pom.xml
+++ b/debezium-scripting/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>3.2.6.Final</version>
+        <version>3.2.6</version>
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-sink/pom.xml
+++ b/debezium-sink/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>3.2.6.Final</version>
+        <version>3.2.6</version>
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
 

--- a/debezium-storage/debezium-storage-azure-blob/pom.xml
+++ b/debezium-storage/debezium-storage-azure-blob/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-storage</artifactId>
-        <version>3.2.6.Final</version>
+        <version>3.2.6</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-storage/debezium-storage-configmap/pom.xml
+++ b/debezium-storage/debezium-storage-configmap/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-storage</artifactId>
-        <version>3.2.6.Final</version>
+        <version>3.2.6</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-storage/debezium-storage-file/pom.xml
+++ b/debezium-storage/debezium-storage-file/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-storage</artifactId>
-        <version>3.2.6.Final</version>
+        <version>3.2.6</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-storage/debezium-storage-jdbc/pom.xml
+++ b/debezium-storage/debezium-storage-jdbc/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-storage</artifactId>
-        <version>3.2.6.Final</version>
+        <version>3.2.6</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-storage/debezium-storage-kafka/pom.xml
+++ b/debezium-storage/debezium-storage-kafka/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-storage</artifactId>
-        <version>3.2.6.Final</version>
+        <version>3.2.6</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-storage/debezium-storage-redis/pom.xml
+++ b/debezium-storage/debezium-storage-redis/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-storage</artifactId>
-        <version>3.2.6.Final</version>
+        <version>3.2.6</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-storage/debezium-storage-rocketmq/pom.xml
+++ b/debezium-storage/debezium-storage-rocketmq/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-storage</artifactId>
-        <version>3.2.6.Final</version>
+        <version>3.2.6</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/debezium-storage/debezium-storage-s3/pom.xml
+++ b/debezium-storage/debezium-storage-s3/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-storage</artifactId>
-        <version>3.2.6.Final</version>
+        <version>3.2.6</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-storage/debezium-storage-tests/pom.xml
+++ b/debezium-storage/debezium-storage-tests/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-storage</artifactId>
-        <version>3.2.6.Final</version>
+        <version>3.2.6</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-storage/pom.xml
+++ b/debezium-storage/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>3.2.6.Final</version>
+        <version>3.2.6</version>
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-testing/debezium-testing-system/pom.xml
+++ b/debezium-testing/debezium-testing-system/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.debezium</groupId>
     <artifactId>debezium-testing</artifactId>
-    <version>3.2.6.Final</version>
+    <version>3.2.6</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -143,7 +143,7 @@
     <database.oracle.pdbname>ORCLPDB1</database.oracle.pdbname>
 
     <!--Debezium connector versions-->
-    <version.debezium.connector>3.2.6.Final</version.debezium.connector>
+    <version.debezium.connector>3.2.6</version.debezium.connector>
 
     <!-- Artifact repository for KC build -->
     <as.url>http://debezium-artifact-server.${ocp.project.debezium}.svc.cluster.local:8080</as.url>

--- a/debezium-testing/debezium-testing-testcontainers/pom.xml
+++ b/debezium-testing/debezium-testing-testcontainers/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>io.debezium</groupId>
     <artifactId>debezium-testing</artifactId>
-    <version>3.2.6.Final</version>
+    <version>3.2.6</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/debezium-testing/pom.xml
+++ b/debezium-testing/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>io.debezium</groupId>
     <artifactId>debezium-parent</artifactId>
-    <version>3.2.6.Final</version>
+    <version>3.2.6</version>
     <relativePath>../debezium-parent/pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>io.debezium</groupId>
     <artifactId>debezium-build-parent</artifactId>
-    <version>3.2.6.Final</version>
+    <version>3.2.6</version>
     <name>Debezium Build Aggregator</name>
     <description>Debezium is an open source change data capture platform</description>
     <packaging>pom</packaging>
@@ -20,7 +20,7 @@
         <connection>scm:git:git@github.com:debezium/debezium.git</connection>
         <developerConnection>scm:git:git@github.com:debezium/debezium.git</developerConnection>
         <url>https://github.com/debezium/debezium</url>
-        <tag>v3.2.6.Final</tag>
+        <tag>v3.2.6</tag>
     </scm>
 
     <issueManagement>

--- a/quarkus-debezium-parent/pom.xml
+++ b/quarkus-debezium-parent/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>3.2.6.Final</version>
+        <version>3.2.6</version>
         <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
 

--- a/quarkus-debezium-parent/quarkus-debezium-engine-parent/deployment/pom.xml
+++ b/quarkus-debezium-parent/quarkus-debezium-engine-parent/deployment/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.debezium.quarkus</groupId>
         <artifactId>quarkus-debezium-engine-parent</artifactId>
-        <version>3.2.6.Final</version>
+        <version>3.2.6</version>
     </parent>
 
     <artifactId>quarkus-debezium-engine-deployment</artifactId>

--- a/quarkus-debezium-parent/quarkus-debezium-engine-parent/pom.xml
+++ b/quarkus-debezium-parent/quarkus-debezium-engine-parent/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.debezium.quarkus</groupId>
         <artifactId>quarkus-debezium-parent</artifactId>
-        <version>3.2.6.Final</version>
+        <version>3.2.6</version>
     </parent>
 
     <artifactId>quarkus-debezium-engine-parent</artifactId>

--- a/quarkus-debezium-parent/quarkus-debezium-engine-parent/runtime/pom.xml
+++ b/quarkus-debezium-parent/quarkus-debezium-engine-parent/runtime/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.debezium.quarkus</groupId>
         <artifactId>quarkus-debezium-engine-parent</artifactId>
-        <version>3.2.6.Final</version>
+        <version>3.2.6</version>
     </parent>
 
     <artifactId>quarkus-debezium-engine</artifactId>

--- a/quarkus-debezium-parent/quarkus-debezium-engine-spi-parent/deployment/pom.xml
+++ b/quarkus-debezium-parent/quarkus-debezium-engine-spi-parent/deployment/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>io.debezium.quarkus</groupId>
         <artifactId>quarkus-debezium-engine-spi-parent</artifactId>
-        <version>3.2.6.Final</version>
+        <version>3.2.6</version>
     </parent>
 
     <artifactId>quarkus-debezium-engine-deployment-spi</artifactId>

--- a/quarkus-debezium-parent/quarkus-debezium-engine-spi-parent/pom.xml
+++ b/quarkus-debezium-parent/quarkus-debezium-engine-spi-parent/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>io.debezium.quarkus</groupId>
         <artifactId>quarkus-debezium-parent</artifactId>
-        <version>3.2.6.Final</version>
+        <version>3.2.6</version>
     </parent>
 
     <name>Quarkus Debezium :: Extension :: SPI :: Build Aggregator</name>

--- a/quarkus-debezium-parent/quarkus-debezium-engine-spi-parent/runtime/pom.xml
+++ b/quarkus-debezium-parent/quarkus-debezium-engine-spi-parent/runtime/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>io.debezium.quarkus</groupId>
         <artifactId>quarkus-debezium-engine-spi-parent</artifactId>
-        <version>3.2.6.Final</version>
+        <version>3.2.6</version>
     </parent>
 
     <artifactId>quarkus-debezium-engine-spi</artifactId>

--- a/quarkus-debezium-parent/quarkus-debezium-postgres-parent/deployment/pom.xml
+++ b/quarkus-debezium-parent/quarkus-debezium-postgres-parent/deployment/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.debezium.quarkus</groupId>
         <artifactId>quarkus-debezium-postgres-parent</artifactId>
-        <version>3.2.6.Final</version>
+        <version>3.2.6</version>
     </parent>
 
     <artifactId>quarkus-debezium-postgres-deployment</artifactId>

--- a/quarkus-debezium-parent/quarkus-debezium-postgres-parent/integration-test/pom.xml
+++ b/quarkus-debezium-parent/quarkus-debezium-postgres-parent/integration-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.debezium.quarkus</groupId>
         <artifactId>quarkus-debezium-postgres-parent</artifactId>
-        <version>3.2.6.Final</version>
+        <version>3.2.6</version>
     </parent>
 
     <artifactId>quarkus-debezium-postgres-integration-test</artifactId>

--- a/quarkus-debezium-parent/quarkus-debezium-postgres-parent/pom.xml
+++ b/quarkus-debezium-parent/quarkus-debezium-postgres-parent/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.debezium.quarkus</groupId>
         <artifactId>quarkus-debezium-parent</artifactId>
-        <version>3.2.6.Final</version>
+        <version>3.2.6</version>
     </parent>
 
     <name>Quarkus Debezium :: Extension :: Postgres :: Build Aggregator</name>

--- a/quarkus-debezium-parent/quarkus-debezium-postgres-parent/runtime/pom.xml
+++ b/quarkus-debezium-parent/quarkus-debezium-postgres-parent/runtime/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.debezium.quarkus</groupId>
         <artifactId>quarkus-debezium-postgres-parent</artifactId>
-        <version>3.2.6.Final</version>
+        <version>3.2.6</version>
     </parent>
 
     <artifactId>quarkus-debezium-postgres</artifactId>

--- a/service.yml
+++ b/service.yml
@@ -1,6 +1,6 @@
 name: debezium
 lang: java
-lang_version: "11"
+lang_version: "21"
 git:
   enable: true
 codeowners:

--- a/service.yml
+++ b/service.yml
@@ -1,0 +1,20 @@
+name: debezium
+lang: java
+lang_version: "11"
+git:
+  enable: true
+codeowners:
+  enable: true
+semaphore:
+  enable: true
+  pipeline_type: cp
+  cve_scan: true
+  extra_build_args: "-Dcloud -Passembly -pl debezium-connector-mysql,debezium-connector-postgres,debezium-connector-sqlserver -am"
+  extra_deploy_args: "-Dcloud -Passembly -pl debezium-connector-mysql,debezium-connector-postgres,debezium-connector-sqlserver -am"
+  branches:
+    - master
+    - main
+    - /^\d+\.\d+\.x$/
+    - /^\d+\.\d+\.\d+\.x$/
+    - /v\d+\.\d+\.\d+\-hotfix\-x/
+    - /^gh-readonly-queue.*/

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,9 @@
+### service-bot sonarqube plugin managed file
+sonar.coverage.exclusions=**/test/**/*,**/tests/**/*,**/mock/**/*,**/mocks/**/*,**/*mock*,**/*test*
+sonar.coverage.jacoco.xmlReportPaths=**/jacoco.xml
+sonar.cpd.exclusions=**/test/**/*,**/tests/**/*,**/mock/**/*,**/mocks/**/*,**/*mock*,**/*test*
+sonar.exclusions=**/*.pb.*,**/mk-include/**/*
+sonar.java.binaries=.
+sonar.language=java
+sonar.projectKey=debezium
+sonar.sources=.

--- a/support/checkstyle/pom.xml
+++ b/support/checkstyle/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-build-parent</artifactId>
-        <version>3.2.6.Final</version>
+        <version>3.2.6</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/support/ide-configs/pom.xml
+++ b/support/ide-configs/pom.xml
@@ -3,7 +3,7 @@
    <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-build-parent</artifactId>
-        <version>3.2.6.Final</version>
+        <version>3.2.6</version>
         <relativePath>../../pom.xml</relativePath>
    </parent>
 

--- a/support/revapi/pom.xml
+++ b/support/revapi/pom.xml
@@ -3,7 +3,7 @@
    <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-build-parent</artifactId>
-        <version>3.2.6.Final</version>
+        <version>3.2.6</version>
         <relativePath>../../pom.xml</relativePath>
    </parent>
 


### PR DESCRIPTION
## Summary
- Replace `3.2.6.Final` with `3.2.6` across all 73 pom.xml files
- Add Semaphore CI configuration files (`.semaphore/project.yml`, `.semaphore/semaphore.yml`, `service.yml`, `.github/CODEOWNERS`, `sonar-project.properties`)

## Context
Setting up the `3.2.6.x` branch for CP release following the [Debezium CVE Patching runbook](https://confluentinc.atlassian.net/wiki/spaces/~7120208d01a37ad2b143418c15c466af23595e/pages/5379359063).

JIRA: CC-39686