### PR TITLE
Stabilize CI on 1.9.7.x: fix EventProcessingFailureHandlingIT and pin MySQL testcontainer

### DIFF
--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlParserIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlParserIT.java
@@ -28,7 +28,6 @@ import io.debezium.connector.mysql.junit.SkipWhenSslModeIsNot;
 import io.debezium.embedded.AbstractConnectorTest;
 import io.debezium.jdbc.JdbcConfiguration;
 import io.debezium.jdbc.JdbcConnection;
-import io.debezium.util.ContainerImageVersions;
 import io.debezium.util.Testing;
 
 /**
@@ -49,7 +48,7 @@ public class MySqlParserIT extends AbstractConnectorTest {
 
     @Before
     public void beforeEach() {
-        String mysqlImage = ContainerImageVersions.getStableImage("debezium/example-mysql");
+        String mysqlImage = "debezium/example-mysql:1.9.7.Final";
         DockerImageName mysqlDockerImageName = DockerImageName.parse(mysqlImage).asCompatibleSubstituteFor("mysql");
         mySQLContainer = new MySQLContainer<>(mysqlDockerImageName)
                 .withDatabaseName("mysql")

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/EventProcessingFailureHandlingIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/EventProcessingFailureHandlingIT.java
@@ -74,8 +74,8 @@ public class EventProcessingFailureHandlingIT extends AbstractConnectorTest {
         connection.execute("INSERT INTO tablea VALUES (1, 'seed')");
 
         SourceRecords records = consumeRecordsByTopic(1);
-        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.tablea")).hasSize(1);
-        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.tableb")).isNull();
+        Assertions.assertThat(records.recordsForTopic("server1.dbo.tablea")).hasSize(1);
+        Assertions.assertThat(records.recordsForTopic("server1.dbo.tableb")).isNull();
 
         // Will allow insertion of strings into what was originally a BIGINT NOT NULL column
         // This will cause NumberFormatExceptions which return nulls and thus an error due to the column being NOT NULL
@@ -116,8 +116,8 @@ public class EventProcessingFailureHandlingIT extends AbstractConnectorTest {
         connection.execute("INSERT INTO tablea VALUES (1, 'seed')");
 
         SourceRecords records = consumeRecordsByTopic(1);
-        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.tablea")).hasSize(1);
-        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.tableb")).isNull();
+        Assertions.assertThat(records.recordsForTopic("server1.dbo.tablea")).hasSize(1);
+        Assertions.assertThat(records.recordsForTopic("server1.dbo.tableb")).isNull();
 
         // Will allow insertion of strings into what was originally a BIGINT NOT NULL column
         // This will cause NumberFormatExceptions which return nulls and thus an error due to the column being NOT NULL
@@ -152,8 +152,8 @@ public class EventProcessingFailureHandlingIT extends AbstractConnectorTest {
         connection.execute("INSERT INTO tablea VALUES (1, 'seed')");
 
         SourceRecords records = consumeRecordsByTopic(1);
-        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.tablea")).hasSize(1);
-        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.tableb")).isNull();
+        Assertions.assertThat(records.recordsForTopic("server1.dbo.tablea")).hasSize(1);
+        Assertions.assertThat(records.recordsForTopic("server1.dbo.tableb")).isNull();
 
         // Will allow insertion of strings into what was originally a BIGINT NOT NULL column
         // This will cause NumberFormatExceptions which return nulls and thus an error due to the column being NOT NULL


### PR DESCRIPTION
## Summary
Test-only changes to restore deterministic CI on the 1.9.7.x branch. **No production code touched. No CVE/dependency changes.** The Guava CVE fix lives on its own branch (PR #437) and will be retried once CI is green here.

### 1. SqlServer — `EventProcessingFailureHandlingIT.{warn,ignore,fail}`
The first-batch assertions on `server1.testDB1.dbo.tablea` never match. `TestHelper.defaultConfig()` runs the connector in single-database mode (`database.dbname=testDB`), which emits topics as `<server>.<schema>.<table>` (i.e. `server1.dbo.tablea`), not the multi-db `<server>.<db>.<schema>.<table>` shape. The bad assertions came from upstream commit `a054ca8232` (DBZ-5525) — valid for Debezium 2.x where SQL Server became multi-db only, wrong for the 1.9 line.

Mirrors the fix already merged on `v1.9.6-hotfix-x` (commit `9691867b69`, "Fixed failing tests for SqlServer") which was never carried to `1.9.7.x`.

### 2. MySQL — `MySqlParserIT.beforeEach` testcontainer failure
`ContainerImageVersions.getStableImage("debezium/example-mysql")` queries Docker Hub at runtime for the latest `<X.Y.Z>.Final` tag. With upstream Debezium now shipping 3.x, the "stable" image resolves to `debezium/example-mysql:3.0.0.Final` (or similar), whose MySQL 8.x config is incompatible with the 1.9.7 connector's expectations. MySQL inside the container exits with code 1 during testcontainers init, `beforeEach()` aborts, and every downstream test in the runner is reported as errored — which is why each MySQL job (default, gtids, percona-server, mysql-ssl) reports large failure counts driven by a single root cause.

Pinning to `debezium/example-mysql:1.9.7.Final` (the matching connector release, confirmed to exist on Docker Hub) restores determinism. Test-only.

## Test plan
- [ ] Semaphore CI on PR passes — all five previously failing jobs (4× MySQL + SqlServer) flip green
- [ ] No regression in the two already-passing Postgres jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)