### PR TITLE
CC-40507 Remove sensitive signal data from log lines

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorConfig.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorConfig.java
@@ -1430,7 +1430,7 @@ public class MongoDbConnectorConfig extends CommonConnectorConfig implements Sha
     public Optional<String[]> parseSignallingMessage(Struct value, String fieldName) {
         final String event = value.getString(fieldName);
         if (event == null) {
-            LOGGER.warn("Field {} part of signal '{}' is missing", fieldName, value);
+            LOGGER.warn("Field {} part of signal is missing", fieldName);
             return Optional.empty();
         }
         final Document fields = Document.parse(event);

--- a/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java
+++ b/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java
@@ -2078,7 +2078,7 @@ public abstract class CommonConnectorConfig extends AbstractConfig {
         }
         List<org.apache.kafka.connect.data.Field> fields = event.schema().fields();
         if (fields.size() != 3) {
-            LOGGER.warn("The signal event '{}' should have 3 fields but has {}", event, fields.size());
+            LOGGER.warn("The signal event should have 3 fields but has {}", fields.size());
             return Optional.empty();
         }
         return Optional.of(new String[]{

--- a/debezium-core/src/main/java/io/debezium/pipeline/signal/actions/Log.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/signal/actions/Log.java
@@ -22,7 +22,7 @@ public class Log<P extends Partition> implements SignalAction<P> {
     public boolean arrived(SignalPayload<P> signalPayload) {
         final String message = signalPayload.data.getString(FIELD_MESSAGE);
         if (message == null || message.isEmpty()) {
-            LOGGER.warn("Logging signal '{}' has arrived but the requested field '{}' is missing from data", signalPayload, FIELD_MESSAGE);
+            LOGGER.warn("Logging signal '{}' has arrived but the requested field '{}' is missing from data", signalPayload.id, FIELD_MESSAGE);
             return false;
         }
         LOGGER.info(message, signalPayload.offsetContext != null ? signalPayload.offsetContext.getOffset() : "<none>");

--- a/debezium-core/src/main/java/io/debezium/pipeline/signal/actions/SchemaChanges.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/signal/actions/SchemaChanges.java
@@ -51,11 +51,11 @@ public class SchemaChanges<P extends Partition> implements SignalAction<P> {
         final String schema = signalPayload.data.getString(FIELD_SCHEMA);
 
         if (changes == null || changes.isEmpty()) {
-            LOGGER.warn("Table changes signal '{}' has arrived but the requested field '{}' is missing from data", signalPayload, FIELD_CHANGES);
+            LOGGER.warn("Table changes signal '{}' has arrived but the requested field '{}' is missing from data", signalPayload.id, FIELD_CHANGES);
             return false;
         }
         if (database == null || database.isEmpty()) {
-            LOGGER.warn("Table changes signal '{}' has arrived but the requested field '{}' is missing from data", signalPayload, FIELD_DATABASE);
+            LOGGER.warn("Table changes signal '{}' has arrived but the requested field '{}' is missing from data", signalPayload.id, FIELD_DATABASE);
             return false;
         }
         for (TableChanges.TableChange tableChange : serializer.deserialize(changes, useCatalogBeforeSchema)) {


### PR DESCRIPTION
## Summary
Removes customer-sensitive data from five log lines flagged by the AppSec SAST scan on v3.2.5-hotfix-x. The logs either emit full signal `Struct` values or the entire `SignalPayload` object. Log redactor rules on top are brittle and susceptible to code changes, so the leaky args are dropped or replaced with the already-safe `signalPayload.id`:

- `MongoDbConnectorConfig.parseSignallingMessage` — drop `value` from `"Field {} part of signal '{}' is missing"`.
- `CommonConnectorConfig.parseSignallingMessage` — drop `event` from `"The signal event '{}' should have 3 fields but has {}"`.
- `Log.arrived` — log `signalPayload.id` instead of full `signalPayload`.
- `SchemaChanges.arrived` — log `signalPayload.id` instead of full `signalPayload` in both missing-field warns.

This is the same pattern already used upstream by [PR #275 (CC-38838)](https://github.com/confluentinc/debezium/pull/275) and [PR #399 (CC-40617)](https://github.com/confluentinc/debezium/pull/399) (the latter was merged only to `v1.9.6-hotfix-x`; these specific lines remain leaky on `v3.2.5-hotfix-x`).

## Jira
- [CC-40507](https://confluentinc.atlassian.net/browse/CC-40507)

## Test plan
- [x] `./mvnw -pl debezium-core,debezium-connector-mongodb -am compile` (BUILD SUCCESS locally).
- [x] CI green on v3.2.5-hotfix-x.

[CC-40507]: https://confluentinc.atlassian.net/browse/CC-40507?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ