### PR TITLE
Upgrade org.postgresql to fix CVE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
         <version.apicurio>2.4.3.Final</version.apicurio>
 
         <!-- Database drivers, should align with databases -->
-        <version.postgresql.driver>42.6.1</version.postgresql.driver>
+        <version.postgresql.driver>42.7.11</version.postgresql.driver>
         <version.mysql.driver>8.0.33</version.mysql.driver>
         <version.mysql.binlog>0.29.0</version.mysql.binlog>
         <version.mongo.driver>4.11.0</version.mongo.driver>


### PR DESCRIPTION
# Problem
[CC-41142](https://confluentinc.atlassian.net/browse/CC-41142) 

# Solution
Fix the CVE in org.postgresql:postgresql by bumping the version to 42.2.11


**Updated Dependency Tree** - 
[deptree_postgres_2.5.4_42.7.11_20260520_132045.txt](https://github.com/user-attachments/files/28048954/deptree_postgres_2.5.4_42.7.11_20260520_132045.txt)


<details>
<summary>Depedency Tree</summary>

<img width="1728" height="959" alt="Screenshot 2026-05-20 at 1 52 15 PM" src="https://github.com/user-attachments/assets/31b90f77-49b9-462b-83c6-c527511864e9" />


<img width="1728" height="959" alt="Screenshot 2026-05-20 at 1 52 02 PM" src="https://github.com/user-attachments/assets/582c63c2-75c6-41c0-94ff-1b5aae0d1c3b" />


</details>


**Confluent Platform v8.2.0**
<details>
<summary>Logs</summary>

**Connector Starting and Snapshot Phase**

<img width="1728" height="959" alt="Screenshot 2026-05-20 at 1 46 32 PM" src="https://github.com/user-attachments/assets/cbfb47ea-daa5-4b41-a54e-ea28b69232d2" />


<img width="1728" height="959" alt="Screenshot 2026-05-20 at 1 46 17 PM" src="https://github.com/user-attachments/assets/f5d10b40-eda9-48d3-91c6-382b4e191932" />


**Snapshot Completion and Streaming Phase**

<img width="1728" height="959" alt="Screenshot 2026-05-20 at 1 46 06 PM" src="https://github.com/user-attachments/assets/86484399-b565-448d-8340-4643e0058e8b" />


<img width="1728" height="959" alt="Screenshot 2026-05-20 at 1 51 00 PM" src="https://github.com/user-attachments/assets/3469e52d-f81f-43a3-8b25-d1d101232d99" />




</details> 


[CC-41142]: https://confluentinc.atlassian.net/browse/CC-41142?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ