### PR TITLE
CC-41012: Remove sensitive log data from EventRouter logs - Oracle XStream

### DIFF
--- a/debezium-core/src/main/java/io/debezium/transforms/outbox/EventRouterDelegate.java
+++ b/debezium-core/src/main/java/io/debezium/transforms/outbox/EventRouterDelegate.java
@@ -323,7 +323,7 @@ public class EventRouterDelegate<R extends ConnectRecord<R>> {
                 LOGGER.error("Unexpected update message received {} and ignored", maybeRedactSensitiveData(r.key()));
                 break;
             case FATAL:
-                throw new IllegalStateException(String.format("Unexpected update message received %s, fail.", r.key()));
+                throw new IllegalStateException(String.format("Unexpected update message received %s, fail.", maybeRedactSensitiveData(r.key())));
         }
     }
 

--- a/debezium-core/src/main/java/io/debezium/transforms/outbox/JsonSchemaData.java
+++ b/debezium-core/src/main/java/io/debezium/transforms/outbox/JsonSchemaData.java
@@ -5,6 +5,8 @@
  */
 package io.debezium.transforms.outbox;
 
+import static io.debezium.util.Loggings.maybeRedactSensitiveData;
+
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -108,7 +110,7 @@ public class JsonSchemaData {
         else {
             schema = toConnectSchema(null, sample);
             if (schema == null) {
-                throw new ConnectException(String.format("Array '%s' has unrecognized member schema.", array.asText()));
+                throw new ConnectException(String.format("Array '%s' has unrecognized member schema.", maybeRedactSensitiveData(array.asText())));
             }
         }
 


### PR DESCRIPTION
`maybeRedactSensitiveData` automatically redacts sensitive data from the logs if TRACE logging is not set. This TRACE logging level is set on the `Loggings.java` class. Cloud blocks TRACE level being set for that class ([ref](https://github.com/confluentinc/cc-terraform-shoreline/pull/1691)) so the logs are safe on cloud.

Identified some other logs lines that could be risky. Wrapped them with `maybeRedactSensitiveData`.

https://confluentinc.atlassian.net/browse/CC-41012