### PR TITLE
Upgrade org.postgresql to fix CVE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
         <version.apicurio>2.6.2.Final</version.apicurio>
 
         <!-- Database drivers, should align with databases -->
-        <version.postgresql.driver>42.7.7</version.postgresql.driver>
+        <version.postgresql.driver>42.7.11</version.postgresql.driver>
         <version.mysql.driver>9.1.0</version.mysql.driver>
         <version.mysql.binlog>0.40.2</version.mysql.binlog>
         <version.mongo.driver>5.2.0</version.mongo.driver>


### PR DESCRIPTION
# Problem
[CC-41141](https://confluentinc.atlassian.net/browse/CC-41141) 

# Solution
Fix the CVE in org.postgresql:postgresql by bumping the version to 42.2.11


**Updated Dependency Tree** - [deptree_postgres_42.7.11_20260520_125736.txt](https://github.com/user-attachments/files/28047145/deptree_postgres_42.7.11_20260520_125736.txt)


[CC-41141]: https://confluentinc.atlassian.net/browse/CC-41141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ