### PR TITLE
CC-41009: Redact chunk end position in incremental snapshot logs - V1 connectors

### DIFF
--- a/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotChangeEventSource.java
@@ -437,8 +437,7 @@ public abstract class AbstractIncrementalSnapshotChangeEventSource<P extends Par
         LOGGER.debug("Exporting data chunk from table '{}' (total {} tables)", currentTable.id(), context.dataCollectionsToBeSnapshottedCount());
 
         final String selectStatement = buildChunkQuery(currentTable);
-        LOGGER.debug("\t For table '{}' using select statement, key: '{}', maximum key: '{}'", currentTable.id(),
-                context.chunkEndPosititon(), context.maximumKey().get());
+        LOGGER.debug("\t For table '{}' using select statement", currentTable.id());
 
         final TableSchema tableSchema = databaseSchema.schemaFor(currentTable.id());
 
@@ -479,7 +478,7 @@ public abstract class AbstractIncrementalSnapshotChangeEventSource<P extends Par
             }
             context.nextChunkPosition(lastKey);
             if (lastRow != null) {
-                LOGGER.debug("\t Next window will resume from {}", (Object) context.chunkEndPosititon());
+                LOGGER.debug("\t Next window will resume");
             }
 
             LOGGER.debug("\t Finished exporting {} records for window of table table '{}'; total duration '{}'", rows,


### PR DESCRIPTION
## Summary

Follow-up to [CC-41009](https://confluentinc.atlassian.net/browse/CC-41009) / #445 / CC-40617 (#399). Two debug logs in `AbstractIncrementalSnapshotChangeEventSource` still emit `context.chunkEndPosititon()` (and `context.maximumKey()`) unredacted:

- L440-441 — `"\t For table '{}' using select statement, key: '{}', maximum key: '{}'"`
- L482 — `"\t Next window will resume from {}"`

`chunkEndPosititon()` is the previous chunk's last primary-key tuple, and `maximumKey()` is the upper PK bound — both are real customer PK values that can include PII (customer ids, emails, natural keys, composite keys, etc.). CC-40617 / #399 redacted the `select statement` portion of the first log but missed the `key` / `maximum key` placeholders, and the second log was missed entirely.

`Loggings.maybeRedactSensitiveData` does not exist on this branch, so this PR follows the v1.9.6 style already established by #399 — drop the sensitive parameter from the message text:

- `"For table '{}' using select statement, key: '{}', maximum key: '{}'"` → `"For table '{}' using select statement"`
- `"Next window will resume from {}"` → `"Next window will resume"`

Mirrors the V2 fix landing in #453 (which used `maybeRedactSensitiveData` because that branch has it).

## Test plan
- [ ] Smoke-run an incremental snapshot and confirm the `"For table … using select statement"` debug log no longer prints `key` / `maximum key` values.
- [ ] Confirm the `"Next window will resume"` debug log no longer prints the raw PK array.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CC-41009]: https://confluentinc.atlassian.net/browse/CC-41009?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ