### PR TITLE
CC-40194: debezium/dbz#1877 Recover stale SqlServer connections at streaming iteration start

### DIFF
--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerChangeEventSourceFactory.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerChangeEventSourceFactory.java
@@ -5,7 +5,11 @@
  */
 package io.debezium.connector.sqlserver;
 
+import java.sql.SQLException;
 import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import io.debezium.jdbc.MainConnectionProvidingConnectionFactory;
 import io.debezium.pipeline.ErrorHandler;
@@ -25,6 +29,8 @@ import io.debezium.util.Clock;
 import io.debezium.util.Strings;
 
 public class SqlServerChangeEventSourceFactory implements ChangeEventSourceFactory<SqlServerPartition, SqlServerOffsetContext> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SqlServerChangeEventSourceFactory.class);
 
     private final SqlServerConnectorConfig configuration;
     private final MainConnectionProvidingConnectionFactory<SqlServerConnection> connectionFactory;
@@ -60,9 +66,13 @@ public class SqlServerChangeEventSourceFactory implements ChangeEventSourceFacto
 
     @Override
     public StreamingChangeEventSource<SqlServerPartition, SqlServerOffsetContext> getStreamingChangeEventSource() {
+        SqlServerConnection dataConnection = connectionFactory.mainConnection();
+        refreshConnectionIfInvalid(dataConnection, "data");
+        refreshConnectionIfInvalid(metadataConnection, "metadata");
+
         return new SqlServerStreamingChangeEventSource(
                 configuration,
-                connectionFactory.mainConnection(),
+                dataConnection,
                 metadataConnection,
                 dispatcher,
                 errorHandler,
@@ -70,6 +80,19 @@ public class SqlServerChangeEventSourceFactory implements ChangeEventSourceFacto
                 schema,
                 notificationService,
                 snapshotterService);
+    }
+
+    private void refreshConnectionIfInvalid(SqlServerConnection connection, String name) {
+        try {
+            if (!connection.isValid()) {
+                LOGGER.warn("The {} connection is no longer valid, refreshing before streaming starts", name);
+                connection.close();
+                connection.reconnect();
+            }
+        }
+        catch (SQLException e) {
+            LOGGER.warn("Error while refreshing {} connection, streaming will attempt to proceed", name, e);
+        }
     }
 
     @Override

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerChangeEventSourceFactory.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerChangeEventSourceFactory.java
@@ -84,6 +84,7 @@ public class SqlServerChangeEventSourceFactory implements ChangeEventSourceFacto
 
     private void refreshConnectionIfInvalid(SqlServerConnection connection, String name) {
         try {
+            LOGGER.debug("Validating {} connection before streaming starts", name);
             if (!connection.isValid()) {
                 LOGGER.warn("The {} connection is no longer valid, refreshing before streaming starts", name);
                 connection.close();

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerChangeEventSourceFactory.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerChangeEventSourceFactory.java
@@ -87,8 +87,8 @@ public class SqlServerChangeEventSourceFactory implements ChangeEventSourceFacto
             LOGGER.debug("Validating {} connection before streaming starts", name);
             if (!connection.isValid()) {
                 LOGGER.warn("The {} connection is no longer valid, refreshing before streaming starts", name);
-                connection.close();
                 connection.reconnect();
+                LOGGER.info("Successfully refreshed the {} connection", name);
             }
         }
         catch (SQLException e) {

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnection.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnection.java
@@ -308,6 +308,15 @@ public class SqlServerConnection extends JdbcConnection {
         return connection;
     }
 
+    @Override
+    public synchronized void reconnect() throws SQLException {
+        // JdbcConnection#reconnect() bypasses connection(boolean) and would
+        //  skip setAutoCommit(false).
+        LOGGER.info("Reopening SQL Server JDBC connection");
+        close();
+        connection();
+    }
+
     /**
      * @return the current largest log sequence number
      */

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerStreamingChangeEventSource.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerStreamingChangeEventSource.java
@@ -176,8 +176,18 @@ public class SqlServerStreamingChangeEventSource implements StreamingChangeEvent
             TxLogPosition lastProcessedPosition = streamingExecutionContext.getLastProcessedPosition();
 
             if (context.isRunning()) {
-                commitTransaction();
-                final Lsn toLsn = getToLsn(dataConnection, databaseName, lastProcessedPosition, maxTransactionsPerIteration);
+                Lsn toLsn;
+                // Recover before iteration state mutates: a connection idle-killed during long schema
+                // recovery surfaces here on the first DB call. Refresh only the broken side and retry
+                // once so streaming resumes instead of failing the task.
+                try {
+                    commitTransaction();
+                    toLsn = getToLsn(dataConnection, databaseName, lastProcessedPosition, maxTransactionsPerIteration);
+                }
+                catch (SQLException e) {
+                    recoverStaleConnections(e, databaseName);
+                    toLsn = getToLsn(dataConnection, databaseName, lastProcessedPosition, maxTransactionsPerIteration);
+                }
 
                 // Shouldn't happen if the agent is running, but it is better to guard against such situation
                 if (!toLsn.isAvailable()) {
@@ -389,6 +399,32 @@ public class SqlServerStreamingChangeEventSource implements StreamingChangeEvent
             dataConnection.commit();
             metadataConnection.commit();
         }
+    }
+
+    private void recoverStaleConnections(SQLException e, String databaseName) throws SQLException {
+        boolean dataValid;
+        boolean metadataValid;
+        try {
+            dataValid = dataConnection.isValid();
+            metadataValid = metadataConnection.isValid();
+        }
+        catch (SQLException probeEx) {
+            e.addSuppressed(probeEx);
+            throw e;
+        }
+        if (dataValid && metadataValid) {
+            throw e;
+        }
+        LOGGER.warn("Stale connection detected at start of streaming iteration for database '{}' (data valid={}, metadata valid={}); refreshing",
+                databaseName, dataValid, metadataValid, e);
+        if (!dataValid) {
+            dataConnection.reconnect();
+        }
+        if (!metadataValid) {
+            metadataConnection.reconnect();
+        }
+        LOGGER.info("Refreshed connections (data refreshed={}, metadata refreshed={}) for database '{}'",
+                !dataValid, !metadataValid, databaseName);
     }
 
     private void migrateTable(SqlServerPartition partition, final Queue<SqlServerChangeTable> schemaChangeCheckpoints, SqlServerOffsetContext offsetContext)

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectionIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectionIT.java
@@ -602,7 +602,7 @@ public class SqlServerConnectionIT {
 
     @Test
     @FixFor("DBZ-1877")
-    void reconnectShouldRebuildConnectionWithAutoCommitDisabled() throws SQLException {
+    public void reconnectShouldRebuildConnectionWithAutoCommitDisabled() throws SQLException {
         TestHelper.createTestDatabase();
         try (SqlServerConnection connection = TestHelper.testConnection()) {
             assertThat(connection.connection().getAutoCommit()).isFalse();
@@ -615,7 +615,7 @@ public class SqlServerConnectionIT {
 
     @Test
     @FixFor("DBZ-1877")
-    void reconnectShouldRecoverAfterServerKillsSession() throws Exception {
+    public void reconnectShouldRecoverAfterServerKillsSession() throws Exception {
         TestHelper.createTestDatabase();
         try (SqlServerConnection connection = TestHelper.testConnection()) {
             connection.connect();
@@ -639,7 +639,7 @@ public class SqlServerConnectionIT {
 
     @Test
     @FixFor("DBZ-1877")
-    void isValidShouldDistinguishKilledFromHealthyConnections() throws Exception {
+    public void isValidShouldDistinguishKilledFromHealthyConnections() throws Exception {
         TestHelper.createTestDatabase();
         try (SqlServerConnection data = TestHelper.testConnection();
                 SqlServerConnection metadata = TestHelper.testConnection()) {

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectionIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectionIT.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
+import java.sql.Connection;
 import java.sql.SQLException;
 import java.time.Instant;
 import java.time.OffsetDateTime;
@@ -597,6 +598,75 @@ public class SqlServerConnectionIT {
                     .isInstanceOf(SQLException.class)
                     .hasMessage("The query has timed out.");
         }
+    }
+
+    @Test
+    @FixFor("DBZ-1877")
+    void reconnectShouldRebuildConnectionWithAutoCommitDisabled() throws SQLException {
+        TestHelper.createTestDatabase();
+        try (SqlServerConnection connection = TestHelper.testConnection()) {
+            assertThat(connection.connection().getAutoCommit()).isFalse();
+
+            connection.reconnect();
+
+            assertThat(connection.connection().getAutoCommit()).isFalse();
+        }
+    }
+
+    @Test
+    @FixFor("DBZ-1877")
+    void reconnectShouldRecoverAfterServerKillsSession() throws Exception {
+        TestHelper.createTestDatabase();
+        try (SqlServerConnection connection = TestHelper.testConnection()) {
+            connection.connect();
+
+            Connection before = connection.connection();
+            int spid = currentSpid(connection);
+            try (SqlServerConnection admin = TestHelper.adminConnection()) {
+                admin.connect();
+                admin.execute("KILL " + spid);
+            }
+
+            Awaitility.await().atMost(10, TimeUnit.SECONDS).until(() -> !connection.isValid());
+
+            connection.reconnect();
+
+            assertThat(connection.isValid()).isTrue();
+            assertThat(connection.connection()).isNotSameAs(before);
+            assertThat(connection.connection().getAutoCommit()).isFalse();
+        }
+    }
+
+    @Test
+    @FixFor("DBZ-1877")
+    void isValidShouldDistinguishKilledFromHealthyConnections() throws Exception {
+        TestHelper.createTestDatabase();
+        try (SqlServerConnection data = TestHelper.testConnection();
+                SqlServerConnection metadata = TestHelper.testConnection()) {
+            data.connect();
+            metadata.connect();
+
+            int dataSpid = currentSpid(data);
+            try (SqlServerConnection admin = TestHelper.adminConnection()) {
+                admin.connect();
+                admin.execute("KILL " + dataSpid);
+            }
+
+            Awaitility.await().atMost(10, TimeUnit.SECONDS).until(() -> !data.isValid());
+            assertThat(metadata.isValid()).isTrue();
+
+            data.reconnect();
+
+            assertThat(data.isValid()).isTrue();
+            assertThat(metadata.isValid()).isTrue();
+        }
+    }
+
+    private static int currentSpid(SqlServerConnection connection) throws SQLException {
+        return connection.queryAndMap("SELECT @@SPID", rs -> {
+            rs.next();
+            return rs.getInt(1);
+        });
     }
 
     private long toMillis(OffsetDateTime datetime) {


### PR DESCRIPTION
## Problem

Debezium issue - https://github.com/debezium/dbz/issues/1877

## Alternatives considered and dropped

| Option | Why dropped |
|---|---|
| Proactive `isValid()` at the top of every iteration | 2 server round-trips per iteration (up to 3s each under `CONNECTION_VALID_CHECK_TIMEOUT_IN_SEC`). Steady-state cost for a rare failure. |
| Proactive `isValid()` inside `JdbcConnection.connection()` | `connection()` is called on every SQL site - adds a round-trip to the hot path. Same core blast radius as any core change. |
| Reactive retry around `prepareStatement / query / execute` | Core change and sprawls across dozens of call sites. Refresh drops imperatively-set session state (autoCommit, isolation level etc.) - a silent retry would run against driver defaults. |
| One-time refresh in `SqlServerChangeEventSourceFactory` (before streaming starts) | Covers only the `streaming.delay.ms` window; does not help if the connection goes idle later. |
| `mssql-jdbc` driver native Connection Resiliency (`connectRetryCount` / `connectRetryInterval`) | Driver rejects customer repro as unrecoverable. No resiliency applied. | 

## Manual Testing

Tested locally with KDP using the following steps:
1. Create connector with `snapshot.mode=no_data` and `streaming.delay.ms=60000` (cloud default)
2. Added HAProxy over the database with an idle timeout of 50s.
3. Wait for schema capture to complete — connector enters 60s streaming delay
4. The proxy kills connection after timeout.

Also tried another approach of schema recovery taking ~2 minutes, hitting the same loop.

**Without fix:** connector fails with `SQLServerException: The connection is broken and recovery is not possible` and enters a restart loop where each restart repeats schema recovery → 60s delay → dead connection → fail

<img width="1179" height="943" alt="Screenshot 2026-04-14 at 3 12 37 PM" src="https://github.com/user-attachments/assets/5452fcea-d0a8-48d1-919e-798baf05d2af" />

**With fix:** connector detects invalid connections on failure, refreshes them, and streams successfully:
<img width="1471" height="900" alt="Screenshot 2026-04-24 at 6 30 52 PM" src="https://github.com/user-attachments/assets/7a926d48-b886-472c-9232-e80183cf46a3" />

[CC-40194]: https://confluentinc.atlassian.net/browse/CC-40194?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ