### PR TITLE
CC-41009: Redact sensitive data in CDC log lines - Oracle XStream

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorConfig.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorConfig.java
@@ -5,6 +5,7 @@
  */
 package io.debezium.connector.mongodb;
 
+import static io.debezium.util.Loggings.maybeRedactSensitiveData;
 import static java.util.function.Predicate.not;
 
 import java.nio.file.Path;
@@ -1435,7 +1436,7 @@ public class MongoDbConnectorConfig extends CommonConnectorConfig implements Sha
         }
         final Document fields = Document.parse(event);
         if (fields.size() != 3) {
-            LOGGER.warn("The signal event '{}' should have 3 fields but has {}", event, fields.size());
+            LOGGER.warn("The signal event '{}' should have 3 fields but has {}", maybeRedactSensitiveData(event), fields.size());
             return Optional.empty();
         }
         final String[] result = new String[3];

--- a/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java
+++ b/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java
@@ -5,6 +5,8 @@
  */
 package io.debezium.config;
 
+import static io.debezium.util.Loggings.maybeRedactSensitiveData;
+
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
@@ -1661,7 +1663,7 @@ public abstract class CommonConnectorConfig {
         }
         List<org.apache.kafka.connect.data.Field> fields = event.schema().fields();
         if (fields.size() != 3) {
-            LOGGER.warn("The signal event '{}' should have 3 fields but has {}", event, fields.size());
+            LOGGER.warn("The signal event '{}' should have 3 fields but has {}", maybeRedactSensitiveData(event), fields.size());
             return Optional.empty();
         }
         return Optional.of(new String[]{

--- a/debezium-core/src/main/java/io/debezium/jdbc/JdbcConnection.java
+++ b/debezium-core/src/main/java/io/debezium/jdbc/JdbcConnection.java
@@ -5,6 +5,8 @@
  */
 package io.debezium.jdbc;
 
+import static io.debezium.util.Loggings.maybeRedactSensitiveData;
+
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -423,7 +425,7 @@ public class JdbcConnection implements AutoCloseable {
             for (String sqlStatement : sqlStatements) {
                 if (sqlStatement != null) {
                     if (LOGGER.isTraceEnabled()) {
-                        LOGGER.trace("executing '{}'", sqlStatement);
+                        LOGGER.trace("executing '{}'", maybeRedactSensitiveData(sqlStatement));
                     }
                     statement.execute(sqlStatement);
                 }
@@ -696,7 +698,7 @@ public class JdbcConnection implements AutoCloseable {
         preparer.accept(statement);
         statement.setQueryTimeout(queryTimeout);
         if (LOGGER.isTraceEnabled()) {
-            LOGGER.trace("Executing '{}' with {}s timeout", preparedQueryString, queryTimeout);
+            LOGGER.trace("Executing '{}' with {}s timeout", maybeRedactSensitiveData(preparedQueryString), queryTimeout);
         }
         try (ResultSet resultSet = statement.executeQuery()) {
             if (resultConsumer != null) {
@@ -778,7 +780,7 @@ public class JdbcConnection implements AutoCloseable {
         }
         statement.setQueryTimeout(queryTimeout);
         if (LOGGER.isTraceEnabled()) {
-            LOGGER.trace("Executing statement '{}' with {}s timeout", stmt, queryTimeout);
+            LOGGER.trace("Executing statement '{}' with {}s timeout", maybeRedactSensitiveData(stmt), queryTimeout);
         }
         statement.execute();
         return this;
@@ -1482,7 +1484,7 @@ public class JdbcConnection implements AutoCloseable {
             statement.setQueryTimeout(queryTimeout);
             for (String stmt : statements) {
                 if (LOGGER.isTraceEnabled()) {
-                    LOGGER.trace("Executing statement '{}' with {}s timeout", stmt, queryTimeout);
+                    LOGGER.trace("Executing statement '{}' with {}s timeout", maybeRedactSensitiveData(stmt), queryTimeout);
                 }
                 statement.execute(stmt);
             }

--- a/debezium-core/src/main/java/io/debezium/pipeline/signal/SignalProcessor.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/signal/SignalProcessor.java
@@ -5,6 +5,8 @@
  */
 package io.debezium.pipeline.signal;
 
+import static io.debezium.util.Loggings.maybeRedactSensitiveData;
+
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Collection;
@@ -178,7 +180,7 @@ public class SignalProcessor<P extends Partition, O extends OffsetContext> {
     private void processSignal(SignalRecord signalRecord) {
 
         LOGGER.debug("Signal Processor offset context {}", previousOffsets.getOffsets());
-        LOGGER.debug("Received signal id = '{}', type = '{}', data = '{}'", signalRecord.getId(), signalRecord.getType(), signalRecord.getData());
+        LOGGER.debug("Received signal id = '{}', type = '{}', data = '{}'", signalRecord.getId(), signalRecord.getType(), maybeRedactSensitiveData(signalRecord.getData()));
         final SignalAction<P> action = signalActions.get(signalRecord.getType());
         if (action == null) {
             LOGGER.warn("Signal '{}' has been received but the type '{}' is not recognized", signalRecord.getId(), signalRecord.getType());
@@ -192,7 +194,8 @@ public class SignalProcessor<P extends Partition, O extends OffsetContext> {
                     previousOffsets.getTheOnlyOffset(), signalRecord.getAdditionalData()));
         }
         catch (IOException e) {
-            LOGGER.warn("Signal '{}' has been received but the data '{}' cannot be parsed", signalRecord.getId(), signalRecord.getData(), e);
+            LOGGER.warn("Signal '{}' has been received but the data '{}' cannot be parsed", signalRecord.getId(),
+                maybeRedactSensitiveData(signalRecord.getData()), e);
         }
         catch (InterruptedException e) {
             LOGGER.warn("Action {} has been interrupted. The signal {} may not have been processed.", signalRecord.getType(), signalRecord);

--- a/debezium-core/src/main/java/io/debezium/pipeline/signal/actions/snapshotting/ExecuteSnapshot.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/signal/actions/snapshotting/ExecuteSnapshot.java
@@ -5,6 +5,8 @@
  */
 package io.debezium.pipeline.signal.actions.snapshotting;
 
+import static io.debezium.util.Loggings.maybeRedactSensitiveData;
+
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -63,7 +65,7 @@ public class ExecuteSnapshot<P extends Partition> extends AbstractSnapshotSignal
         Optional<String> surrogateKey = getSurrogateKey(signalPayload.data);
 
         LOGGER.info("Requested '{}' snapshot of data collections '{}' with additional conditions '{}' and surrogate key '{}'",
-                type, dataCollections, additionalConditions, surrogateKey.orElse("PK of table will be used"));
+                type, dataCollections, maybeRedactSensitiveData(additionalConditions), surrogateKey.orElse("PK of table will be used"));
 
         SnapshotConfiguration.Builder snapsthoConfigurationBuilder = SnapshotConfiguration.Builder.builder();
         snapsthoConfigurationBuilder.dataCollections(dataCollections);
@@ -107,7 +109,7 @@ public class ExecuteSnapshot<P extends Partition> extends AbstractSnapshotSignal
         if (dataCollectionsArray == null || dataCollectionsArray.isEmpty()) {
             LOGGER.warn(
                     "Execute snapshot signal '{}' has arrived but the requested field '{}' is missing from data or is empty",
-                    data, FIELD_DATA_COLLECTIONS);
+                    maybeRedactSensitiveData(data), FIELD_DATA_COLLECTIONS);
             return null;
         }
         return dataCollectionsArray.streamValues()

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotChangeEventSource.java
@@ -436,7 +436,7 @@ public abstract class AbstractIncrementalSnapshotChangeEventSource<P extends Par
 
     private Table readSchema() {
         final String selectStatement = chunkQueryBuilder.buildChunkQuery(context, currentTable, 0, Optional.empty());
-        LOGGER.debug("Reading schema for table '{}' using select statement: '{}'", currentTable.id(), selectStatement);
+        LOGGER.debug("Reading schema for table '{}' using select statement: '{}'", currentTable.id(), maybeRedactSensitiveData(selectStatement));
 
         try (PreparedStatement statement = chunkQueryBuilder.readTableChunkStatement(context, currentTable, selectStatement);
                 ResultSet rs = statement.executeQuery()) {
@@ -584,7 +584,7 @@ public abstract class AbstractIncrementalSnapshotChangeEventSource<P extends Par
 
         final String selectStatement = chunkQueryBuilder.buildChunkQuery(context, currentTable, context.currentDataCollectionId().getAdditionalCondition());
         LOGGER.debug("\t For table '{}' using select statement: '{}', key: '{}', maximum key: '{}'", currentTable.id(),
-                selectStatement, context.chunkEndPosititon(), maybeRedactSensitiveData(context.maximumKey().get()));
+                maybeRedactSensitiveData(selectStatement), context.chunkEndPosititon(), maybeRedactSensitiveData(context.maximumKey().get()));
 
         final TableSchema tableSchema = databaseSchema.schemaFor(currentTable.id());
 

--- a/debezium-core/src/test/java/io/debezium/pipeline/signal/SignalProcessorTest.java
+++ b/debezium-core/src/test/java/io/debezium/pipeline/signal/SignalProcessorTest.java
@@ -167,7 +167,7 @@ public class SignalProcessorTest {
         Awaitility.await()
                 .atMost(40, TimeUnit.SECONDS)
                 .untilAsserted(
-                        () -> assertThat(log.containsMessage("Signal 'log1' has been received but the data '{\"message: \"signallog\"}' cannot be parsed")).isTrue());
+                        () -> assertThat(log.containsMessage("Signal 'log1' has been received but the data '[REDACTED]' cannot be parsed")).isTrue());
 
         signalProcess.stop();
     }


### PR DESCRIPTION
## Summary

In-code redaction (via `Loggings.maybeRedactSensitiveData`) is added to log lines that today are only masked by upstream CDC logredactor rules. Once this lands the matching upstream rules (see [CC-41009](https://confluentinc.atlassian.net/browse/CC-41009)) can be removed for this branch.

Changes:
- `SignalProcessor` — redact `data` in the `"Received signal id = '…', type = '…', data = '…'"` debug log and the `"Signal '…' has been received but the data '…' cannot be parsed"` warning.
- `ExecuteSnapshot` — redact `additionalConditions` in the `"Requested … snapshot of data collections …"` info log, and redact the raw `data` Document in the `"Execute snapshot signal … has arrived"` warning.
- `AbstractIncrementalSnapshotChangeEventSource` — redact `selectStatement` in the incremental `"For table … using select statement: …"` and `"Reading schema for table … using select statement: …"` debug logs.
- `JdbcConnection` — redact `sqlStatement` / `preparedQueryString` / `stmt` in the four TRACE-level `executing`/`Executing statement` logs.
- `CommonConnectorConfig` and `MongoDbConnectorConfig` — redact the raw signal event in the `"The signal event '…' should have 3 fields"` warning.

### Coverage of the upstream rules

| Upstream rule trigger | Status after this PR |
|---|---|
| `Received signal … data = '…'` | Redacted in this PR (`SignalProcessor`). |
| `For table … select statement: '…'` | Relational redacted by #393; incremental redacted in this PR. |
| `Requested 'BLOCKING' snapshot … additional conditions '…' and surrogate key` | Redacted in this PR (covers both `BLOCKING` and `INCREMENTAL`). |
| `executing '…'` | All four `JdbcConnection` TRACE call-sites redacted in this PR. |
| `Execute snapshot signal '…' has` | Redacted in this PR. |
| `Signal … has been received but the data '…' cannot` | Redacted in this PR. |
| `The signal event 'Struct{…}' should have N fields` | `CommonConnectorConfig` and `MongoDbConnectorConfig` redacted in this PR. |

## Test plan
- [ ] Smoke-run an incremental snapshot and confirm the `"For table … using select statement"` debug log emits `[REDACTED]` instead of the raw SQL.
- [ ] Trigger an ad-hoc snapshot signal with a malformed payload and confirm the `"Execute snapshot signal … has arrived"` warning emits `[REDACTED]` for the data field.
- [ ] Enable TRACE on `io.debezium.jdbc.JdbcConnection` + `io.debezium.util.Loggings` and confirm the original SQL is visible (verifying the TRACE-gate of `maybeRedactSensitiveData` works).
- [ ] Send a malformed signal and confirm the `"signal event should have 3 fields"` warning no longer prints the event payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CC-41009]: https://confluentinc.atlassian.net/browse/CC-41009?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ