### PR TITLE
CC-41009: Redact chunk end position in incremental snapshot logs - V2

### DIFF
--- a/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotChangeEventSource.java
@@ -584,7 +584,7 @@ public abstract class AbstractIncrementalSnapshotChangeEventSource<P extends Par
 
         final String selectStatement = chunkQueryBuilder.buildChunkQuery(context, currentTable, context.currentDataCollectionId().getAdditionalCondition());
         LOGGER.debug("\t For table '{}' using select statement: '{}', key: '{}', maximum key: '{}'", currentTable.id(),
-                maybeRedactSensitiveData(selectStatement), context.chunkEndPosititon(), maybeRedactSensitiveData(context.maximumKey().get()));
+                maybeRedactSensitiveData(selectStatement), maybeRedactSensitiveData(context.chunkEndPosititon()), maybeRedactSensitiveData(context.maximumKey().get()));
 
         final TableSchema tableSchema = databaseSchema.schemaFor(currentTable.id());
 
@@ -625,7 +625,7 @@ public abstract class AbstractIncrementalSnapshotChangeEventSource<P extends Par
             }
             context.nextChunkPosition(lastKey);
             if (lastRow != null) {
-                LOGGER.debug("\t Next window will resume from {}", (Object) context.chunkEndPosititon());
+                LOGGER.debug("\t Next window will resume from {}", maybeRedactSensitiveData(context.chunkEndPosititon()));
             }
 
             LOGGER.debug("\t Finished exporting {} records for window of table table '{}'; total duration '{}'", rows,


### PR DESCRIPTION
## Summary

Follow-up to #444 ([CC-41009](https://confluentinc.atlassian.net/browse/CC-41009)). Two debug logs in `AbstractIncrementalSnapshotChangeEventSource` still emit `context.chunkEndPosititon()` unredacted:

- L587 — `"\t For table '{}' using select statement: '{}', key: '{}', maximum key: '{}'"` (the `key: '{}'` placeholder)
- L628 — `"\t Next window will resume from {}"`

`chunkEndPosititon()` is the previous chunk's last primary-key tuple — same sensitivity class as `context.maximumKey()`, which is already wrapped. Customer PKs can include PII (customer ids, emails, natural keys, composite keys, etc.).

Today the upstream redactor rule's greedy `select statement: '(.*)'` happens to span the rest of the line on L587, but the whole point of CC-41009 is to remove that upstream rule. Once removed, PK values would start leaking in connector logs.

This PR wraps both call-sites in `Loggings.maybeRedactSensitiveData`, matching the MongoDB equivalent which was already done correctly (`MongoDbIncrementalSnapshotChangeEventSource.java:533, 579`).

## Test plan
- [ ] Smoke-run an incremental snapshot and confirm the `"For table … using select statement: …, key: '[REDACTED]', maximum key: '[REDACTED]'"` debug log emits `[REDACTED]` for the key placeholder.
- [ ] Confirm the `"Next window will resume from [REDACTED]"` debug log emits `[REDACTED]` instead of the raw PK array.
- [ ] Enable TRACE on `io.debezium.util.Loggings` and confirm the original PK is visible (validates the TRACE-gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CC-41009]: https://confluentinc.atlassian.net/browse/CC-41009?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ