### PR TITLE
CC-41354 : Add numeric companion JMX metrics for OpenTelemetry scraping

### DIFF
--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/metrics/SqlServerSnapshotPartitionMetrics.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/metrics/SqlServerSnapshotPartitionMetrics.java
@@ -56,6 +56,11 @@ class SqlServerSnapshotPartitionMetrics extends AbstractSqlServerPartitionMetric
     }
 
     @Override
+    public long getSnapshotStatusCode() {
+        return snapshotMeter.getSnapshotStatusCode();
+    }
+
+    @Override
     public long getSnapshotDurationInSeconds() {
         return snapshotMeter.getSnapshotDurationInSeconds();
     }

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/metrics/SqlServerSnapshotPartitionMetrics.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/metrics/SqlServerSnapshotPartitionMetrics.java
@@ -56,7 +56,7 @@ class SqlServerSnapshotPartitionMetrics extends AbstractSqlServerPartitionMetric
     }
 
     @Override
-    public long getSnapshotStatusCode() {
+    public int getSnapshotStatusCode() {
         return snapshotMeter.getSnapshotStatusCode();
     }
 

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/metrics/SqlServerStreamingTaskMetrics.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/metrics/SqlServerStreamingTaskMetrics.java
@@ -41,6 +41,11 @@ class SqlServerStreamingTaskMetrics extends AbstractSqlServerTaskMetrics<SqlServ
     }
 
     @Override
+    public long getConnectedCode() {
+        return connectionMeter.getConnectedCode();
+    }
+
+    @Override
     public void connected(boolean connected) {
         connectionMeter.connected(connected);
     }

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/metrics/SqlServerStreamingTaskMetrics.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/metrics/SqlServerStreamingTaskMetrics.java
@@ -41,7 +41,7 @@ class SqlServerStreamingTaskMetrics extends AbstractSqlServerTaskMetrics<SqlServ
     }
 
     @Override
-    public long getConnectedCode() {
+    public int getConnectedCode() {
         return connectionMeter.getConnectedCode();
     }
 

--- a/debezium-core/src/main/java/io/debezium/pipeline/meters/ConnectionMeter.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/meters/ConnectionMeter.java
@@ -23,6 +23,11 @@ public class ConnectionMeter implements ConnectionMetricsMXBean {
         return this.connected.get();
     }
 
+    @Override
+    public long getConnectedCode() {
+        return this.connected.get() ? 1L : 0L;
+    }
+
     public void connected(boolean connected) {
         this.connected.set(connected);
     }

--- a/debezium-core/src/main/java/io/debezium/pipeline/meters/ConnectionMeter.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/meters/ConnectionMeter.java
@@ -24,8 +24,8 @@ public class ConnectionMeter implements ConnectionMetricsMXBean {
     }
 
     @Override
-    public long getConnectedCode() {
-        return this.connected.get() ? 1L : 0L;
+    public int getConnectedCode() {
+        return this.connected.get() ? 1 : 0;
     }
 
     public void connected(boolean connected) {

--- a/debezium-core/src/main/java/io/debezium/pipeline/meters/SnapshotMeter.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/meters/SnapshotMeter.java
@@ -89,6 +89,23 @@ public class SnapshotMeter implements SnapshotMetricsMXBean {
     }
 
     @Override
+    public long getSnapshotStatusCode() {
+        if (snapshotAborted.get()) {
+            return 4L;
+        }
+        if (snapshotCompleted.get()) {
+            return 3L;
+        }
+        if (snapshotPaused.get()) {
+            return 2L;
+        }
+        if (snapshotRunning.get()) {
+            return 1L;
+        }
+        return 0L;
+    }
+
+    @Override
     public long getSnapshotDurationInSeconds() {
         final long startMillis = startTime.get();
         if (startMillis <= 0L) {

--- a/debezium-core/src/main/java/io/debezium/pipeline/meters/SnapshotMeter.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/meters/SnapshotMeter.java
@@ -31,11 +31,11 @@ import io.debezium.util.Clock;
 public class SnapshotMeter implements SnapshotMetricsMXBean {
     private static final Logger LOGGER = LoggerFactory.getLogger(SnapshotMeter.class);
 
-    public static final long SNAPSHOT_NOT_STARTED = 0L;
-    public static final long SNAPSHOT_RUNNING = 1L;
-    public static final long SNAPSHOT_PAUSED = 2L;
-    public static final long SNAPSHOT_COMPLETED = 3L;
-    public static final long SNAPSHOT_ABORTED = 4L;
+    public static final int SNAPSHOT_NOT_STARTED = 0;
+    public static final int SNAPSHOT_RUNNING = 1;
+    public static final int SNAPSHOT_PAUSED = 2;
+    public static final int SNAPSHOT_COMPLETED = 3;
+    public static final int SNAPSHOT_ABORTED = 4;
 
     private final AtomicBoolean snapshotRunning = new AtomicBoolean();
     private final AtomicBoolean snapshotPaused = new AtomicBoolean();
@@ -95,7 +95,7 @@ public class SnapshotMeter implements SnapshotMetricsMXBean {
     }
 
     @Override
-    public long getSnapshotStatusCode() {
+    public int getSnapshotStatusCode() {
         if (snapshotAborted.get()) {
             return SNAPSHOT_ABORTED;
         }

--- a/debezium-core/src/main/java/io/debezium/pipeline/meters/SnapshotMeter.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/meters/SnapshotMeter.java
@@ -31,6 +31,12 @@ import io.debezium.util.Clock;
 public class SnapshotMeter implements SnapshotMetricsMXBean {
     private static final Logger LOGGER = LoggerFactory.getLogger(SnapshotMeter.class);
 
+    public static final long SNAPSHOT_NOT_STARTED = 0L;
+    public static final long SNAPSHOT_RUNNING = 1L;
+    public static final long SNAPSHOT_PAUSED = 2L;
+    public static final long SNAPSHOT_COMPLETED = 3L;
+    public static final long SNAPSHOT_ABORTED = 4L;
+
     private final AtomicBoolean snapshotRunning = new AtomicBoolean();
     private final AtomicBoolean snapshotPaused = new AtomicBoolean();
     private final AtomicBoolean snapshotCompleted = new AtomicBoolean();
@@ -91,18 +97,18 @@ public class SnapshotMeter implements SnapshotMetricsMXBean {
     @Override
     public long getSnapshotStatusCode() {
         if (snapshotAborted.get()) {
-            return 4L;
+            return SNAPSHOT_ABORTED;
         }
         if (snapshotCompleted.get()) {
-            return 3L;
+            return SNAPSHOT_COMPLETED;
         }
         if (snapshotPaused.get()) {
-            return 2L;
+            return SNAPSHOT_PAUSED;
         }
         if (snapshotRunning.get()) {
-            return 1L;
+            return SNAPSHOT_RUNNING;
         }
-        return 0L;
+        return SNAPSHOT_NOT_STARTED;
     }
 
     @Override

--- a/debezium-core/src/main/java/io/debezium/pipeline/metrics/DefaultSnapshotChangeEventSourceMetrics.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/metrics/DefaultSnapshotChangeEventSourceMetrics.java
@@ -71,6 +71,11 @@ public class DefaultSnapshotChangeEventSourceMetrics<P extends Partition> extend
     }
 
     @Override
+    public long getSnapshotStatusCode() {
+        return snapshotMeter.getSnapshotStatusCode();
+    }
+
+    @Override
     public long getSnapshotDurationInSeconds() {
         return snapshotMeter.getSnapshotDurationInSeconds();
     }

--- a/debezium-core/src/main/java/io/debezium/pipeline/metrics/DefaultSnapshotChangeEventSourceMetrics.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/metrics/DefaultSnapshotChangeEventSourceMetrics.java
@@ -71,7 +71,7 @@ public class DefaultSnapshotChangeEventSourceMetrics<P extends Partition> extend
     }
 
     @Override
-    public long getSnapshotStatusCode() {
+    public int getSnapshotStatusCode() {
         return snapshotMeter.getSnapshotStatusCode();
     }
 

--- a/debezium-core/src/main/java/io/debezium/pipeline/metrics/DefaultStreamingChangeEventSourceMetrics.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/metrics/DefaultStreamingChangeEventSourceMetrics.java
@@ -57,6 +57,11 @@ public class DefaultStreamingChangeEventSourceMetrics<P extends Partition> exten
     }
 
     @Override
+    public long getConnectedCode() {
+        return connectionMeter.getConnectedCode();
+    }
+
+    @Override
     public String[] getCapturedTables() {
         return streamingMeter.getCapturedTables();
     }

--- a/debezium-core/src/main/java/io/debezium/pipeline/metrics/DefaultStreamingChangeEventSourceMetrics.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/metrics/DefaultStreamingChangeEventSourceMetrics.java
@@ -57,7 +57,7 @@ public class DefaultStreamingChangeEventSourceMetrics<P extends Partition> exten
     }
 
     @Override
-    public long getConnectedCode() {
+    public int getConnectedCode() {
         return connectionMeter.getConnectedCode();
     }
 

--- a/debezium-core/src/main/java/io/debezium/pipeline/metrics/traits/ConnectionMetricsMXBean.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/metrics/traits/ConnectionMetricsMXBean.java
@@ -11,4 +11,7 @@ package io.debezium.pipeline.metrics.traits;
 public interface ConnectionMetricsMXBean {
 
     boolean isConnected();
+
+    /** Numeric companion to {@link #isConnected()}: 1 when connected, 0 otherwise. */
+    long getConnectedCode();
 }

--- a/debezium-core/src/main/java/io/debezium/pipeline/metrics/traits/ConnectionMetricsMXBean.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/metrics/traits/ConnectionMetricsMXBean.java
@@ -13,5 +13,5 @@ public interface ConnectionMetricsMXBean {
     boolean isConnected();
 
     /** Numeric companion to {@link #isConnected()}: 1 when connected, 0 otherwise. */
-    long getConnectedCode();
+    int getConnectedCode();
 }

--- a/debezium-core/src/main/java/io/debezium/pipeline/metrics/traits/SnapshotMetricsMXBean.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/metrics/traits/SnapshotMetricsMXBean.java
@@ -24,6 +24,12 @@ public interface SnapshotMetricsMXBean extends SchemaMetricsMXBean {
 
     boolean getSnapshotAborted();
 
+    /**
+     * Numeric companion to the four boolean snapshot state attributes:
+     * 0=NOT_STARTED, 1=RUNNING, 2=PAUSED, 3=COMPLETED, 4=ABORTED.
+     */
+    long getSnapshotStatusCode();
+
     long getSnapshotDurationInSeconds();
 
     long getSnapshotPausedDurationInSeconds();

--- a/debezium-core/src/main/java/io/debezium/pipeline/metrics/traits/SnapshotMetricsMXBean.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/metrics/traits/SnapshotMetricsMXBean.java
@@ -25,8 +25,9 @@ public interface SnapshotMetricsMXBean extends SchemaMetricsMXBean {
     boolean getSnapshotAborted();
 
     /**
-     * Numeric companion to the four boolean snapshot state attributes:
-     * 0=NOT_STARTED, 1=RUNNING, 2=PAUSED, 3=COMPLETED, 4=ABORTED.
+     * Numeric companion to the four boolean snapshot state attributes. Required because the
+     * OpenTelemetry JMX scraper only forwards numeric MBean attributes.
+     * Encoding: 0=NOT_STARTED, 1=RUNNING, 2=PAUSED, 3=COMPLETED, 4=ABORTED.
      */
     long getSnapshotStatusCode();
 

--- a/debezium-core/src/main/java/io/debezium/pipeline/metrics/traits/SnapshotMetricsMXBean.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/metrics/traits/SnapshotMetricsMXBean.java
@@ -29,7 +29,7 @@ public interface SnapshotMetricsMXBean extends SchemaMetricsMXBean {
      * OpenTelemetry JMX scraper only forwards numeric MBean attributes.
      * Encoding: 0=NOT_STARTED, 1=RUNNING, 2=PAUSED, 3=COMPLETED, 4=ABORTED.
      */
-    long getSnapshotStatusCode();
+    int getSnapshotStatusCode();
 
     long getSnapshotDurationInSeconds();
 

--- a/debezium-core/src/main/java/io/debezium/relational/history/SchemaHistoryMXBean.java
+++ b/debezium-core/src/main/java/io/debezium/relational/history/SchemaHistoryMXBean.java
@@ -22,6 +22,9 @@ public interface SchemaHistoryMXBean {
      */
     String getStatus();
 
+    /** Numeric companion to {@link #getStatus()}: 0=STOPPED, 1=RECOVERING, 2=RUNNING. */
+    long getStatusCode();
+
     /**
      * @return time in epoch seconds when recovery has started
      */

--- a/debezium-core/src/main/java/io/debezium/relational/history/SchemaHistoryMXBean.java
+++ b/debezium-core/src/main/java/io/debezium/relational/history/SchemaHistoryMXBean.java
@@ -23,7 +23,7 @@ public interface SchemaHistoryMXBean {
     String getStatus();
 
     /** Numeric companion to {@link #getStatus()}: 0=STOPPED, 1=RECOVERING, 2=RUNNING. */
-    long getStatusCode();
+    int getStatusCode();
 
     /**
      * @return time in epoch seconds when recovery has started

--- a/debezium-core/src/main/java/io/debezium/relational/history/SchemaHistoryMetrics.java
+++ b/debezium-core/src/main/java/io/debezium/relational/history/SchemaHistoryMetrics.java
@@ -62,6 +62,20 @@ public class SchemaHistoryMetrics extends Metrics implements SchemaHistoryListen
     }
 
     @Override
+    public long getStatusCode() {
+        switch (status) {
+            case STOPPED:
+                return 0L;
+            case RECOVERING:
+                return 1L;
+            case RUNNING:
+                return 2L;
+            default:
+                throw new IllegalStateException("Unknown SchemaHistoryStatus: " + status);
+        }
+    }
+
+    @Override
     public long getRecoveryStartTime() {
         return recoveryStartTime == null ? -1 : recoveryStartTime.getEpochSecond();
     }

--- a/debezium-core/src/main/java/io/debezium/relational/history/SchemaHistoryMetrics.java
+++ b/debezium-core/src/main/java/io/debezium/relational/history/SchemaHistoryMetrics.java
@@ -62,14 +62,14 @@ public class SchemaHistoryMetrics extends Metrics implements SchemaHistoryListen
     }
 
     @Override
-    public long getStatusCode() {
+    public int getStatusCode() {
         switch (status) {
             case STOPPED:
-                return 0L;
+                return 0;
             case RECOVERING:
-                return 1L;
+                return 1;
             case RUNNING:
-                return 2L;
+                return 2;
             default:
                 throw new IllegalStateException("Unknown SchemaHistoryStatus: " + status);
         }

--- a/debezium-core/src/test/java/io/debezium/metrics/NumericMetricsRegistrationTest.java
+++ b/debezium-core/src/test/java/io/debezium/metrics/NumericMetricsRegistrationTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.management.ManagementFactory;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import javax.management.MBeanAttributeInfo;
+import javax.management.MBeanInfo;
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+
+import org.junit.After;
+import org.junit.Test;
+
+import io.debezium.config.CommonConnectorConfig;
+import io.debezium.config.Configuration;
+import io.debezium.config.EnumeratedValue;
+import io.debezium.connector.SourceInfoStructMaker;
+import io.debezium.relational.history.SchemaHistoryMetrics;
+
+public class NumericMetricsRegistrationTest {
+
+    private SchemaHistoryMetrics metrics;
+
+    @After
+    public void cleanup() {
+        if (metrics != null) {
+            metrics.stopped();
+        }
+    }
+
+    @Test
+    public void schemaHistoryExposesBothStatusAndStatusCode() throws Exception {
+        metrics = new SchemaHistoryMetrics(testConfig(), false);
+        metrics.started();
+
+        MBeanInfo info = mbeanInfo();
+        assertThat(attributeType(info, "Status")).isEqualTo("java.lang.String");
+        assertThat(attributeType(info, "StatusCode")).isEqualTo("long");
+    }
+
+    @Test
+    public void statusCodeReflectsLifecycleTransitions() throws Exception {
+        metrics = new SchemaHistoryMetrics(testConfig(), false);
+        metrics.started();
+
+        MBeanServer mbeanServer = ManagementFactory.getPlatformMBeanServer();
+        ObjectName name = objectName();
+
+        assertThat((Long) mbeanServer.getAttribute(name, "StatusCode")).isEqualTo(2L);
+        assertThat((String) mbeanServer.getAttribute(name, "Status")).isEqualTo("RUNNING");
+
+        metrics.recoveryStarted();
+        assertThat((Long) mbeanServer.getAttribute(name, "StatusCode")).isEqualTo(1L);
+        assertThat((String) mbeanServer.getAttribute(name, "Status")).isEqualTo("RECOVERING");
+
+        metrics.recoveryStopped();
+        assertThat((Long) mbeanServer.getAttribute(name, "StatusCode")).isEqualTo(2L);
+        assertThat((String) mbeanServer.getAttribute(name, "Status")).isEqualTo("RUNNING");
+    }
+
+    private static MBeanInfo mbeanInfo() throws Exception {
+        return ManagementFactory.getPlatformMBeanServer().getMBeanInfo(objectName());
+    }
+
+    private static ObjectName objectName() throws Exception {
+        return new ObjectName(
+                "debezium.test:type=connector-metrics,context=schema-history,server=test-server");
+    }
+
+    private static String attributeType(MBeanInfo info, String name) {
+        for (MBeanAttributeInfo a : info.getAttributes()) {
+            if (a.getName().equals(name)) {
+                return a.getType();
+            }
+        }
+        throw new AssertionError("attribute " + name + " not exposed; have: "
+                + Arrays.stream(info.getAttributes()).map(MBeanAttributeInfo::getName).collect(Collectors.toSet()));
+    }
+
+    private static CommonConnectorConfig testConfig() {
+        Configuration cfg = Configuration.create()
+                .with(CommonConnectorConfig.TOPIC_PREFIX, "test-server")
+                .build();
+        return new TestConnectorConfig(cfg);
+    }
+
+    private static final class TestConnectorConfig extends CommonConnectorConfig {
+
+        private TestConnectorConfig(Configuration config) {
+            super(config, 0);
+        }
+
+        @Override
+        public String getContextName() {
+            return "test";
+        }
+
+        @Override
+        public String getConnectorName() {
+            return "test";
+        }
+
+        @Override
+        public EnumeratedValue getSnapshotMode() {
+            return null;
+        }
+
+        @Override
+        public Optional<EnumeratedValue> getSnapshotLockingMode() {
+            return Optional.empty();
+        }
+
+        @Override
+        protected SourceInfoStructMaker<?> getSourceInfoStructMaker(Version version) {
+            return null;
+        }
+    }
+}

--- a/debezium-core/src/test/java/io/debezium/metrics/NumericMetricsRegistrationTest.java
+++ b/debezium-core/src/test/java/io/debezium/metrics/NumericMetricsRegistrationTest.java
@@ -44,7 +44,7 @@ public class NumericMetricsRegistrationTest {
 
         MBeanInfo info = mbeanInfo();
         assertThat(attributeType(info, "Status")).isEqualTo("java.lang.String");
-        assertThat(attributeType(info, "StatusCode")).isEqualTo("long");
+        assertThat(attributeType(info, "StatusCode")).isEqualTo("int");
     }
 
     @Test
@@ -55,15 +55,15 @@ public class NumericMetricsRegistrationTest {
         MBeanServer mbeanServer = ManagementFactory.getPlatformMBeanServer();
         ObjectName name = objectName();
 
-        assertThat((Long) mbeanServer.getAttribute(name, "StatusCode")).isEqualTo(2L);
+        assertThat((Integer) mbeanServer.getAttribute(name, "StatusCode")).isEqualTo(2);
         assertThat((String) mbeanServer.getAttribute(name, "Status")).isEqualTo("RUNNING");
 
         metrics.recoveryStarted();
-        assertThat((Long) mbeanServer.getAttribute(name, "StatusCode")).isEqualTo(1L);
+        assertThat((Integer) mbeanServer.getAttribute(name, "StatusCode")).isEqualTo(1);
         assertThat((String) mbeanServer.getAttribute(name, "Status")).isEqualTo("RECOVERING");
 
         metrics.recoveryStopped();
-        assertThat((Long) mbeanServer.getAttribute(name, "StatusCode")).isEqualTo(2L);
+        assertThat((Integer) mbeanServer.getAttribute(name, "StatusCode")).isEqualTo(2);
         assertThat((String) mbeanServer.getAttribute(name, "Status")).isEqualTo("RUNNING");
     }
 


### PR DESCRIPTION
JIRA: https://confluentinc.atlassian.net/browse/CC-41354

## Summary
The OpenTelemetry JMX agent silently drops `boolean/String` MBean attributes, blocking exposure of six metrics (Connected, SnapshotRunning/Paused/Completed/Aborted, schema-history Status) on cloud.

Add three long-typed companion attributes that sit alongside the existing legacy ones.

| MBean | New attribute | Encoding |                      
  |---|---|---|
  | streaming | `ConnectedCode` | `0`=disconnected, `1`=connected |
  | snapshot | `SnapshotStatusCode` | `0=NOT_STARTED, 1=RUNNING, 2=PAUSED, 3=COMPLETED, 4=ABORTED` (priority: aborted > completed > paused > running > not-started) |                                                                                                       
  | schema-history | `StatusCode` | `0=STOPPED, 1=RECOVERING, 2=RUNNING` |

The four Snapshot* booleans are collapsed into a single `SnapshotStatusCode`.

## Test plan

- New unit test `NumericMetricsRegistrationTest` - asserts original and numeric metrics coexist on the platform MBean server.
- Validated on KDP - released connector with original metrics and the connector with additional numeric metrics:
<img width="1659" height="305" alt="Screenshot 2026-05-14 at 1 29 04 PM" src="https://github.com/user-attachments/assets/fa1cb83e-c530-481c-ab50-451907365a0a" />

Before (Released connector):
<img width="810" height="934" alt="Screenshot 2026-05-14 at 3 09 55 PM" src="https://github.com/user-attachments/assets/2cfa031d-d1d2-40c4-ace2-f0aefc98e9ab" />
<img width="810" height="918" alt="Screenshot 2026-05-14 at 3 10 11 PM" src="https://github.com/user-attachments/assets/307b8120-dd1f-46e8-b15f-04de39c62cb4" />
<img width="806" height="290" alt="Screenshot 2026-05-14 at 3 10 32 PM" src="https://github.com/user-attachments/assets/931165bb-5e3f-46d0-973b-1c17a0c83b7d" />

After (Connector with numeric metrics):
<img width="811" height="898" alt="Screenshot 2026-05-14 at 3 15 45 PM" src="https://github.com/user-attachments/assets/3a9bf234-960b-49aa-8ee2-814a1d8a9a16" />
<img width="803" height="899" alt="Screenshot 2026-05-14 at 3 16 17 PM" src="https://github.com/user-attachments/assets/989c0d6f-bb4d-4980-b8b4-e662e73dcc29" />
<img width="818" height="310" alt="Screenshot 2026-05-14 at 3 16 57 PM" src="https://github.com/user-attachments/assets/779bebae-f1e2-4105-a3f3-890b64f785da" />
<img width="734" height="142" alt="Screenshot 2026-05-14 at 3 17 06 PM" src="https://github.com/user-attachments/assets/8afb4908-3f60-4fd3-bd83-cb6cdea5ddd0" />

