### PR TITLE
Deploy original POM with debezium-core for correct transitive depende…

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -36,6 +36,7 @@ blocks:
       jobs:
         - name: Release debezium-core
           commands:
+            - cp debezium-core/pom.xml debezium-core/pom.xml.orig
             - ci-tools ci-update-version
             - ci-tools ci-push-tag
             # Build debezium-core with original groupId (io.debezium) to keep dependencies intact
@@ -50,11 +51,12 @@ blocks:
                 ls -la debezium-core/target/
                 exit 1
               fi
-            # Deploy main JAR with io.confluent groupId
+            # Deploy main JAR with io.confluent groupId, using original POM for correct transitive deps
             - mvn deploy:deploy-file
               -Durl=https://confluent-519856050701.d.codeartifact.us-west-2.amazonaws.com/maven/maven-snapshots/
               -DrepositoryId=confluent-codeartifact-internal
               -Dfile=debezium-core/target/debezium-core-${DEBEZIUM_VERSION}.jar
+              -DpomFile=debezium-core/pom.xml.orig
               -DgroupId=io.confluent
               -DartifactId=debezium-core
               -Dversion=${DEBEZIUM_VERSION}


### PR DESCRIPTION
…ncy resolution

Save the original debezium-core POM before ci-tools ci-update-version modifies all versions, then use it via -DpomFile during deploy. This ensures the deployed POM references debezium-parent:3.3.2.Final so transitive dependencies (debezium-api, debezium-common, etc.) resolve from Maven Central instead of looking for non-existent spanner versions.