### PR TITLE
CC-41009: Redact sensitive data in JdbcConnection log lines - V1 connectors

### DIFF
--- a/debezium-core/src/main/java/io/debezium/jdbc/JdbcConnection.java
+++ b/debezium-core/src/main/java/io/debezium/jdbc/JdbcConnection.java
@@ -767,7 +767,7 @@ public class JdbcConnection implements AutoCloseable {
         if (preparer != null) {
             preparer.accept(statement);
         }
-        LOGGER.trace("Executing statement '{}'", stmt);
+        LOGGER.trace("Executing statement");
         statement.execute();
         return this;
     }
@@ -1441,7 +1441,7 @@ public class JdbcConnection implements AutoCloseable {
         try (Statement statement = conn.createStatement()) {
             for (String stmt : statements) {
                 if (LOGGER.isTraceEnabled()) {
-                    LOGGER.trace("Executing statement {}", stmt);
+                    LOGGER.trace("Executing statement");
                 }
                 statement.execute(stmt);
             }


### PR DESCRIPTION
## Summary

[CC-40617](https://confluentinc.atlassian.net/browse/CC-40617) (#399) on this branch removed sensitive customer data from signal/snapshot log lines and covered most of the upstream CDC redactor rules listed in [CC-41009](https://confluentinc.atlassian.net/browse/CC-41009). However, for the `JdbcConnection` SQL-logging rule (`executing '...'`), only one of three TRACE-level call-sites was redacted (`JdbcConnection.java:425`). The remaining two still logged raw `stmt`:

- `prepareUpdate` (line 767): `LOGGER.trace("Executing statement '{}'", stmt);`
- `executeWithoutCommitting` (line 1441): `LOGGER.trace("Executing statement {}", stmt);`

This PR drops the `stmt` argument from both, matching the pattern already used at `JdbcConnection.java:425` (`"executing statement"`).

### Coverage of the upstream rules for v1.9.6

| Upstream rule trigger | v1.9.6 status after this PR |
|---|---|
| `Received signal … data = '…'` | `Signal.java:126` rewritten by #399 — non-matching ✅ |
| `For table … select statement: '…'` | Relational + incremental + legacy MySQL redacted by #399 ✅ |
| `Requested 'BLOCKING' snapshot …` | N/A — v1.9.6 has no BLOCKING snapshot |
| `executing '…'` (JdbcConnection) | Line 425 redacted by #399; **lines 767 + 1441 redacted by this PR** ✅ |
| `Execute snapshot signal '…' has` | `ExecuteSnapshot.java:83` redacted by #399 ✅ |
| `Signal … has been received but the data '…' cannot` | `Signal.java:138` rewritten by #399 — non-matching ✅ |
| `The signal event 'Struct{…}' should have N fields` | `CommonConnectorConfig` and `MongoDbConnectorConfig` redacted by #399 ✅ |

## Test plan
- [ ] Enable TRACE on `io.debezium.jdbc.JdbcConnection` against a v1.9.6 connector exercising `prepareUpdate` / `executeWithoutCommitting` (e.g., a signalling/Postgres-style snapshot path) and confirm the log line emits `Executing statement` without the SQL payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CC-40617]: https://confluentinc.atlassian.net/browse/CC-40617?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CC-41009]: https://confluentinc.atlassian.net/browse/CC-41009?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ