### PR TITLE
Fix TimescaleDB SMT configuration definition to expose database connection properties

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/transforms/timescaledb/TimescaleDb.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/transforms/timescaledb/TimescaleDb.java
@@ -138,7 +138,14 @@ public class TimescaleDb<R extends ConnectRecord<R>> implements Transformation<R
     @Override
     public ConfigDef config() {
         final ConfigDef config = new ConfigDef();
-        Field.group(config, null, TimescaleDbConfigDefinition.SCHEMA_LIST_NAMES_FIELD, TimescaleDbConfigDefinition.TARGET_TOPIC_PREFIX_FIELD);
+        Field.group(config, null,
+                TimescaleDbConfigDefinition.SCHEMA_LIST_NAMES_FIELD,
+                TimescaleDbConfigDefinition.TARGET_TOPIC_PREFIX_FIELD,
+                TimescaleDbConfigDefinition.DATABASE_HOSTNAME_FIELD,
+                TimescaleDbConfigDefinition.DATABASE_PORT_FIELD,
+                TimescaleDbConfigDefinition.DATABASE_USER_FIELD,
+                TimescaleDbConfigDefinition.DATABASE_PASSWORD_FIELD,
+                TimescaleDbConfigDefinition.DATABASE_DBNAME_FIELD);
         return config;
     }
 

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/transforms/timescaledb/TimescaleDbConfigDefinition.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/transforms/timescaledb/TimescaleDbConfigDefinition.java
@@ -5,6 +5,8 @@
  */
 package io.debezium.connector.postgresql.transforms.timescaledb;
 
+import io.debezium.connector.postgresql.PostgresConnectorConfig;
+import io.debezium.relational.RelationalDatabaseConnectorConfig;
 import org.apache.kafka.common.config.ConfigDef;
 
 import io.debezium.config.Field;
@@ -32,4 +34,10 @@ public class TimescaleDbConfigDefinition {
             .withWidth(ConfigDef.Width.MEDIUM)
             .withImportance(ConfigDef.Importance.MEDIUM)
             .withDescription("The namespace (prefix) of topics where TimescaleDB events will be routed, defaults to: '" + SCHEMA_LIST_NAMES_DEFAULT + "'");
+
+    static final Field DATABASE_HOSTNAME_FIELD = RelationalDatabaseConnectorConfig.HOSTNAME;
+    static final Field DATABASE_PORT_FIELD = PostgresConnectorConfig.PORT;
+    static final Field DATABASE_USER_FIELD = RelationalDatabaseConnectorConfig.USER;
+    static final Field DATABASE_PASSWORD_FIELD = RelationalDatabaseConnectorConfig.PASSWORD;
+    static final Field DATABASE_DBNAME_FIELD = RelationalDatabaseConnectorConfig.DATABASE_NAME;
 }


### PR DESCRIPTION
## Problem
The TimescaleDB SMT fails to initialize on CCloud with a `hostname resolution` error.
This occurs because the SMT's `ConfigDef` implementation in `TimescaleDb#config()` does not declare the required database connection properties (like `database.hostname`, `database.port`, `database.user`, `database.password`, `database.dbname`).

## Solution
This PR updates the `TimescaleDbConfigDefinition` and `TimescaleDb` classes to explicitly declare the necessary database connection fields in the SMT's ConfigDef.

- `TimescaleDbConfigDefinition`: Added fields for `hostname`, `port`, `user`, `password`, and `dbname`, reusing the standard definitions from `RelationalDatabaseConnectorConfig` and `PostgresConnectorConfig` to ensure consistency.
- `TimescaleDb`: Updated the `config()` method to include these new fields in the returned `ConfigDef`.


This change ensures that all required configuration properties are exposed, validated, and correctly passed to the SMT in all Kafka Connect environments.

## Testing

<details>
<summary>Devel Testing</summary>

**Connector SMT Config**
<img width="3440" height="1868" alt="image" src="https://github.com/user-attachments/assets/f1af50d8-0921-4595-9293-cb214a4aa195" />


**Kafka Topic Headers**
<img width="3440" height="1868" alt="image" src="https://github.com/user-attachments/assets/50c3823b-7cf8-49d7-84d2-e007af99b704" />


**Kafka Topic Value Record**
<img width="3440" height="1868" alt="image" src="https://github.com/user-attachments/assets/a0087361-dd54-4320-8d6b-cbdffc708038" />

</details> 