### PR TITLE
CC-41012: Remove sensitive log data from EventRouter logs - V1 connectors

### DIFF
--- a/debezium-core/src/main/java/io/debezium/transforms/outbox/EventRouterDelegate.java
+++ b/debezium-core/src/main/java/io/debezium/transforms/outbox/EventRouterDelegate.java
@@ -83,7 +83,7 @@ public class EventRouterDelegate<R extends ConnectRecord<R>> {
     public R apply(R r, RecordConverter<R> recordConverter) {
         // Ignoring tombstones
         if (r.value() == null) {
-            LOGGER.debug("Tombstone message ignored. Message key: \"{}\"", r.key());
+            LOGGER.debug("Tombstone message ignored.");
             return null;
         }
 
@@ -98,7 +98,7 @@ public class EventRouterDelegate<R extends ConnectRecord<R>> {
 
         // Skipping deletes
         if (op.equals(Envelope.Operation.DELETE.code())) {
-            LOGGER.debug("Delete message {} ignored", r.key());
+            LOGGER.debug("Delete message ignored");
             return null;
         }
 
@@ -153,7 +153,7 @@ public class EventRouterDelegate<R extends ConnectRecord<R>> {
         // Check to expand JSON string into real JSON.
         if (expandJsonPayload) {
             if (!(payload instanceof String)) {
-                LOGGER.warn("Expand JSON payload is turned on but payload is not a string in {}", r.key());
+                LOGGER.warn("Expand JSON payload is turned on but payload is not a string");
             }
             else {
                 final String payloadString = (String) payload;
@@ -228,7 +228,7 @@ public class EventRouterDelegate<R extends ConnectRecord<R>> {
                 timestamp,
                 headers);
 
-        LOGGER.debug("Message emitted with event id: \"{}\", event key: \"{}\"", eventId, recordKey);
+        LOGGER.debug("Message emitted");
 
         final Matcher matcher = routeTopicRegex.matcher(newRecord.topic());
         if (matcher.matches()) {
@@ -308,13 +308,13 @@ public class EventRouterDelegate<R extends ConnectRecord<R>> {
     private void handleUnexpectedOperation(R r) {
         switch (invalidOperationBehavior) {
             case SKIP_AND_WARN:
-                LOGGER.warn("Unexpected update message received {} and ignored", r.key());
+                LOGGER.warn("Unexpected update message received and ignored");
                 break;
             case SKIP_AND_ERROR:
-                LOGGER.error("Unexpected update message received {} and ignored", r.key());
+                LOGGER.error("Unexpected update message received and ignored");
                 break;
             case FATAL:
-                throw new IllegalStateException(String.format("Unexpected update message received %s, fail.", r.key()));
+                throw new IllegalStateException("Unexpected update message received, fail.");
         }
     }
 


### PR DESCRIPTION
Following the logredactor rules in : https://confluentinc.atlassian.net/browse/CC-41012

Removing sensitive log data from the logs. 