### PR TITLE
CC-40617 : Remove sensitive data from signal and snapshot log lines

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorConfig.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorConfig.java
@@ -822,12 +822,12 @@ public class MongoDbConnectorConfig extends CommonConnectorConfig {
     public Optional<String[]> parseSignallingMessage(Struct value) {
         final String after = value.getString(Envelope.FieldName.AFTER);
         if (after == null) {
-            LOGGER.warn("After part of signal '{}' is missing", value);
+            LOGGER.warn("After part of signal is missing");
             return Optional.empty();
         }
         final Document fields = Document.parse(after);
         if (fields.size() != 3) {
-            LOGGER.warn("The signal event '{}' should have 3 fields but has {}", after, fields.size());
+            LOGGER.warn("The signal event should have 3 fields but has {}", fields.size());
             return Optional.empty();
         }
         final String[] result = new String[3];

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/legacy/SnapshotReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/legacy/SnapshotReader.java
@@ -561,7 +561,7 @@ public class SnapshotReader extends AbstractReader {
                             Map<TableId, String> selectOverrides = context.getConnectorConfig().getSnapshotSelectOverridesByTable();
 
                             String selectStatement = selectOverrides.getOrDefault(tableId, "SELECT * FROM " + quote(tableId));
-                            logger.info("For table '{}' using select statement: '{}'", tableId, selectStatement);
+                            logger.info("For table '{}' using select statement", tableId);
                             sql.set(selectStatement);
 
                             try {

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/signal/KafkaSignalThread.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/signal/KafkaSignalThread.java
@@ -141,7 +141,7 @@ public class KafkaSignalThread<T extends DataCollectionId> {
             return;
         }
         String value = record.value();
-        LOGGER.trace("Processing signal: {}", value);
+        LOGGER.trace("Processing signal");
         final Document jsonData = (value == null || value.isEmpty()) ? Document.create()
                 : DocumentReader.defaultReader().read(value);
         String type = jsonData.getString("type");

--- a/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java
+++ b/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java
@@ -945,12 +945,12 @@ public abstract class CommonConnectorConfig {
     public Optional<String[]> parseSignallingMessage(Struct value) {
         final Struct after = value.getStruct(Envelope.FieldName.AFTER);
         if (after == null) {
-            LOGGER.warn("After part of signal '{}' is missing", value);
+            LOGGER.warn("After part of signal is missing");
             return Optional.empty();
         }
         List<org.apache.kafka.connect.data.Field> fields = after.schema().fields();
         if (fields.size() != 3) {
-            LOGGER.warn("The signal event '{}' should have 3 fields but has {}", after, fields.size());
+            LOGGER.warn("The signal event should have 3 fields but has {}", fields.size());
             return Optional.empty();
         }
         return Optional.of(new String[]{

--- a/debezium-core/src/main/java/io/debezium/jdbc/JdbcConnection.java
+++ b/debezium-core/src/main/java/io/debezium/jdbc/JdbcConnection.java
@@ -425,7 +425,7 @@ public class JdbcConnection implements AutoCloseable {
             for (String sqlStatement : sqlStatements) {
                 if (sqlStatement != null) {
                     if (LOGGER.isTraceEnabled()) {
-                        LOGGER.trace("executing '{}'", sqlStatement);
+                        LOGGER.trace("executing statement");
                     }
                     statement.execute(sqlStatement);
                 }

--- a/debezium-core/src/main/java/io/debezium/pipeline/signal/ExecuteSnapshot.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/signal/ExecuteSnapshot.java
@@ -80,8 +80,8 @@ public class ExecuteSnapshot<P extends Partition> implements Signal.Action<P> {
         final Array dataCollectionsArray = data.getArray(FIELD_DATA_COLLECTIONS);
         if (dataCollectionsArray == null || dataCollectionsArray.isEmpty()) {
             LOGGER.warn(
-                    "Execute snapshot signal '{}' has arrived but the requested field '{}' is missing from data or is empty",
-                    data, FIELD_DATA_COLLECTIONS);
+                    "Execute snapshot signal has arrived but the requested field '{}' is missing from data or is empty",
+                    FIELD_DATA_COLLECTIONS);
             return null;
         }
         return dataCollectionsArray.streamValues()

--- a/debezium-core/src/main/java/io/debezium/pipeline/signal/Log.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/signal/Log.java
@@ -22,7 +22,7 @@ public class Log<P extends Partition> implements Signal.Action<P> {
     public boolean arrived(Payload<P> signalPayload) {
         final String message = signalPayload.data.getString(FIELD_MESSAGE);
         if (message == null || message.isEmpty()) {
-            LOGGER.warn("Logging signal '{}' has arrived but the requested field '{}' is missing from data", signalPayload, FIELD_MESSAGE);
+            LOGGER.warn("Logging signal '{}' has arrived but the requested field '{}' is missing from data", signalPayload.id, FIELD_MESSAGE);
             return false;
         }
         LOGGER.info(message, signalPayload.offsetContext != null ? signalPayload.offsetContext.getOffset() : "<none>");

--- a/debezium-core/src/main/java/io/debezium/pipeline/signal/SchemaChanges.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/signal/SchemaChanges.java
@@ -48,11 +48,11 @@ public class SchemaChanges<P extends Partition> implements Signal.Action<P> {
         final String schema = signalPayload.data.getString(FIELD_SCHEMA);
 
         if (changes == null || changes.isEmpty()) {
-            LOGGER.warn("Table changes signal '{}' has arrived but the requested field '{}' is missing from data", signalPayload, FIELD_CHANGES);
+            LOGGER.warn("Table changes signal '{}' has arrived but the requested field '{}' is missing from data", signalPayload.id, FIELD_CHANGES);
             return false;
         }
         if (database == null || database.isEmpty()) {
-            LOGGER.warn("Table changes signal '{}' has arrived but the requested field '{}' is missing from data", signalPayload, FIELD_DATABASE);
+            LOGGER.warn("Table changes signal '{}' has arrived but the requested field '{}' is missing from data", signalPayload.id, FIELD_DATABASE);
             return false;
         }
         for (TableChanges.TableChange tableChange : serializer.deserialize(changes, useCatalogBeforeSchema)) {

--- a/debezium-core/src/main/java/io/debezium/pipeline/signal/Signal.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/signal/Signal.java
@@ -123,7 +123,7 @@ public class Signal<P extends Partition> {
     }
 
     public boolean process(P partition, String id, String type, String data, OffsetContext offset, Struct source) throws InterruptedException {
-        LOGGER.debug("Received signal id = '{}', type = '{}', data = '{}'", id, type, data);
+        LOGGER.debug("Received signal id = '{}', type = '{}'", id, type);
         final Action<P> action = signalActions.get(type);
         if (action == null) {
             LOGGER.warn("Signal '{}' has been received but the type '{}' is not recognized", id, type);
@@ -135,7 +135,7 @@ public class Signal<P extends Partition> {
             return action.arrived(new Payload<>(partition, id, type, jsonData, offset, source));
         }
         catch (IOException e) {
-            LOGGER.warn("Signal '{}' has been received but the data '{}' cannot be parsed", id, data, e);
+            LOGGER.warn("Signal '{}' has been received but the data cannot be parsed", id, e);
             return false;
         }
     }
@@ -168,7 +168,7 @@ public class Signal<P extends Partition> {
             data = parseSignal.get()[2];
         }
         catch (Exception e) {
-            LOGGER.warn("Exception while preparing to process the signal '{}'", value, e);
+            LOGGER.warn("Exception while preparing to process the signal", e);
         }
         return process(partition, id, type, data, offset, source);
     }

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotChangeEventSource.java
@@ -388,7 +388,7 @@ public abstract class AbstractIncrementalSnapshotChangeEventSource<P extends Par
 
     private Table readSchema() {
         final String selectStatement = buildChunkQuery(currentTable, 0);
-        LOGGER.debug("Reading schema for table '{}' using select statement: '{}'", currentTable.id(), selectStatement);
+        LOGGER.debug("Reading schema for table '{}' using select statement", currentTable.id());
 
         try (PreparedStatement statement = readTableChunkStatement(selectStatement);
                 ResultSet rs = statement.executeQuery()) {
@@ -437,8 +437,8 @@ public abstract class AbstractIncrementalSnapshotChangeEventSource<P extends Par
         LOGGER.debug("Exporting data chunk from table '{}' (total {} tables)", currentTable.id(), context.dataCollectionsToBeSnapshottedCount());
 
         final String selectStatement = buildChunkQuery(currentTable);
-        LOGGER.debug("\t For table '{}' using select statement: '{}', key: '{}', maximum key: '{}'", currentTable.id(),
-                selectStatement, context.chunkEndPosititon(), context.maximumKey().get());
+        LOGGER.debug("\t For table '{}' using select statement, key: '{}', maximum key: '{}'", currentTable.id(),
+                context.chunkEndPosititon(), context.maximumKey().get());
 
         final TableSchema tableSchema = databaseSchema.schemaFor(currentTable.id());
 

--- a/debezium-core/src/main/java/io/debezium/relational/RelationalSnapshotChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/relational/RelationalSnapshotChangeEventSource.java
@@ -365,7 +365,7 @@ public abstract class RelationalSnapshotChangeEventSource<P extends Partition, O
             snapshotProgressListener.dataCollectionSnapshotCompleted(snapshotContext.partition, table.id(), 0);
             return;
         }
-        LOGGER.info("\t For table '{}' using select statement: '{}'", table.id(), selectStatement.get());
+        LOGGER.info("\t For table '{}' using select statement", table.id());
         final OptionalLong rowCount = rowCountForTable(table.id());
         Instant sourceTableSnapshotTimestamp = getSnapshotSourceTimestamp(snapshotContext, table.id());
 


### PR DESCRIPTION
JIRA: [CC-40617](https://confluentinc.atlassian.net/browse/CC-40617)

Remove potentially sensitive customer data (signal payloads, Struct values) from log lines in the signal processing path.  Refer to the fix in https://github.com/confluentinc/debezium/pull/276

Covers all Debezium CDC redactor rules in https://github.com/confluentinc/logredactor-rules/blob/master/public/prod-connect.rules that apply to this branch.
- Rule number 24 adhoc snapshot signal data
- Rule number 25 snapshot select statements
- Rule number 27 JdbcConnection SQL statements
- Rule number 28 ExecuteSnapshot signal data
- Rule number 29/36 SignalProcessor data parse
- Rule number 30 signal event struct field count
- Rule number 33 signal preparation exception
- Rule number 34 missing signal field

[CC-40617]: https://confluentinc.atlassian.net/browse/CC-40617?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ