### PR TITLE
Convert boolean/String JMX metrics to numeric for OTel scraping

### DIFF
--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/metrics/BinlogStreamingChangeEventSourceMetrics.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/metrics/BinlogStreamingChangeEventSourceMetrics.java
@@ -53,7 +53,7 @@ public class BinlogStreamingChangeEventSourceMetrics<T extends BinlogDatabaseSch
     }
 
     @Override
-    public long isConnected() {
+    public long getConnected() {
         return this.client.isConnected() ? 1 : 0;
     }
 

--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/metrics/BinlogStreamingChangeEventSourceMetrics.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/metrics/BinlogStreamingChangeEventSourceMetrics.java
@@ -53,8 +53,8 @@ public class BinlogStreamingChangeEventSourceMetrics<T extends BinlogDatabaseSch
     }
 
     @Override
-    public boolean isConnected() {
-        return this.client.isConnected();
+    public long isConnected() {
+        return this.client.isConnected() ? 1 : 0;
     }
 
     @Override

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogMetricsIT.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogMetricsIT.java
@@ -85,8 +85,8 @@ public abstract class BinlogMetricsIT<C extends SourceConnector> extends Abstrac
     }
 
     @Override
-    protected boolean snapshotCompleted() {
-        return true;
+    protected long snapshotCompleted() {
+        return 1L;
     }
 
     @Before

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/AbstractMongoConnectorIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/AbstractMongoConnectorIT.java
@@ -354,8 +354,7 @@ public abstract class AbstractMongoConnectorIT extends AbstractAsyncEngineConnec
                 .atMost(waitTimeForRecords() * 30, TimeUnit.SECONDS)
                 .ignoreException(InstanceNotFoundException.class)
                 .until(() -> {
-                    Object attr = mbeanServer.getAttribute(objectName, "SnapshotCompleted");
-                    return attr instanceof Long ? (Long) attr == 1L : (Boolean) attr;
+                    return (long) mbeanServer.getAttribute(objectName, "SnapshotCompleted") == 1L;
                 });
     }
 
@@ -367,8 +366,7 @@ public abstract class AbstractMongoConnectorIT extends AbstractAsyncEngineConnec
                 .atMost(waitTimeForRecords() * 30, TimeUnit.SECONDS)
                 .ignoreException(InstanceNotFoundException.class)
                 .until(() -> {
-                    Object attr = mbeanServer.getAttribute(objectName, "Connected");
-                    return attr instanceof Long ? (Long) attr == 1L : (Boolean) attr;
+                    return (long) mbeanServer.getAttribute(objectName, "Connected") == 1L;
                 });
     }
 

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/AbstractMongoConnectorIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/AbstractMongoConnectorIT.java
@@ -353,7 +353,10 @@ public abstract class AbstractMongoConnectorIT extends AbstractAsyncEngineConnec
                 .pollInterval(100, TimeUnit.MILLISECONDS)
                 .atMost(waitTimeForRecords() * 30, TimeUnit.SECONDS)
                 .ignoreException(InstanceNotFoundException.class)
-                .until(() -> (boolean) mbeanServer.getAttribute(objectName, "SnapshotCompleted"));
+                .until(() -> {
+                    Object attr = mbeanServer.getAttribute(objectName, "SnapshotCompleted");
+                    return attr instanceof Long ? (Long) attr == 1L : (Boolean) attr;
+                });
     }
 
     private static void waitForStreamingRunning(ObjectName objectName) {
@@ -363,7 +366,10 @@ public abstract class AbstractMongoConnectorIT extends AbstractAsyncEngineConnec
                 .pollInterval(100, TimeUnit.MILLISECONDS)
                 .atMost(waitTimeForRecords() * 30, TimeUnit.SECONDS)
                 .ignoreException(InstanceNotFoundException.class)
-                .until(() -> (boolean) mbeanServer.getAttribute(objectName, "Connected"));
+                .until(() -> {
+                    Object attr = mbeanServer.getAttribute(objectName, "Connected");
+                    return attr instanceof Long ? (Long) attr == 1L : (Boolean) attr;
+                });
     }
 
     private static ObjectName getMetricsObjectNameWithTags(String connector, Map<String, String> tags) {

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoMetricsIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoMetricsIT.java
@@ -137,7 +137,7 @@ public class MongoMetricsIT extends AbstractMongoConnectorIT {
         final ObjectName objectName = getStreamingMetricsObjectName("mongodb", "mongo1");
 
         assertThat(mBeanServer.getAttribute(objectName, "SourceEventPosition")).isNotNull();
-        assertThat(mBeanServer.getAttribute(objectName, "Connected")).isEqualTo(true);
+        assertThat(mBeanServer.getAttribute(objectName, "Connected")).isEqualTo(1L);
         assertThat(mBeanServer.getAttribute(objectName, "CapturedTables")).isEqualTo(new String[]{});
         assertThat(mBeanServer.getAttribute(objectName, "LastEvent")).isNotNull();
         assertThat(mBeanServer.getAttribute(objectName, "TotalNumberOfEventsSeen")).isEqualTo(6L);

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoMetricsIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoMetricsIT.java
@@ -96,16 +96,16 @@ public class MongoMetricsIT extends AbstractMongoConnectorIT {
 
         assertThat(mBeanServer.getAttribute(objectName, "TotalTableCount")).isEqualTo(1);
         assertThat(mBeanServer.getAttribute(objectName, "RemainingTableCount")).isEqualTo(0);
-        assertThat(mBeanServer.getAttribute(objectName, "SnapshotRunning")).isEqualTo(false);
-        assertThat(mBeanServer.getAttribute(objectName, "SnapshotAborted")).isEqualTo(false);
-        assertThat(mBeanServer.getAttribute(objectName, "SnapshotCompleted")).isEqualTo(true);
+        assertThat(mBeanServer.getAttribute(objectName, "SnapshotRunning")).isEqualTo(0L);
+        assertThat(mBeanServer.getAttribute(objectName, "SnapshotAborted")).isEqualTo(0L);
+        assertThat(mBeanServer.getAttribute(objectName, "SnapshotCompleted")).isEqualTo(1L);
         assertThat(mBeanServer.getAttribute(objectName, "TotalNumberOfEventsSeen")).isEqualTo(6L);
         assertThat(mBeanServer.getAttribute(objectName, "NumberOfEventsFiltered")).isEqualTo(0L);
         assertThat(mBeanServer.getAttribute(objectName, "NumberOfErroneousEvents")).isEqualTo(0L);
         assertThat(mBeanServer.getAttribute(objectName, "CapturedTables")).isEqualTo(new String[]{ "dbit.restaurants" });
         assertThat(mBeanServer.getAttribute(objectName, "LastEvent")).isNotNull();
         assertThat(mBeanServer.getAttribute(objectName, "NumberOfDisconnects")).isEqualTo(0L);
-        assertThat(mBeanServer.getAttribute(objectName, "SnapshotPaused")).isEqualTo(false);
+        assertThat(mBeanServer.getAttribute(objectName, "SnapshotPaused")).isEqualTo(0L);
         assertThat(mBeanServer.getAttribute(objectName, "SnapshotPausedDurationInSeconds")).isEqualTo(0L);
     }
 

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleMetricsIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleMetricsIT.java
@@ -65,8 +65,8 @@ public class OracleMetricsIT extends AbstractMetricsTest<OracleConnector> {
     }
 
     @Override
-    protected boolean snapshotCompleted() {
-        return true;
+    protected long snapshotCompleted() {
+        return 1L;
     }
 
     @BeforeClass

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
@@ -2084,8 +2084,8 @@ public class PostgresConnectorIT extends AbstractAsyncEngineConnectorTest {
                 .until(() -> {
                     // Required due to DBZ-3158, creates empty transaction
                     TestHelper.create().execute("vacuum full").close();
-                    return (boolean) ManagementFactory.getPlatformMBeanServer()
-                            .getAttribute(getSnapshotMetricsObjectName("postgres", TestHelper.TEST_SERVER), "SnapshotCompleted");
+                    return (long) ManagementFactory.getPlatformMBeanServer()
+                            .getAttribute(getSnapshotMetricsObjectName("postgres", TestHelper.TEST_SERVER), "SnapshotCompleted") == 1L;
                 });
 
         // wait for the second streaming phase

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresMetricsIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresMetricsIT.java
@@ -82,8 +82,8 @@ public class PostgresMetricsIT extends AbstractMetricsTest<PostgresConnector> {
     }
 
     @Override
-    protected boolean snapshotCompleted() {
-        return false;
+    protected long snapshotCompleted() {
+        return 0L;
     }
 
     @Before

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/metrics/SqlServerSnapshotPartitionMetrics.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/metrics/SqlServerSnapshotPartitionMetrics.java
@@ -36,22 +36,22 @@ class SqlServerSnapshotPartitionMetrics extends AbstractSqlServerPartitionMetric
     }
 
     @Override
-    public boolean getSnapshotRunning() {
+    public long getSnapshotRunning() {
         return snapshotMeter.getSnapshotRunning();
     }
 
     @Override
-    public boolean getSnapshotPaused() {
+    public long getSnapshotPaused() {
         return snapshotMeter.getSnapshotPaused();
     }
 
     @Override
-    public boolean getSnapshotCompleted() {
+    public long getSnapshotCompleted() {
         return snapshotMeter.getSnapshotCompleted();
     }
 
     @Override
-    public boolean getSnapshotAborted() {
+    public long getSnapshotAborted() {
         return snapshotMeter.getSnapshotAborted();
     }
 

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/metrics/SqlServerStreamingTaskMetrics.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/metrics/SqlServerStreamingTaskMetrics.java
@@ -36,8 +36,8 @@ class SqlServerStreamingTaskMetrics extends AbstractSqlServerTaskMetrics<SqlServ
     }
 
     @Override
-    public long isConnected() {
-        return connectionMeter.isConnected();
+    public long getConnected() {
+        return connectionMeter.getConnected();
     }
 
     @Override

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/metrics/SqlServerStreamingTaskMetrics.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/metrics/SqlServerStreamingTaskMetrics.java
@@ -36,7 +36,7 @@ class SqlServerStreamingTaskMetrics extends AbstractSqlServerTaskMetrics<SqlServ
     }
 
     @Override
-    public boolean isConnected() {
+    public long isConnected() {
         return connectionMeter.isConnected();
     }
 

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerMetricsIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerMetricsIT.java
@@ -70,8 +70,8 @@ public class SqlServerMetricsIT extends AbstractMetricsTest<SqlServerConnector> 
     }
 
     @Override
-    protected boolean snapshotCompleted() {
-        return true;
+    protected long snapshotCompleted() {
+        return 1L;
     }
 
     @Override

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/util/TestHelper.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/util/TestHelper.java
@@ -462,7 +462,8 @@ public class TestHelper {
         try {
             Awaitility.await("Snapshot not completed").atMost(Duration.ofSeconds(60)).until(() -> {
                 try {
-                    return (boolean) mbeanServer.getAttribute(objectName, "SnapshotCompleted");
+                    Object attr = mbeanServer.getAttribute(objectName, "SnapshotCompleted");
+                    return attr instanceof Long ? (Long) attr == 1L : (Boolean) attr;
                 }
                 catch (InstanceNotFoundException e) {
                     // Metrics has not started yet
@@ -491,7 +492,8 @@ public class TestHelper {
         try {
             Awaitility.await("Streaming never started").atMost(Duration.ofSeconds(60)).until(() -> {
                 try {
-                    return (boolean) mbeanServer.getAttribute(objectName, "Connected");
+                    Object attr = mbeanServer.getAttribute(objectName, "Connected");
+                    return attr instanceof Long ? (Long) attr == 1L : (Boolean) attr;
                 }
                 catch (InstanceNotFoundException e) {
                     // Metrics has not started yet

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/util/TestHelper.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/util/TestHelper.java
@@ -462,8 +462,7 @@ public class TestHelper {
         try {
             Awaitility.await("Snapshot not completed").atMost(Duration.ofSeconds(60)).until(() -> {
                 try {
-                    Object attr = mbeanServer.getAttribute(objectName, "SnapshotCompleted");
-                    return attr instanceof Long ? (Long) attr == 1L : (Boolean) attr;
+                    return (long) mbeanServer.getAttribute(objectName, "SnapshotCompleted") == 1L;
                 }
                 catch (InstanceNotFoundException e) {
                     // Metrics has not started yet
@@ -492,8 +491,7 @@ public class TestHelper {
         try {
             Awaitility.await("Streaming never started").atMost(Duration.ofSeconds(60)).until(() -> {
                 try {
-                    Object attr = mbeanServer.getAttribute(objectName, "Connected");
-                    return attr instanceof Long ? (Long) attr == 1L : (Boolean) attr;
+                    return (long) mbeanServer.getAttribute(objectName, "Connected") == 1L;
                 }
                 catch (InstanceNotFoundException e) {
                     // Metrics has not started yet

--- a/debezium-core/src/main/java/io/debezium/pipeline/meters/ConnectionMeter.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/meters/ConnectionMeter.java
@@ -19,7 +19,7 @@ public class ConnectionMeter implements ConnectionMetricsMXBean {
     private final AtomicLong connected = new AtomicLong();
 
     @Override
-    public long isConnected() {
+    public long getConnected() {
         return this.connected.get();
     }
 

--- a/debezium-core/src/main/java/io/debezium/pipeline/meters/ConnectionMeter.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/meters/ConnectionMeter.java
@@ -5,7 +5,7 @@
  */
 package io.debezium.pipeline.meters;
 
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 
 import io.debezium.annotation.ThreadSafe;
 import io.debezium.pipeline.metrics.traits.ConnectionMetricsMXBean;
@@ -16,18 +16,18 @@ import io.debezium.pipeline.metrics.traits.ConnectionMetricsMXBean;
 @ThreadSafe
 public class ConnectionMeter implements ConnectionMetricsMXBean {
 
-    private final AtomicBoolean connected = new AtomicBoolean();
+    private final AtomicLong connected = new AtomicLong();
 
     @Override
-    public boolean isConnected() {
+    public long isConnected() {
         return this.connected.get();
     }
 
     public void connected(boolean connected) {
-        this.connected.set(connected);
+        this.connected.set(connected ? 1 : 0);
     }
 
     public void reset() {
-        connected.set(false);
+        connected.set(0);
     }
 }

--- a/debezium-core/src/main/java/io/debezium/pipeline/meters/SnapshotMeter.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/meters/SnapshotMeter.java
@@ -11,7 +11,6 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -31,10 +30,10 @@ import io.debezium.util.Clock;
 public class SnapshotMeter implements SnapshotMetricsMXBean {
     private static final Logger LOGGER = LoggerFactory.getLogger(SnapshotMeter.class);
 
-    private final AtomicBoolean snapshotRunning = new AtomicBoolean();
-    private final AtomicBoolean snapshotPaused = new AtomicBoolean();
-    private final AtomicBoolean snapshotCompleted = new AtomicBoolean();
-    private final AtomicBoolean snapshotAborted = new AtomicBoolean();
+    private final AtomicLong snapshotRunning = new AtomicLong();
+    private final AtomicLong snapshotPaused = new AtomicLong();
+    private final AtomicLong snapshotCompleted = new AtomicLong();
+    private final AtomicLong snapshotAborted = new AtomicLong();
     private final AtomicLong startTime = new AtomicLong();
     private final AtomicLong stopTime = new AtomicLong();
     private final AtomicLong startPauseTime = new AtomicLong();
@@ -69,22 +68,22 @@ public class SnapshotMeter implements SnapshotMetricsMXBean {
     }
 
     @Override
-    public boolean getSnapshotRunning() {
+    public long getSnapshotRunning() {
         return this.snapshotRunning.get();
     }
 
     @Override
-    public boolean getSnapshotPaused() {
+    public long getSnapshotPaused() {
         return this.snapshotPaused.get();
     }
 
     @Override
-    public boolean getSnapshotCompleted() {
+    public long getSnapshotCompleted() {
         return this.snapshotCompleted.get();
     }
 
     @Override
-    public boolean getSnapshotAborted() {
+    public long getSnapshotAborted() {
         return this.snapshotAborted.get();
     }
 
@@ -125,10 +124,10 @@ public class SnapshotMeter implements SnapshotMetricsMXBean {
     }
 
     public void snapshotStarted() {
-        this.snapshotRunning.set(true);
-        this.snapshotPaused.set(false);
-        this.snapshotCompleted.set(false);
-        this.snapshotAborted.set(false);
+        this.snapshotRunning.set(1);
+        this.snapshotPaused.set(0);
+        this.snapshotCompleted.set(0);
+        this.snapshotAborted.set(0);
         this.startTime.set(clock.currentTimeInMillis());
         this.stopTime.set(0L);
         this.startPauseTime.set(0);
@@ -137,19 +136,19 @@ public class SnapshotMeter implements SnapshotMetricsMXBean {
     }
 
     public void snapshotPaused() {
-        this.snapshotRunning.set(false);
-        this.snapshotPaused.set(true);
-        this.snapshotCompleted.set(false);
-        this.snapshotAborted.set(false);
+        this.snapshotRunning.set(0);
+        this.snapshotPaused.set(1);
+        this.snapshotCompleted.set(0);
+        this.snapshotAborted.set(0);
         this.startPauseTime.set(clock.currentTimeInMillis());
         this.stopPauseTime.set(0L);
     }
 
     public void snapshotResumed() {
-        this.snapshotRunning.set(true);
-        this.snapshotPaused.set(false);
-        this.snapshotCompleted.set(false);
-        this.snapshotAborted.set(false);
+        this.snapshotRunning.set(1);
+        this.snapshotPaused.set(0);
+        this.snapshotCompleted.set(0);
+        this.snapshotAborted.set(0);
         final long currTime = clock.currentTimeInMillis();
         this.stopPauseTime.set(currTime);
 
@@ -166,18 +165,18 @@ public class SnapshotMeter implements SnapshotMetricsMXBean {
     }
 
     public void snapshotCompleted() {
-        this.snapshotCompleted.set(true);
-        this.snapshotAborted.set(false);
-        this.snapshotRunning.set(false);
-        this.snapshotPaused.set(false);
+        this.snapshotCompleted.set(1);
+        this.snapshotAborted.set(0);
+        this.snapshotRunning.set(0);
+        this.snapshotPaused.set(0);
         this.stopTime.set(clock.currentTimeInMillis());
     }
 
     public void snapshotAborted() {
-        this.snapshotCompleted.set(false);
-        this.snapshotAborted.set(true);
-        this.snapshotRunning.set(false);
-        this.snapshotPaused.set(false);
+        this.snapshotCompleted.set(0);
+        this.snapshotAborted.set(1);
+        this.snapshotRunning.set(0);
+        this.snapshotPaused.set(0);
         this.stopTime.set(clock.currentTimeInMillis());
     }
 
@@ -232,10 +231,10 @@ public class SnapshotMeter implements SnapshotMetricsMXBean {
     }
 
     public void reset() {
-        snapshotRunning.set(false);
-        snapshotPaused.set(false);
-        snapshotCompleted.set(false);
-        snapshotAborted.set(false);
+        snapshotRunning.set(0);
+        snapshotPaused.set(0);
+        snapshotCompleted.set(0);
+        snapshotAborted.set(0);
         startTime.set(0);
         stopTime.set(0);
         startPauseTime.set(0);

--- a/debezium-core/src/main/java/io/debezium/pipeline/metrics/DefaultSnapshotChangeEventSourceMetrics.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/metrics/DefaultSnapshotChangeEventSourceMetrics.java
@@ -51,22 +51,22 @@ public class DefaultSnapshotChangeEventSourceMetrics<P extends Partition> extend
     }
 
     @Override
-    public boolean getSnapshotRunning() {
+    public long getSnapshotRunning() {
         return snapshotMeter.getSnapshotRunning();
     }
 
     @Override
-    public boolean getSnapshotPaused() {
+    public long getSnapshotPaused() {
         return snapshotMeter.getSnapshotPaused();
     }
 
     @Override
-    public boolean getSnapshotCompleted() {
+    public long getSnapshotCompleted() {
         return snapshotMeter.getSnapshotCompleted();
     }
 
     @Override
-    public boolean getSnapshotAborted() {
+    public long getSnapshotAborted() {
         return snapshotMeter.getSnapshotAborted();
     }
 

--- a/debezium-core/src/main/java/io/debezium/pipeline/metrics/DefaultStreamingChangeEventSourceMetrics.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/metrics/DefaultStreamingChangeEventSourceMetrics.java
@@ -52,7 +52,7 @@ public class DefaultStreamingChangeEventSourceMetrics<P extends Partition> exten
     }
 
     @Override
-    public boolean isConnected() {
+    public long isConnected() {
         return connectionMeter.isConnected();
     }
 

--- a/debezium-core/src/main/java/io/debezium/pipeline/metrics/DefaultStreamingChangeEventSourceMetrics.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/metrics/DefaultStreamingChangeEventSourceMetrics.java
@@ -52,8 +52,8 @@ public class DefaultStreamingChangeEventSourceMetrics<P extends Partition> exten
     }
 
     @Override
-    public long isConnected() {
-        return connectionMeter.isConnected();
+    public long getConnected() {
+        return connectionMeter.getConnected();
     }
 
     @Override

--- a/debezium-core/src/main/java/io/debezium/pipeline/metrics/traits/ConnectionMetricsMXBean.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/metrics/traits/ConnectionMetricsMXBean.java
@@ -10,5 +10,5 @@ package io.debezium.pipeline.metrics.traits;
  */
 public interface ConnectionMetricsMXBean {
 
-    long isConnected();
+    long getConnected();
 }

--- a/debezium-core/src/main/java/io/debezium/pipeline/metrics/traits/ConnectionMetricsMXBean.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/metrics/traits/ConnectionMetricsMXBean.java
@@ -10,5 +10,5 @@ package io.debezium.pipeline.metrics.traits;
  */
 public interface ConnectionMetricsMXBean {
 
-    boolean isConnected();
+    long isConnected();
 }

--- a/debezium-core/src/main/java/io/debezium/pipeline/metrics/traits/SnapshotMetricsMXBean.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/metrics/traits/SnapshotMetricsMXBean.java
@@ -16,13 +16,13 @@ public interface SnapshotMetricsMXBean extends SchemaMetricsMXBean {
 
     int getRemainingTableCount();
 
-    boolean getSnapshotRunning();
+    long getSnapshotRunning();
 
-    boolean getSnapshotPaused();
+    long getSnapshotPaused();
 
-    boolean getSnapshotCompleted();
+    long getSnapshotCompleted();
 
-    boolean getSnapshotAborted();
+    long getSnapshotAborted();
 
     long getSnapshotDurationInSeconds();
 

--- a/debezium-core/src/main/java/io/debezium/relational/RelationalSnapshotChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/relational/RelationalSnapshotChangeEventSource.java
@@ -5,6 +5,8 @@
  */
 package io.debezium.relational;
 
+import static io.debezium.util.Loggings.maybeRedactSensitiveData;
+
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -68,8 +70,6 @@ import io.debezium.util.ColumnUtils;
 import io.debezium.util.Strings;
 import io.debezium.util.Threads;
 import io.debezium.util.Threads.Timer;
-
-import static io.debezium.util.Loggings.maybeRedactSensitiveData;
 
 /**
  * Base class for {@link SnapshotChangeEventSource} for relational databases with or without a schema history.

--- a/debezium-core/src/main/java/io/debezium/relational/history/SchemaHistoryMXBean.java
+++ b/debezium-core/src/main/java/io/debezium/relational/history/SchemaHistoryMXBean.java
@@ -20,7 +20,7 @@ public interface SchemaHistoryMXBean {
      *
      * @return schema history component state
      */
-    String getStatus();
+    long getStatus();
 
     /**
      * @return time in epoch seconds when recovery has started

--- a/debezium-core/src/main/java/io/debezium/relational/history/SchemaHistoryMetrics.java
+++ b/debezium-core/src/main/java/io/debezium/relational/history/SchemaHistoryMetrics.java
@@ -57,8 +57,14 @@ public class SchemaHistoryMetrics extends Metrics implements SchemaHistoryListen
     }
 
     @Override
-    public String getStatus() {
-        return status.toString();
+    public long getStatus() {
+        if (status == SchemaHistoryStatus.STOPPED) {
+            return 0;
+        }
+        else if (status == SchemaHistoryStatus.RECOVERING) {
+            return 1;
+        }
+        return 2;
     }
 
     @Override

--- a/debezium-embedded/src/test/java/io/debezium/embedded/AbstractConnectorTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/embedded/AbstractConnectorTest.java
@@ -1423,8 +1423,7 @@ public abstract class AbstractConnectorTest implements Testing {
         try {
             ObjectName streamingMetricsObjectName = task != null ? getStreamingMetricsObjectName(connector, server, contextName, task)
                     : getStreamingMetricsObjectName(connector, server, contextName);
-            Object attr = mbeanServer.getAttribute(streamingMetricsObjectName, "Connected");
-            return attr instanceof Long ? (Long) attr == 1L : (Boolean) attr;
+            return (long) mbeanServer.getAttribute(streamingMetricsObjectName, "Connected") == 1L;
         }
         catch (JMException ignored) {
         }
@@ -1436,8 +1435,7 @@ public abstract class AbstractConnectorTest implements Testing {
 
         try {
             ObjectName streamingMetricsObjectName = getStreamingMetricsObjectName(connector, server, task, null, props);
-            Object attr = mbeanServer.getAttribute(streamingMetricsObjectName, "Connected");
-            return attr instanceof Long ? (Long) attr == 1L : (Boolean) attr;
+            return (long) mbeanServer.getAttribute(streamingMetricsObjectName, "Connected") == 1L;
         }
         catch (JMException ignored) {
         }

--- a/debezium-embedded/src/test/java/io/debezium/embedded/AbstractConnectorTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/embedded/AbstractConnectorTest.java
@@ -1338,8 +1338,8 @@ public abstract class AbstractConnectorTest implements Testing {
                 .pollInterval(100, TimeUnit.MILLISECONDS)
                 .atMost(waitTimeForRecords() * 30L, TimeUnit.SECONDS)
                 .ignoreException(InstanceNotFoundException.class)
-                .until(() -> (boolean) mbeanServer
-                        .getAttribute(getSnapshotMetricsObjectName(connector, server, props), "SnapshotCompleted"));
+                .until(() -> (long) mbeanServer
+                        .getAttribute(getSnapshotMetricsObjectName(connector, server, props), "SnapshotCompleted") == 1L);
     }
 
     public static void waitForSnapshotWithCustomMetricsToBeCompleted(String connector, String server, String task, String database, Map<String, String> props)
@@ -1351,8 +1351,8 @@ public abstract class AbstractConnectorTest implements Testing {
                 .pollInterval(100, TimeUnit.MILLISECONDS)
                 .atMost(waitTimeForRecords() * 30L, TimeUnit.SECONDS)
                 .ignoreException(InstanceNotFoundException.class)
-                .until(() -> (boolean) mbeanServer
-                        .getAttribute(getSnapshotMetricsObjectName(connector, server, task, database, props), "SnapshotCompleted"));
+                .until(() -> (long) mbeanServer
+                        .getAttribute(getSnapshotMetricsObjectName(connector, server, task, database, props), "SnapshotCompleted") == 1L);
     }
 
     private static void waitForSnapshotEvent(String connector, String server, String event, String task, String database) throws InterruptedException {
@@ -1363,8 +1363,8 @@ public abstract class AbstractConnectorTest implements Testing {
                 .pollInterval(100, TimeUnit.MILLISECONDS)
                 .atMost(waitTimeForRecords() * 30L, TimeUnit.SECONDS)
                 .ignoreException(InstanceNotFoundException.class)
-                .until(() -> (boolean) mbeanServer
-                        .getAttribute(getSnapshotMetricsObjectName(connector, server, task, database), event));
+                .until(() -> (long) mbeanServer
+                        .getAttribute(getSnapshotMetricsObjectName(connector, server, task, database), event) == 1L);
     }
 
     public static void waitForStreamingRunning(String connector, String server) throws InterruptedException {
@@ -1423,7 +1423,8 @@ public abstract class AbstractConnectorTest implements Testing {
         try {
             ObjectName streamingMetricsObjectName = task != null ? getStreamingMetricsObjectName(connector, server, contextName, task)
                     : getStreamingMetricsObjectName(connector, server, contextName);
-            return (boolean) mbeanServer.getAttribute(streamingMetricsObjectName, "Connected");
+            Object attr = mbeanServer.getAttribute(streamingMetricsObjectName, "Connected");
+            return attr instanceof Long ? (Long) attr == 1L : (Boolean) attr;
         }
         catch (JMException ignored) {
         }
@@ -1435,7 +1436,8 @@ public abstract class AbstractConnectorTest implements Testing {
 
         try {
             ObjectName streamingMetricsObjectName = getStreamingMetricsObjectName(connector, server, task, null, props);
-            return (boolean) mbeanServer.getAttribute(streamingMetricsObjectName, "Connected");
+            Object attr = mbeanServer.getAttribute(streamingMetricsObjectName, "Connected");
+            return attr instanceof Long ? (Long) attr == 1L : (Boolean) attr;
         }
         catch (JMException ignored) {
         }

--- a/debezium-embedded/src/test/java/io/debezium/pipeline/AbstractMetricsTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/pipeline/AbstractMetricsTest.java
@@ -50,7 +50,7 @@ public abstract class AbstractMetricsTest<T extends SourceConnector> extends Abs
 
     protected abstract long expectedEvents();
 
-    protected abstract boolean snapshotCompleted();
+    protected abstract long snapshotCompleted();
 
     protected String task() {
         return null;
@@ -208,10 +208,10 @@ public abstract class AbstractMetricsTest<T extends SourceConnector> extends Abs
         assertThat(mBeanServer.getAttribute(getSnapshotMetricsObjectName(), "CapturedTables")).isEqualTo(new String[]{ tableName() });
         assertThat(mBeanServer.getAttribute(getSnapshotMetricsObjectName(), "TotalNumberOfEventsSeen")).isEqualTo(2L);
         assertThat(mBeanServer.getAttribute(getSnapshotMetricsObjectName(), "RemainingTableCount")).isEqualTo(0);
-        assertThat(mBeanServer.getAttribute(getSnapshotMetricsObjectName(), "SnapshotRunning")).isEqualTo(false);
-        assertThat(mBeanServer.getAttribute(getSnapshotMetricsObjectName(), "SnapshotAborted")).isEqualTo(false);
-        assertThat(mBeanServer.getAttribute(getSnapshotMetricsObjectName(), "SnapshotCompleted")).isEqualTo(true);
-        assertThat(mBeanServer.getAttribute(getSnapshotMetricsObjectName(), "SnapshotPaused")).isEqualTo(false);
+        assertThat(mBeanServer.getAttribute(getSnapshotMetricsObjectName(), "SnapshotRunning")).isEqualTo(0L);
+        assertThat(mBeanServer.getAttribute(getSnapshotMetricsObjectName(), "SnapshotAborted")).isEqualTo(0L);
+        assertThat(mBeanServer.getAttribute(getSnapshotMetricsObjectName(), "SnapshotCompleted")).isEqualTo(1L);
+        assertThat(mBeanServer.getAttribute(getSnapshotMetricsObjectName(), "SnapshotPaused")).isEqualTo(0L);
         assertThat(mBeanServer.getAttribute(getSnapshotMetricsObjectName(), "SnapshotPausedDurationInSeconds")).isEqualTo(0L);
     }
 
@@ -227,10 +227,10 @@ public abstract class AbstractMetricsTest<T extends SourceConnector> extends Abs
         assertThat(mBeanServer.getAttribute(objectName, "CapturedTables")).isEqualTo(new String[]{ tableName() });
         assertThat(mBeanServer.getAttribute(objectName, "TotalNumberOfEventsSeen")).isEqualTo(2L);
         assertThat(mBeanServer.getAttribute(objectName, "RemainingTableCount")).isEqualTo(0);
-        assertThat(mBeanServer.getAttribute(objectName, "SnapshotRunning")).isEqualTo(false);
-        assertThat(mBeanServer.getAttribute(objectName, "SnapshotAborted")).isEqualTo(false);
-        assertThat(mBeanServer.getAttribute(objectName, "SnapshotCompleted")).isEqualTo(true);
-        assertThat(mBeanServer.getAttribute(objectName, "SnapshotPaused")).isEqualTo(false);
+        assertThat(mBeanServer.getAttribute(objectName, "SnapshotRunning")).isEqualTo(0L);
+        assertThat(mBeanServer.getAttribute(objectName, "SnapshotAborted")).isEqualTo(0L);
+        assertThat(mBeanServer.getAttribute(objectName, "SnapshotCompleted")).isEqualTo(1L);
+        assertThat(mBeanServer.getAttribute(objectName, "SnapshotPaused")).isEqualTo(0L);
         assertThat(mBeanServer.getAttribute(objectName, "SnapshotPausedDurationInSeconds")).isEqualTo(0L);
     }
 

--- a/debezium-embedded/src/test/java/io/debezium/pipeline/AbstractMetricsTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/pipeline/AbstractMetricsTest.java
@@ -265,7 +265,7 @@ public abstract class AbstractMetricsTest<T extends SourceConnector> extends Abs
 
         // Check streaming metrics
         Testing.print("****ASSERTIONS****");
-        assertThat(mBeanServer.getAttribute(getStreamingMetricsObjectName(), "Connected")).isEqualTo(true);
+        assertThat(mBeanServer.getAttribute(getStreamingMetricsObjectName(), "Connected")).isEqualTo(1L);
         assertThat(mBeanServer.getAttribute(getMultiplePartitionStreamingMetricsObjectName(), "TotalNumberOfCreateEventsSeen")).isEqualTo(expectedEvents);
         assertThat(mBeanServer.getAttribute(getMultiplePartitionStreamingMetricsObjectName(), "CapturedTables")).isEqualTo(new String[]{ tableName() });
 
@@ -313,7 +313,7 @@ public abstract class AbstractMetricsTest<T extends SourceConnector> extends Abs
 
         // Check streaming metrics
         Testing.print("****ASSERTIONS****");
-        assertThat(mBeanServer.getAttribute(getStreamingMetricsObjectName(connector(), server(), task(), null, customMetricTags), "Connected")).isEqualTo(true);
+        assertThat(mBeanServer.getAttribute(getStreamingMetricsObjectName(connector(), server(), task(), null, customMetricTags), "Connected")).isEqualTo(1L);
         assertThat(mBeanServer.getAttribute(getMultiplePartitionStreamingMetricsObjectNameCustomTags(customMetricTags), "TotalNumberOfCreateEventsSeen"))
                 .isEqualTo(expectedEvents);
     }

--- a/debezium-microbenchmark-engine/src/main/java/io/debezium/performance/engine/PostgresEndToEndPerf.java
+++ b/debezium-microbenchmark-engine/src/main/java/io/debezium/performance/engine/PostgresEndToEndPerf.java
@@ -236,8 +236,7 @@ public class PostgresEndToEndPerf {
                 .until(() -> {
                     final MBeanServer server = ManagementFactory.getPlatformMBeanServer();
                     try {
-                        Object attr = server.getAttribute(getMbeanName(), "Connected");
-                        return attr instanceof Long ? (Long) attr == 1L : (Boolean) attr;
+                        return (long) server.getAttribute(getMbeanName(), "Connected") == 1L;
                     }
                     catch (JMException ignored) {
                     }

--- a/debezium-microbenchmark-engine/src/main/java/io/debezium/performance/engine/PostgresEndToEndPerf.java
+++ b/debezium-microbenchmark-engine/src/main/java/io/debezium/performance/engine/PostgresEndToEndPerf.java
@@ -236,7 +236,8 @@ public class PostgresEndToEndPerf {
                 .until(() -> {
                     final MBeanServer server = ManagementFactory.getPlatformMBeanServer();
                     try {
-                        return (boolean) server.getAttribute(getMbeanName(), "Connected");
+                        Object attr = server.getAttribute(getMbeanName(), "Connected");
+                        return attr instanceof Long ? (Long) attr == 1L : (Boolean) attr;
                     }
                     catch (JMException ignored) {
                     }

--- a/debezium-microbenchmark-oracle/src/main/java/io/debezium/performance/connector/oracle/EndToEndPerf.java
+++ b/debezium-microbenchmark-oracle/src/main/java/io/debezium/performance/connector/oracle/EndToEndPerf.java
@@ -278,8 +278,7 @@ public class EndToEndPerf {
                     .until(() -> {
                         final MBeanServer server = ManagementFactory.getPlatformMBeanServer();
                         try {
-                            Object attr = server.getAttribute(getName(), "Connected");
-                            return attr instanceof Long ? (Long) attr == 1L : (Boolean) attr;
+                            return (long) server.getAttribute(getName(), "Connected") == 1L;
                         }
                         catch (JMException ignored) {
                         }

--- a/debezium-microbenchmark-oracle/src/main/java/io/debezium/performance/connector/oracle/EndToEndPerf.java
+++ b/debezium-microbenchmark-oracle/src/main/java/io/debezium/performance/connector/oracle/EndToEndPerf.java
@@ -278,7 +278,8 @@ public class EndToEndPerf {
                     .until(() -> {
                         final MBeanServer server = ManagementFactory.getPlatformMBeanServer();
                         try {
-                            return (boolean) server.getAttribute(getName(), "Connected");
+                            Object attr = server.getAttribute(getName(), "Connected");
+                            return attr instanceof Long ? (Long) attr == 1L : (Boolean) attr;
                         }
                         catch (JMException ignored) {
                         }

--- a/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/DebeziumContainer.java
+++ b/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/DebeziumContainer.java
@@ -440,7 +440,8 @@ public class DebeziumContainer extends GenericContainer<DebeziumContainer> {
                 mBeanServerConnection = connectorJmx.getMBeanServerConnection();
                 ObjectName streamingMetricsObjectName = task != null ? getStreamingMetricsObjectName(connectorTypeId, server, contextName, task)
                         : getStreamingMetricsObjectName(connectorTypeId, server, contextName);
-                return (boolean) mBeanServerConnection.getAttribute(streamingMetricsObjectName, "Connected");
+                Object attr = mBeanServerConnection.getAttribute(streamingMetricsObjectName, "Connected");
+                return attr instanceof Long ? (Long) attr == 1L : (Boolean) attr;
             }
         }
         catch (IOException e) {

--- a/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/DebeziumContainer.java
+++ b/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/DebeziumContainer.java
@@ -440,8 +440,7 @@ public class DebeziumContainer extends GenericContainer<DebeziumContainer> {
                 mBeanServerConnection = connectorJmx.getMBeanServerConnection();
                 ObjectName streamingMetricsObjectName = task != null ? getStreamingMetricsObjectName(connectorTypeId, server, contextName, task)
                         : getStreamingMetricsObjectName(connectorTypeId, server, contextName);
-                Object attr = mBeanServerConnection.getAttribute(streamingMetricsObjectName, "Connected");
-                return attr instanceof Long ? (Long) attr == 1L : (Boolean) attr;
+                return (long) mBeanServerConnection.getAttribute(streamingMetricsObjectName, "Connected") == 1L;
             }
         }
         catch (IOException e) {


### PR DESCRIPTION
## Summary

- Converts 6 JMX MBean attributes from `boolean`/`String` to `long` so the OTel JMX scraper can emit them as numeric gauges instead of stringified values:
    - `Connected` - `boolean` -> `long` (0/1)
    - `SnapshotRunning` / `SnapshotPaused` / `SnapshotCompleted` / `SnapshotAborted` - `boolean` -> `long` (0/1)
    - `SchemaHistoryMXBean.Status` - `String` -> `long` (0=STOPPED, 1=RECOVERING, 2=RUNNING)
- Renames `isConnected()` -> `getConnected()` on the connection metrics MBean and all overriding classes.
- Updates every caller to read the attributes as `long` and compare against `0L`/`1L`.

## Compatibility

- MBean attribute names are unchanged (`Connected`, `SnapshotRunning`, `Status`, …), so the downstream collectors do not need to change - they already map these to `gauge` type.

## Test plan

- CI passed on all non-flaky jobs
- Will test the fix on devel - metrics visible on Grafana