### PR TITLE
Upgrade org.postgresql to fix CVE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
         <version.apicurio>2.6.2.Final</version.apicurio>
 
         <!-- Database drivers, should align with databases -->
-        <version.postgresql.driver>42.7.7</version.postgresql.driver>
+        <version.postgresql.driver>42.7.11</version.postgresql.driver>
         <version.mysql.driver>9.1.0</version.mysql.driver>
         <version.mysql.binlog>0.40.2</version.mysql.binlog>
         <version.mongo.driver>5.2.0</version.mongo.driver>


### PR DESCRIPTION
# Problem
[CC-41141](https://confluentinc.atlassian.net/browse/CC-41141) 

# Solution
Fix the CVE in org.postgresql:postgresql by bumping the version to 42.2.11


**Updated Dependency Tree** - [deptree_postgres_42.7.11_20260520_125736.txt](https://github.com/user-attachments/files/28047145/deptree_postgres_42.7.11_20260520_125736.txt)

<details>
<summary>Depedency Tree</summary>

<img width="1728" height="959" alt="Screenshot 2026-05-20 at 1 00 04 PM" src="https://github.com/user-attachments/assets/d8c7383b-9642-4956-960e-2aa0459a519d" />

<img width="1728" height="959" alt="Screenshot 2026-05-20 at 12 59 31 PM" src="https://github.com/user-attachments/assets/3f89296e-6665-4ae0-952b-48402feabd82" />

</details>


**Confluent Platform v8.2.0**
<details>
<summary>Logs</summary>

**Connector Starting and Snapshot Phase**

<img width="1728" height="959" alt="Screenshot 2026-05-20 at 12 53 15 PM" src="https://github.com/user-attachments/assets/3b15fa63-1e6e-41d2-b33d-d9b5580446c1" />


**Snapshot Completion and Streaming Phase**

<img width="1728" height="959" alt="image" src="https://github.com/user-attachments/assets/22d20b66-5372-4a26-ad90-3dcfb1fd96db" />



</details> 



[CC-41141]: https://confluentinc.atlassian.net/browse/CC-41141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ