### PR TITLE
CC-39686: Cherry-pick blocking snapshot race condition fixes

### DIFF
--- a/debezium-connector-mariadb/src/test/resources/logback-test.xml
+++ b/debezium-connector-mariadb/src/test/resources/logback-test.xml
@@ -46,7 +46,7 @@
     <!-- For debug purpose -->
     <logger
             name="io.debezium.pipeline.ChangeEventSourceCoordinator"
-            level="off" additivity="false">
+            level="warn" additivity="false">
         <appender-ref ref="CONSOLE" />
     </logger>
 

--- a/debezium-connector-mysql/src/test/resources/logback-test.xml
+++ b/debezium-connector-mysql/src/test/resources/logback-test.xml
@@ -46,7 +46,7 @@
     <!-- For debug purpose -->
     <logger
             name="io.debezium.pipeline.ChangeEventSourceCoordinator"
-            level="off" additivity="false">
+            level="warn" additivity="false">
         <appender-ref ref="CONSOLE" />
     </logger>
 

--- a/debezium-core/src/main/java/io/debezium/pipeline/ChangeEventSourceCoordinator.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/ChangeEventSourceCoordinator.java
@@ -251,19 +251,22 @@ public class ChangeEventSourceCoordinator<P extends Partition, O extends OffsetC
                 LOGGER.info("Starting snapshot");
 
                 SnapshottingTask snapshottingTask = snapshotSource.getBlockingSnapshottingTask(partition, (O) offsetContext, snapshotConfiguration);
-                try {
-                    doSnapshot(snapshotSource, context, partition, (O) offsetContext, snapshottingTask);
-                }
-                catch (Exception e) {
-                    LOGGER.warn("Error while executing requested blocking snapshot.", e);
-                }
-                finally {
-                    eventDispatcher.setEventListener(streamingMetrics);
-                    resumeStreaming(partition);
-                }
+                doSnapshot(snapshotSource, context, partition, (O) offsetContext, snapshottingTask);
             }
             catch (InterruptedException e) {
                 throw new DebeziumException("Blocking snapshot has been interrupted");
+            }
+            catch (Exception e) {
+                LOGGER.warn("Error while executing requested blocking snapshot.", e);
+            }
+            finally {
+                eventDispatcher.setEventListener(streamingMetrics);
+                try {
+                    resumeStreaming(partition);
+                }
+                catch (InterruptedException e) {
+                    LOGGER.warn("Streaming resume has been interrupted");
+                }
             }
         });
     }

--- a/debezium-core/src/main/java/io/debezium/pipeline/ChangeEventSourceCoordinator.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/ChangeEventSourceCoordinator.java
@@ -459,9 +459,9 @@ public class ChangeEventSourceCoordinator<P extends Partition, O extends OffsetC
                 while (paused) {
                     LOGGER.trace("Waiting for snapshot to be completed.");
                     snapshotFinished.await();
-                    streaming = true;
-                    streamingRunning.signalAll();
                 }
+                streaming = true;
+                streamingRunning.signalAll();
             }
             finally {
                 lock.unlock();

--- a/debezium-core/src/main/java/io/debezium/pipeline/ChangeEventSourceCoordinator.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/ChangeEventSourceCoordinator.java
@@ -241,10 +241,8 @@ public class ChangeEventSourceCoordinator<P extends Partition, O extends OffsetC
             previousLogContext.set(taskContext.configureLoggingContext("streaming", partition));
 
             paused = true;
-            streaming = true;
 
             try {
-
                 context.waitStreamingPaused();
 
                 previousLogContext.set(taskContext.configureLoggingContext("snapshot"));
@@ -423,6 +421,7 @@ public class ChangeEventSourceCoordinator<P extends Partition, O extends OffsetC
         private final Lock lock = new ReentrantLock();
         private final Condition snapshotFinished = lock.newCondition();
         private final Condition streamingPaused = lock.newCondition();
+        private final Condition streamingRunning = lock.newCondition();
 
         @Override
         public boolean isPaused() {
@@ -435,11 +434,18 @@ public class ChangeEventSourceCoordinator<P extends Partition, O extends OffsetC
         }
 
         @Override
-        public void resumeStreaming() {
+        public void resumeStreaming() throws InterruptedException {
             lock.lock();
             try {
                 snapshotFinished.signalAll();
                 LOGGER.trace("Streaming will now resume.");
+                if (running) {
+                    streamingRunning.await();
+                }
+                else {
+                    throw new InterruptedException("Coordinator is stopping, interrupting the blocking snapshot thread.");
+                }
+                LOGGER.trace("Streaming resumed.");
             }
             finally {
                 lock.unlock();
@@ -454,6 +460,7 @@ public class ChangeEventSourceCoordinator<P extends Partition, O extends OffsetC
                     LOGGER.trace("Waiting for snapshot to be completed.");
                     snapshotFinished.await();
                     streaming = true;
+                    streamingRunning.signalAll();
                 }
             }
             finally {
@@ -478,9 +485,12 @@ public class ChangeEventSourceCoordinator<P extends Partition, O extends OffsetC
         public void waitStreamingPaused() throws InterruptedException {
             lock.lock();
             try {
-                while (streaming) {
+                while (streaming && running) {
                     LOGGER.trace("Requested a blocking snapshot. Waiting for streaming to be paused.");
                     streamingPaused.await();
+                }
+                if (!running) {
+                    throw new InterruptedException("Coordinator is stopping, interrupting the blocking snapshot request.");
                 }
             }
             finally {

--- a/debezium-embedded/src/test/java/io/debezium/pipeline/AbstractBlockingSnapshotTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/pipeline/AbstractBlockingSnapshotTest.java
@@ -417,6 +417,35 @@ public abstract class AbstractBlockingSnapshotTest<T extends SourceConnector> ex
         stopConnector();
     }
 
+    @Test
+    @FixFor("DBZ-9494")
+    public void anErrorDuringBlockingSnapshotShouldNotLeaveTheStreamingPaused() throws Exception {
+        populateTable();
+
+        startConnectorWithSnapshot(x -> mutableConfig(false, false)
+                .with(CommonConnectorConfig.MAX_BATCH_SIZE, 1));
+
+        waitForSnapshotToBeCompleted(connector(), server(), task(), database());
+
+        insertRecords(ROW_COUNT, ROW_COUNT);
+
+        SourceRecords consumedRecordsByTopic = consumeRecordsByTopic(ROW_COUNT * 2, 20);
+        assertRecordsFromSnapshotAndStreamingArePresent(ROW_COUNT * 2, consumedRecordsByTopic);
+
+        sendAdHocSnapshotSignalWithAdditionalConditionsWithSurrogateKey(
+                String.format("{\"data-collection\": \"%s\"}", tableDataCollectionIds().get(1)), "", BLOCKING,
+                tableDataCollectionIds().get(1));
+
+        waitForLogMessage("Error while executing requested blocking snapshot.", ChangeEventSourceCoordinator.class);
+
+        insertRecords(ROW_COUNT, ROW_COUNT * 2);
+
+        signalingRecords = 1;
+
+        assertStreamingRecordsArePresent(ROW_COUNT, consumeRecordsByTopic(ROW_COUNT + signalingRecords, 10));
+
+    }
+
     protected int expectedDdlsCount() {
         return 0;
     };

--- a/debezium-embedded/src/test/java/io/debezium/pipeline/AbstractBlockingSnapshotTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/pipeline/AbstractBlockingSnapshotTest.java
@@ -107,6 +107,43 @@ public abstract class AbstractBlockingSnapshotTest<T extends SourceConnector> ex
     }
 
     @Test
+    @FixFor("dbz#1778")
+    public void executeMultipleBlockingSnapshots() throws Exception {
+        // Testing.Print.enable();
+
+        populateTable();
+
+        startConnectorWithSnapshot(x -> mutableConfig(false, false));
+
+        waitForSnapshotToBeCompleted(connector(), server(), task(), database());
+
+        insertRecords(ROW_COUNT, ROW_COUNT);
+
+        SourceRecords consumedRecordsByTopic = consumeRecordsByTopic(ROW_COUNT * 2, 10);
+        assertRecordsFromSnapshotAndStreamingArePresent(ROW_COUNT * 2, consumedRecordsByTopic);
+
+        // Send 3 blocking snapshot signals back-to-back
+        sendAdHocSnapshotSignalWithAdditionalConditionWithSurrogateKey("", "", BLOCKING, tableDataCollectionId());
+        sendAdHocSnapshotSignalWithAdditionalConditionWithSurrogateKey("", "", BLOCKING, tableDataCollectionId());
+        sendAdHocSnapshotSignalWithAdditionalConditionWithSurrogateKey("", "", BLOCKING, tableDataCollectionId());
+
+        LogInterceptor interceptor = new LogInterceptor("io.debezium");
+        Awaitility.await()
+                .alias("Streaming did not resume after all blocking snapshots")
+                .pollInterval(100, TimeUnit.MILLISECONDS)
+                .atMost(waitTimeForRecords() * 60L, TimeUnit.SECONDS)
+                .until(() -> interceptor.countOccurrences("Streaming resumed") == 3);
+
+        signalingRecords = 3;
+
+        consumeRecordsByTopic((ROW_COUNT * 2 * 3) + signalingRecords, 10);
+
+        insertRecords(ROW_COUNT, ROW_COUNT * 2);
+
+        assertStreamingRecordsArePresent(ROW_COUNT, consumeRecordsByTopic(ROW_COUNT, 10));
+    }
+
+    @Test
     public void executeBlockingSnapshotWhileStreaming() throws Exception {
         // Testing.Debug.enable();
 

--- a/debezium-embedded/src/test/java/io/debezium/pipeline/AbstractBlockingSnapshotTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/pipeline/AbstractBlockingSnapshotTest.java
@@ -122,17 +122,17 @@ public abstract class AbstractBlockingSnapshotTest<T extends SourceConnector> ex
         SourceRecords consumedRecordsByTopic = consumeRecordsByTopic(ROW_COUNT * 2, 10);
         assertRecordsFromSnapshotAndStreamingArePresent(ROW_COUNT * 2, consumedRecordsByTopic);
 
+        LogInterceptor interceptor = new LogInterceptor("io.debezium");
+
         // Send 3 blocking snapshot signals back-to-back
         sendAdHocSnapshotSignalWithAdditionalConditionWithSurrogateKey("", "", BLOCKING, tableDataCollectionId());
         sendAdHocSnapshotSignalWithAdditionalConditionWithSurrogateKey("", "", BLOCKING, tableDataCollectionId());
         sendAdHocSnapshotSignalWithAdditionalConditionWithSurrogateKey("", "", BLOCKING, tableDataCollectionId());
-
-        LogInterceptor interceptor = new LogInterceptor("io.debezium");
         Awaitility.await()
                 .alias("Streaming did not resume after all blocking snapshots")
                 .pollInterval(100, TimeUnit.MILLISECONDS)
                 .atMost(waitTimeForRecords() * 60L, TimeUnit.SECONDS)
-                .until(() -> interceptor.countOccurrences("Streaming resumed") == 3);
+                .until(() -> interceptor.countOccurrences("Streaming resumed") >= 3);
 
         signalingRecords = 3;
 
@@ -485,11 +485,20 @@ public abstract class AbstractBlockingSnapshotTest<T extends SourceConnector> ex
         SourceRecords consumedRecordsByTopic = consumeRecordsByTopic(ROW_COUNT * 2, 20);
         assertRecordsFromSnapshotAndStreamingArePresent(ROW_COUNT * 2, consumedRecordsByTopic);
 
+        waitForStreamingRunning(connector(), server(), getStreamingNamespace(), task());
+
+        LogInterceptor interceptor = new LogInterceptor(ChangeEventSourceCoordinator.class);
+
+
         sendAdHocSnapshotSignalWithAdditionalConditionsWithSurrogateKey(
                 String.format("{\"data-collection\": \"%s\"}", tableDataCollectionIds().get(1)), "", BLOCKING,
                 tableDataCollectionIds().get(1));
 
-        waitForLogMessage("Error while executing requested blocking snapshot.", ChangeEventSourceCoordinator.class);
+        Awaitility.await()
+                .alias("Snapshot not completed on time")
+                .pollInterval(100, TimeUnit.MILLISECONDS)
+                .atMost(waitTimeForRecords() * 60L, TimeUnit.SECONDS)
+                .until(() -> interceptor.containsMessage("Error while executing requested blocking snapshot."));
 
         insertRecords(ROW_COUNT, ROW_COUNT * 2);
 

--- a/debezium-embedded/src/test/java/io/debezium/pipeline/source/snapshot/incremental/AbstractSnapshotTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/pipeline/source/snapshot/incremental/AbstractSnapshotTest.java
@@ -381,20 +381,28 @@ public abstract class AbstractSnapshotTest<T extends SourceConnector> extends Ab
     protected void sendAdHocSnapshotSignalWithAdditionalConditionsWithSurrogateKey(Map<String, String> additionalConditions, String surrogateKey,
                                                                                    AbstractSnapshotSignal.SnapshotType snapshotType,
                                                                                    String... dataCollectionIds) {
+        sendAdHocSnapshotSignalWithAdditionalConditionsWithSurrogateKey(
+                !additionalConditions.isEmpty() ? buildAdditionalConditions(additionalConditions) : null,
+                surrogateKey, snapshotType, dataCollectionIds);
+    }
+
+    protected void sendAdHocSnapshotSignalWithAdditionalConditionsWithSurrogateKey(String additionalConditions, String surrogateKey,
+                                                                                   AbstractSnapshotSignal.SnapshotType snapshotType,
+                                                                                   String... dataCollectionIds) {
         final String dataCollectionIdsList = Arrays.stream(dataCollectionIds)
                 .map(x -> '"' + x + '"')
                 .collect(Collectors.joining(", "));
         try (JdbcConnection connection = databaseConnection()) {
             String query;
-            if (!additionalConditions.isEmpty() && !Strings.isNullOrEmpty(surrogateKey)) {
+            if (!Strings.isNullOrEmpty(additionalConditions) && !Strings.isNullOrEmpty(surrogateKey)) {
                 query = String.format(
                         "INSERT INTO %s VALUES('ad-hoc', 'execute-snapshot', '{\"type\": \"%s\",\"data-collections\": [%s], \"additional-conditions\": [%s], \"surrogate-key\": %s}')",
-                        signalTableName(), snapshotType.toString(), dataCollectionIdsList, buildAdditionalConditions(additionalConditions), surrogateKey);
+                        signalTableName(), snapshotType.toString(), dataCollectionIdsList, additionalConditions, surrogateKey);
             }
-            else if (!additionalConditions.isEmpty()) {
+            else if (!Strings.isNullOrEmpty(additionalConditions)) {
                 query = String.format(
                         "INSERT INTO %s VALUES('ad-hoc', 'execute-snapshot', '{\"type\": \"%s\",\"data-collections\": [%s], \"additional-conditions\": [%s]}')",
-                        signalTableName(), snapshotType.toString(), dataCollectionIdsList, buildAdditionalConditions(additionalConditions));
+                        signalTableName(), snapshotType.toString(), dataCollectionIdsList, additionalConditions);
             }
             else if (!Strings.isNullOrEmpty(surrogateKey)) {
                 query = String.format(


### PR DESCRIPTION
## Summary
- Cherry-picks 6 commits from PR #386 (merged to `v3.2.5-hotfix-x`) into `3.2.6.x`
- Fixes blocking snapshot race conditions in `ChangeEventSourceCoordinator` (DBZ-9494, debezium/dbz#1778)

## Context
Extends the blocking snapshot race condition fix previously applied to Oracle XStream connector (CC-38226) to all Debezium CDC connectors. See [debezium/dbz#1778](https://github.com/debezium/dbz/issues/1778) for identified race conditions.

## Testing
Tested locally on SQL Server with 6 consecutive blocking snapshot signals — all completed successfully, streaming resumed without deadlock.

JIRA: CC-39686