### PR TITLE
Redact snapshot select statement in logs

### DIFF
--- a/debezium-core/src/main/java/io/debezium/relational/RelationalSnapshotChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/relational/RelationalSnapshotChangeEventSource.java
@@ -69,6 +69,8 @@ import io.debezium.util.Strings;
 import io.debezium.util.Threads;
 import io.debezium.util.Threads.Timer;
 
+import static io.debezium.util.Loggings.maybeRedactSensitiveData;
+
 /**
  * Base class for {@link SnapshotChangeEventSource} for relational databases with or without a schema history.
  * <p>
@@ -494,7 +496,7 @@ public abstract class RelationalSnapshotChangeEventSource<P extends Partition, O
         for (TableId tableId : snapshotContext.capturedTables) {
             final Optional<String> selectStatement = determineSnapshotSelect(snapshotContext, tableId, snapshotSelectOverridesByTable);
             if (selectStatement.isPresent()) {
-                LOGGER.info("For table '{}' using select statement: '{}'", tableId, selectStatement.get());
+                LOGGER.info("For table '{}' using select statement: '{}'", tableId, maybeRedactSensitiveData(selectStatement.get()));
                 queryTables.put(tableId, selectStatement.get());
 
                 final OptionalLong rowCount = rowCountForTable(tableId);


### PR DESCRIPTION
## Summary
- Cherry-pick of 47dd230802 from main
- Redacts the select statement logged during snapshotting to avoid exposing sensitive SQL in logs

## Test plan
- [ ] Verify snapshot select statement is redacted in connector logs
- [ ] Verify existing snapshot functionality is not affected