### PR TITLE
Add spanner hotfix branch to Semaphore branch whitelist

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -18,6 +18,7 @@ semaphore:
     - /^\d+\.\d+\.\d+\.x$/
     - /v\d+\.\d+\.\d+\-hotfix\-x/
     - /v\d+\.\d+\.\d+\-orcl\-hotfix\-x/
+    - /v\d+\.\d+\.\d+\-spanner\-hotfix\-x/
     - /^gh-readonly-queue.*/
   tasks:
     - name: create-debezium-tag


### PR DESCRIPTION
This enables Semaphore CI pipelines to trigger on v*-spanner-hotfix-x branches, allowing the debezium-core Release block to run.