### PR TITLE
Add credentials.json to PASSWORD_PATTERN for log masking

### DIFF
--- a/debezium-core/src/main/java/io/debezium/config/Configuration.java
+++ b/debezium-core/src/main/java/io/debezium/config/Configuration.java
@@ -64,7 +64,7 @@ public interface Configuration {
 
     Logger CONFIGURATION_LOGGER = LoggerFactory.getLogger(Configuration.class);
 
-    Pattern PASSWORD_PATTERN = Pattern.compile(".*secret$|.*password$|.*sasl\\.jaas\\.config$|.*basic\\.auth\\.user\\.info|.*registry\\.auth\\.client-secret",
+    Pattern PASSWORD_PATTERN = Pattern.compile(".*secret$|.*password$|.*sasl\\.jaas\\.config$|.*basic\\.auth\\.user\\.info|.*registry\\.auth\\.client-secret|.*credentials\\.json$",
             Pattern.CASE_INSENSITIVE);
 
     /**

--- a/debezium-core/src/main/java/io/debezium/config/Configuration.java
+++ b/debezium-core/src/main/java/io/debezium/config/Configuration.java
@@ -64,7 +64,8 @@ public interface Configuration {
 
     Logger CONFIGURATION_LOGGER = LoggerFactory.getLogger(Configuration.class);
 
-    Pattern PASSWORD_PATTERN = Pattern.compile(".*secret$|.*password$|.*sasl\\.jaas\\.config$|.*basic\\.auth\\.user\\.info|.*registry\\.auth\\.client-secret|.*credentials\\.json$",
+    Pattern PASSWORD_PATTERN = Pattern.compile(
+            ".*secret$|.*password$|.*sasl\\.jaas\\.config$|.*basic\\.auth\\.user\\.info|.*registry\\.auth\\.client-secret|.*credentials\\.json$",
             Pattern.CASE_INSENSITIVE);
 
     /**


### PR DESCRIPTION
## Description

Add `.*credentials\.json$` to `PASSWORD_PATTERN` in `Configuration.java` so that config keys ending in `credentials.json` (e.g., `gcp.spanner.credentials.json`) are masked when configurations are logged through Debezium's `Configuration` class.

Currently, `PASSWORD_PATTERN` matches keys ending in `secret`, `password`, `sasl.jaas.config`, `basic.auth.user.info`, and `registry.auth.client-secret`, but does not cover credential JSON keys - allowing them to be printed in plaintext in logs.