### PR TITLE
Reset connect task DND on snapshotAborted

### DIFF
--- a/debezium-core/src/main/java/io/debezium/pipeline/meters/SnapshotMeter.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/meters/SnapshotMeter.java
@@ -191,6 +191,7 @@ public class SnapshotMeter implements SnapshotMetricsMXBean {
         this.snapshotRunning.set(0);
         this.snapshotPaused.set(0);
         this.snapshotSkipped.set(0);
+        this.taskStateMetrics.setConnectTaskDnd(0);
         this.stopTime.set(clock.currentTimeInMillis());
     }
 


### PR DESCRIPTION
Set `setConnectTaskDnd(0)` in `SnapshotMeter.snapshotAborted()`.

This used to [exist](https://github.com/confluentinc/debezium/pull/238/changes) in the `v3.0.8-hotfix-x` but seems to have been missed in the port/cherrypick. 