### PR TITLE
CC-41410 Bring in log redaction rules at connector level

### DIFF
--- a/debezium-core/src/main/java/io/debezium/pipeline/signal/channels/SourceSignalChannel.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/signal/channels/SourceSignalChannel.java
@@ -18,6 +18,8 @@ import io.debezium.annotation.NotThreadSafe;
 import io.debezium.config.CommonConnectorConfig;
 import io.debezium.pipeline.signal.SignalRecord;
 
+import static io.debezium.util.Loggings.maybeRedactSensitiveData;
+
 /**
  * The class responsible for processing of signals delivered to Debezium via a dedicated signaling table.
  * The processor supports a common set of signals that it can process and every connector can register its own
@@ -93,7 +95,8 @@ public class SourceSignalChannel implements SignalChannelReader {
             return true;
         }
         catch (Exception e) {
-            LOGGER.warn("Exception while preparing to process the signal", e);
+
+            LOGGER.warn("Exception while preparing to process the signal {}", maybeRedactSensitiveData(e));
             return false;
         }
     }


### PR DESCRIPTION
In CC-41410 all log rules were listed as

```
{
     "description": "Redact Debezium signal record on action failure while processing the signal",
     "trigger": "Action ",
     "caseSensitive": false,
     "search": "Action (.*) failed\\. The signal SignalRecord\\{([\\s\\S]*)\\} may not have been processed\\.",
     "replace": "Action $1 failed. The signal SignalRecord{REDACTED} may not have been processed."
   },
   {
     "description": "Redact Debezium signal record on action interrupted while processing the signal",
     "trigger": "Action ",
     "caseSensitive": false,
     "search": "Action (.*) has been interrupted\\. The signal SignalRecord\\{([\\s\\S]*)\\} may not have been processed\\.",
     "replace": "Action $1 has been interrupted. The signal SignalRecord{REDACTED} may not have been processed."
   },
   {
     "description": "Redact Debezium signal struct in preparation exception",
     "trigger": "Exception while preparing to process the signal",
     "caseSensitive": false,
     "search": "Exception while preparing to process the signal 'Struct\\{([\\s\\S]*)\\}'",
     "replace": "Exception while preparing to process the signal 'Struct{REDACTED}'"
   },
   {
     "description": "Redact Debezium signal struct when field is missing",
     "trigger": "Field ",
     "caseSensitive": false,
     "search": "Field (.*) part of signal 'Struct\\{([\\s\\S]*)\\}' is missing",
     "replace": "Field $1 part of signal 'Struct{REDACTED}' is missing"
   },
   {
     "description": "Redact signal id when type is not recognized",
     "trigger": "has been received but the type",
     "caseSensitive": false,
     "search": "Signal '(.*)' has been received but the type '(.*)' is not recognized",
     "replace": "Signal '[REDACTED]' has been received but the type '$2' is not recognized"
   },
   {
     "description": "Redact signal id and data when parse fails",
     "trigger": "has been received but the data",
     "caseSensitive": false,
     "search": "Signal '(.*)' has been received but the data '(.*)' cannot be parsed",
     "replace": "Signal '[REDACTED]' has been received but the data '[REDACTED]' cannot be parsed"
last month
   }
```

These were analysed, expect one all of them were fixed earlier. 
Past commit where these changes were brought in code is as:
- CC-38838: Remove sensitive logging of signalRecord (#275) (#276)


For "Signal '(.*)' has been received but the type '(.*)' is not recognized", -> ONLY displays signal ID, which is not a sensitive information.

Only at one place, we were logging exception stacktrace, which might be sensitive data. So, fixing that in this PR.


