### PR TITLE
CC-41009: Redact sensitive data in CDC log lines - V2 connectors

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorConfig.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorConfig.java
@@ -1435,7 +1435,7 @@ public class MongoDbConnectorConfig extends CommonConnectorConfig implements Sha
         }
         final Document fields = Document.parse(event);
         if (fields.size() != 3) {
-            LOGGER.warn("The signal event '{}' should have 3 fields but has {}", event, fields.size());
+            LOGGER.warn("The signal event should have 3 fields but has {}", fields.size());
             return Optional.empty();
         }
         final String[] result = new String[3];

--- a/debezium-core/src/main/java/io/debezium/jdbc/JdbcConnection.java
+++ b/debezium-core/src/main/java/io/debezium/jdbc/JdbcConnection.java
@@ -5,6 +5,8 @@
  */
 package io.debezium.jdbc;
 
+import static io.debezium.util.Loggings.maybeRedactSensitiveData;
+
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -435,7 +437,7 @@ public class JdbcConnection implements AutoCloseable {
             for (String sqlStatement : sqlStatements) {
                 if (sqlStatement != null) {
                     if (LOGGER.isTraceEnabled()) {
-                        LOGGER.trace("executing '{}'", sqlStatement);
+                        LOGGER.trace("executing '{}'", maybeRedactSensitiveData(sqlStatement));
                     }
 
                     statement.execute(sqlStatement);
@@ -709,7 +711,7 @@ public class JdbcConnection implements AutoCloseable {
         preparer.accept(statement);
         statement.setQueryTimeout(queryTimeout);
         if (LOGGER.isTraceEnabled()) {
-            LOGGER.trace("Executing '{}' with {}s timeout", preparedQueryString, queryTimeout);
+            LOGGER.trace("Executing '{}' with {}s timeout", maybeRedactSensitiveData(preparedQueryString), queryTimeout);
         }
         try (ResultSet resultSet = statement.executeQuery()) {
             if (resultConsumer != null) {
@@ -791,7 +793,7 @@ public class JdbcConnection implements AutoCloseable {
         }
         statement.setQueryTimeout(queryTimeout);
         if (LOGGER.isTraceEnabled()) {
-            LOGGER.trace("Executing statement '{}' with {}s timeout", stmt, queryTimeout);
+            LOGGER.trace("Executing statement '{}' with {}s timeout", maybeRedactSensitiveData(stmt), queryTimeout);
         }
 
         try {
@@ -1586,7 +1588,7 @@ public class JdbcConnection implements AutoCloseable {
             statement.setQueryTimeout(queryTimeout);
             for (String stmt : statements) {
                 if (LOGGER.isTraceEnabled()) {
-                    LOGGER.trace("Executing statement '{}' with {}s timeout", stmt, queryTimeout);
+                    LOGGER.trace("Executing statement '{}' with {}s timeout", maybeRedactSensitiveData(stmt), queryTimeout);
                 }
                 statement.execute(stmt);
             }

--- a/debezium-core/src/main/java/io/debezium/pipeline/signal/actions/snapshotting/ExecuteSnapshot.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/signal/actions/snapshotting/ExecuteSnapshot.java
@@ -5,6 +5,8 @@
  */
 package io.debezium.pipeline.signal.actions.snapshotting;
 
+import static io.debezium.util.Loggings.maybeRedactSensitiveData;
+
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -63,7 +65,7 @@ public class ExecuteSnapshot<P extends Partition> extends AbstractSnapshotSignal
         Optional<String> surrogateKey = getSurrogateKey(signalPayload.data);
 
         LOGGER.info("Requested '{}' snapshot of data collections '{}' with additional conditions '{}' and surrogate key '{}'",
-                type, dataCollections, additionalConditions, surrogateKey.orElse("PK of table will be used"));
+                type, dataCollections, maybeRedactSensitiveData(additionalConditions), surrogateKey.orElse("PK of table will be used"));
 
         SnapshotConfiguration.Builder snapsthoConfigurationBuilder = SnapshotConfiguration.Builder.builder();
         snapsthoConfigurationBuilder.dataCollections(dataCollections);
@@ -117,7 +119,7 @@ public class ExecuteSnapshot<P extends Partition> extends AbstractSnapshotSignal
         if (dataCollectionsArray == null || dataCollectionsArray.isEmpty()) {
             LOGGER.warn(
                     "Execute snapshot signal '{}' has arrived but the requested field '{}' is missing from data or is empty",
-                    data, FIELD_DATA_COLLECTIONS);
+                    maybeRedactSensitiveData(data), FIELD_DATA_COLLECTIONS);
             return null;
         }
         return dataCollectionsArray.streamValues()

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotChangeEventSource.java
@@ -436,7 +436,7 @@ public abstract class AbstractIncrementalSnapshotChangeEventSource<P extends Par
 
     private Table readSchema() {
         final String selectStatement = chunkQueryBuilder.buildChunkQuery(context, currentTable, 0, Optional.empty());
-        LOGGER.debug("Reading schema for table '{}' using select statement: '{}'", currentTable.id(), selectStatement);
+        LOGGER.debug("Reading schema for table '{}' using select statement: '{}'", currentTable.id(), maybeRedactSensitiveData(selectStatement));
 
         try (PreparedStatement statement = chunkQueryBuilder.readTableChunkStatement(context, currentTable, selectStatement);
                 ResultSet rs = statement.executeQuery()) {
@@ -584,7 +584,7 @@ public abstract class AbstractIncrementalSnapshotChangeEventSource<P extends Par
 
         final String selectStatement = chunkQueryBuilder.buildChunkQuery(context, currentTable, context.currentDataCollectionId().getAdditionalCondition());
         LOGGER.debug("\t For table '{}' using select statement: '{}', key: '{}', maximum key: '{}'", currentTable.id(),
-                selectStatement, context.chunkEndPosititon(), maybeRedactSensitiveData(context.maximumKey().get()));
+                maybeRedactSensitiveData(selectStatement), context.chunkEndPosititon(), maybeRedactSensitiveData(context.maximumKey().get()));
 
         final TableSchema tableSchema = databaseSchema.schemaFor(currentTable.id());
 


### PR DESCRIPTION
## Summary

In-code redaction (via `Loggings.maybeRedactSensitiveData`) is added to log lines that today are only masked by upstream CDC logredactor rules. Once this lands the matching upstream rules (see [CC-41009](https://confluentinc.atlassian.net/browse/CC-41009)) can be removed.

Changes:
- `AbstractIncrementalSnapshotChangeEventSource` — redact `selectStatement` in the incremental snapshot `"For table … using select statement: …"` and `"Reading schema for table … using select statement: …"` debug logs.
- `ExecuteSnapshot` — redact `additionalConditions` in the `"Requested … snapshot of data collections …"` info log, and redact the raw `data` Document in the `"Execute snapshot signal … has arrived but the requested field … is missing"` warning.
- `JdbcConnection` — redact `sqlStatement` / `preparedQueryString` / `stmt` in the four TRACE-level `executing`/`Executing statement` logs.
- `MongoDbConnectorConfig` — drop the raw signal event from the `"The signal event … should have 3 fields"` warning, mirroring the fix already applied to `CommonConnectorConfig` in CC-40507.

### Coverage of the upstream rules

| Upstream rule trigger | Status after this PR |
|---|---|
| `Received signal … data = '…'` | Already non-matching (log no longer contains `data`); upstream rule can be removed. |
| `For table … select statement: '…'` | Redacted: relational (#359) + incremental (this PR). |
| `Requested 'BLOCKING' snapshot … additional conditions '…' and surrogate key` | Redacted in this PR (covers both `BLOCKING` and `INCREMENTAL`). |
| `executing '…'` | All four `JdbcConnection` TRACE call-sites redacted in this PR. |
| `Execute snapshot signal '…' has` | Redacted in this PR. |
| `Signal '…' has been received but the data '…' cannot` | Already non-matching (message rewritten upstream); upstream rule can be removed. |
| `The signal event 'Struct{…}' should have N fields` | `CommonConnectorConfig` already redacted (CC-40507); MongoDB redacted in this PR. |

## Test plan
- [ ] Smoke-run an incremental snapshot and confirm the `"For table … using select statement"` debug log emits `[REDACTED]` instead of the raw SQL.
- [ ] Trigger an ad-hoc snapshot signal with a malformed payload and confirm the `"Execute snapshot signal … has arrived"` warning emits `[REDACTED]` for the data field.
- [ ] Enable TRACE on `io.debezium.jdbc.JdbcConnection` + `io.debezium.util.Loggings` and confirm the original SQL is visible (verifying the TRACE-gate of `maybeRedactSensitiveData` works).
- [ ] Send a malformed Kafka signal to MongoDB and confirm the `"signal event should have 3 fields"` warning no longer prints the event payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CC-41009]: https://confluentinc.atlassian.net/browse/CC-41009?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ