### PR TITLE
CC-39686: Fix CI for 3.2.6.x branch

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -37,26 +37,26 @@ blocks:
       jobs:
         - name: Mysql 8.0
           commands:
-            - mvn -Dcloud -Passembly -pl debezium-connector-mysql -am -U -Dmysql.server.image.source=mysql/mysql-server -Dversion.mysql.server=8.0.13 -Dformat.skip=true -Dmaven.wagon.http.retryHandler.count=10 --batch-mode --no-transfer-progress
-              clean verify install validate
+            - mvn -Dcloud -Passembly -pl debezium-connector-mysql -am -U -Dmysql.server.image.source=mysql/mysql-server -Dversion.mysql.server=8.0.13 -Dformat.skip=true -Drevapi.skip=true -Dmaven.wagon.http.retryHandler.count=10 --batch-mode --no-transfer-progress
+              verify
             - . cve-scan
             - . cache-maven store
         - name: Mysql 8.4
           commands:
-            - mvn -Dcloud -Passembly -pl debezium-connector-mysql -am -U -Dmysql.server.image.source=container-registry.oracle.com/mysql/community-server -Dversion.mysql.server=8.4 -Dformat.skip=true -Dmaven.wagon.http.retryHandler.count=10 --batch-mode --no-transfer-progress
-              clean verify install validate
+            - mvn -Dcloud -Passembly -pl debezium-connector-mysql -am -U -Dmysql.server.image.source=container-registry.oracle.com/mysql/community-server -Dversion.mysql.server=8.4 -Dformat.skip=true -Drevapi.skip=true -Dmaven.wagon.http.retryHandler.count=10 --batch-mode --no-transfer-progress
+              verify
             - . cve-scan
             - . cache-maven store
         - name: Postgres
           commands:
-            - mvn -Dcloud -Passembly -pl debezium-connector-postgres -am -U -Dformat.skip=true -Dmaven.wagon.http.retryHandler.count=10 --batch-mode --no-transfer-progress
-              clean verify install validate
+            - mvn -Dcloud -Passembly -pl debezium-connector-postgres -am -U -Dformat.skip=true -Drevapi.skip=true -Dmaven.wagon.http.retryHandler.count=10 --batch-mode --no-transfer-progress
+              verify
             - . cve-scan
             - . cache-maven store
         - name: SqlServer
           commands:
-            - mvn -Dcloud -Passembly -pl debezium-connector-sqlserver -am -U -Dformat.skip=true -Dmaven.wagon.http.retryHandler.count=10 --batch-mode --no-transfer-progress
-              clean verify install validate
+            - mvn -Dcloud -Passembly -pl debezium-connector-sqlserver -am -U -Dformat.skip=true -Drevapi.skip=true -Dmaven.wagon.http.retryHandler.count=10 --batch-mode --no-transfer-progress
+              verify
             - . cve-scan
             - . cache-maven store
       env_vars:

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
         <version.dependency.plugin>3.1.1</version.dependency.plugin>
         <version.enforcer.plugin>3.0.0-M2</version.enforcer.plugin>
 
-        <version.maven>3.9.8</version.maven>
+        <version.maven>3.9.4</version.maven>
         <version.jar.plugin>3.0.2</version.jar.plugin>
         <version.source.plugin>3.1.0</version.source.plugin>
         <version.assembly.plugin>3.1.1</version.assembly.plugin>


### PR DESCRIPTION
## Summary
- Lower required Maven version from 3.9.8 to 3.9.4 (Semaphore agents have 3.9.4.1)
- Add `-Drevapi.skip=true` to CI commands (no previous 3.2.6 baseline in CodeArtifact)
- Use `verify` goal instead of `clean verify install validate`

## Context
Follow-up to #391. CI was failing due to:
1. `RequireMavenVersion` enforcing >= 3.9.8 but Semaphore has 3.9.4.1
2. Revapi API compatibility check failing with no prior version to compare against

Verified locally — all 21 modules build successfully.

JIRA: CC-39686