### PR TITLE
CC-39714: Upgrade guava to 32.0.1-jre for CVE fixes

### DIFF
--- a/debezium-bom/pom.xml
+++ b/debezium-bom/pom.xml
@@ -17,7 +17,7 @@
 
         <!-- Connectors -->
         <version.dropwizard>4.0.1</version.dropwizard>
-        <version.guava>30.1.1-jre</version.guava>
+        <version.guava>32.0.1-jre</version.guava>
         <version.jaxb>2.3.1</version.jaxb>
         <version.jetty>9.4.12.v20180830</version.jetty>
 


### PR DESCRIPTION
## Summary
- Bumps `version.guava` in `debezium-bom/pom.xml` from `30.1.1-jre` to `32.0.1-jre`.
- Resolves the master CVE ticket [CC-39714](https://confluentinc.atlassian.net/browse/CC-39714) and the four linked vuln issues:
  - **CVE-2020-8908** (CVE-13228, CVE-16422) — `Files.createTempDir()` world-readable temp dir
  - **CVE-2023-2976** (CVE-13227, CVE-16421) — `FileBackedOutputStream` default tmpdir
- Neither vulnerable API (`Files.createTempDir`, `FileBackedOutputStream`) is referenced in the codebase, so this is a dependency-hygiene fix.

## Why 32.0.1-jre
- `32.0.0-android` (suggested by the auto-ticket) is the wrong flavor — repo uses `-jre`.
- CVE-13227 description explicitly notes 32.0.0 broke functionality on Windows; 32.0.1 is the minimum patch level that fully closes the CVE.
- Keeps us on the same major as the rest of the 1.9.7-x dep set.
- All Guava APIs actually used (`Preconditions`, `CacheBuilder/CacheLoader/LoadingCache`, `Sets.newIdentityHashSet`, `VisibleForTesting`, plus MySQL `Range*` and schema-generator `Charsets`/`Files` non-temp-dir methods) are stable across 30 → 32.0.1.

## Test plan
- [ ] Semaphore CI passes on `1.9.7.x` base
- [ ] No new unit / integration test failures attributable to the version bump
- [ ] Post-merge vuln scanner clears CC-39714 and linked CVE tickets

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CC-39714]: https://confluentinc.atlassian.net/browse/CC-39714?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ