### PR TITLE
CC-41772: DBZ-8562 - Move schema history recovery out of task start (Fix schema history recovery for Oracle XStream connector)

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -117,10 +117,10 @@ blocks:
   - name: Release
     dependencies: []
     run:
-      when: "branch != 'master' and branch !~ '[0-9]+\\.[0-9]+\\.x' and branch =~ 'v[0-9]+\\.[0-9]+\\.[0-9]+\\-orcl\\-hotfix\\-x' and change_in('debezium-core/')"
+      when: "branch != 'master' and branch !~ '[0-9]+\\.[0-9]+\\.x' and branch =~ 'v[0-9]+\\.[0-9]+\\.[0-9]+\\-orcl\\-hotfix\\-x' and (change_in('debezium-core/') or change_in('debezium-storage/'))"
     task:
       jobs:
-        - name: Release debezium-core
+        - name: Release debezium-core and debezium-storage-kafka
           commands:
             - ci-tools ci-update-version
             - ci-tools ci-push-tag
@@ -176,6 +176,43 @@ blocks:
               -Dfile=debezium-core/target/debezium-core-${DEBEZIUM_VERSION}-tests.jar
               -DgroupId=io.confluent
               -DartifactId=debezium-core
+              -Dversion=${DEBEZIUM_VERSION}
+              -Dpackaging=jar
+              -Dclassifier=tests
+            # Build debezium-storage-kafka with original groupId (io.debezium) to keep dependencies intact
+            - mvn -U -Dmaven.wagon.http.retryHandler.count=10 --batch-mode install -Passembly -pl debezium-storage/debezium-storage-kafka -am -DskipTests -DskipITs
+            - export STORAGE_KAFKA_DIR=debezium-storage/debezium-storage-kafka
+            # Create a modified POM with io.confluent groupId for deployment
+            - cp ${STORAGE_KAFKA_DIR}/pom.xml ${STORAGE_KAFKA_DIR}/target/debezium-storage-kafka-${DEBEZIUM_VERSION}.pom
+            # Add explicit groupId and version after modelVersion (since they're inherited from parent)
+            - sed -i '/<\/modelVersion>/a\    <groupId>io.confluent</groupId>\n    <version>'"${DEBEZIUM_VERSION}"'</version>' ${STORAGE_KAFKA_DIR}/target/debezium-storage-kafka-${DEBEZIUM_VERSION}.pom
+            # Deploy main JAR with io.confluent groupId
+            - mvn deploy:deploy-file
+              -Durl=https://confluent-519856050701.d.codeartifact.us-west-2.amazonaws.com/maven/maven-snapshots/
+              -DrepositoryId=confluent-codeartifact-internal
+              -Dfile=${STORAGE_KAFKA_DIR}/target/debezium-storage-kafka-${DEBEZIUM_VERSION}.jar
+              -DpomFile=${STORAGE_KAFKA_DIR}/target/debezium-storage-kafka-${DEBEZIUM_VERSION}.pom
+              -DgroupId=io.confluent
+              -DartifactId=debezium-storage-kafka
+              -Dversion=${DEBEZIUM_VERSION}
+              -Dpackaging=jar
+            # Deploy sources JAR
+            - mvn deploy:deploy-file
+              -Durl=https://confluent-519856050701.d.codeartifact.us-west-2.amazonaws.com/maven/maven-snapshots/
+              -DrepositoryId=confluent-codeartifact-internal
+              -Dfile=${STORAGE_KAFKA_DIR}/target/debezium-storage-kafka-${DEBEZIUM_VERSION}-sources.jar
+              -DgroupId=io.confluent
+              -DartifactId=debezium-storage-kafka
+              -Dversion=${DEBEZIUM_VERSION}
+              -Dpackaging=jar
+              -Dclassifier=sources
+            # Deploy tests JAR
+            - mvn deploy:deploy-file
+              -Durl=https://confluent-519856050701.d.codeartifact.us-west-2.amazonaws.com/maven/maven-snapshots/
+              -DrepositoryId=confluent-codeartifact-internal
+              -Dfile=${STORAGE_KAFKA_DIR}/target/debezium-storage-kafka-${DEBEZIUM_VERSION}-tests.jar
+              -DgroupId=io.confluent
+              -DartifactId=debezium-storage-kafka
               -Dversion=${DEBEZIUM_VERSION}
               -Dpackaging=jar
               -Dclassifier=tests

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogConnectorIT.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogConnectorIT.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
@@ -32,6 +33,7 @@ import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.header.Header;
 import org.apache.kafka.connect.source.SourceConnector;
 import org.apache.kafka.connect.source.SourceRecord;
+import org.awaitility.Awaitility;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -58,6 +60,7 @@ import io.debezium.relational.RelationalDatabaseConnectorConfig.DecimalHandlingM
 import io.debezium.relational.RelationalDatabaseSchema;
 import io.debezium.relational.history.SchemaHistory;
 import io.debezium.schema.DatabaseSchema;
+import io.debezium.storage.file.history.DelayingFileBasedSchemaHistory;
 import io.debezium.storage.file.history.FileSchemaHistory;
 import io.debezium.storage.kafka.history.KafkaSchemaHistory;
 import io.debezium.util.Testing;
@@ -2818,6 +2821,50 @@ public abstract class BinlogConnectorIT<C extends SourceConnector, P extends Bin
         // Here we count all the records obtained from binlog, not only records pushed into the sink.
         // Number of records may vary between MySQL and MariaDB and also between the runs on the same DB.
         stopConnector(value -> assertThat(logInterceptor.messageMatches("^Stopped reading binlog after [5-9] events(.*)")).isTrue());
+    }
+
+    @Test
+    public void taskStartShouldNotWaitOnSchemaHistoryRecovery() throws InterruptedException {
+        // Introduce a delay of 10 seconds in recovering every record in schema history. This is
+        // done to increase the time taken to recovery schema history.
+        Configuration config = DATABASE.defaultConfig()
+                .with(BinlogConnectorConfig.SCHEMA_HISTORY, DelayingFileBasedSchemaHistory.class.getName())
+                .with(DelayingFileBasedSchemaHistory.RECOVERY_DELAY_MS_PROPERTY, 10_000)
+                .build();
+
+        start(getConnectorClass(), config);
+        logger.info("Sleeping for 2 seconds to allow connector to start and commit an offset");
+        Thread.sleep(2_000);
+
+        stopConnector();
+
+        CountDownLatch taskStartLatch = new CountDownLatch(1);
+
+        Thread startConnectorThread = new Thread(() -> {
+            logger.info("Starting connector again");
+            start(getConnectorClass(), config, new DebeziumEngine.ConnectorCallback() {
+                @Override
+                public void taskStarted() {
+                    taskStartLatch.countDown();
+                }
+            });
+        });
+
+        startConnectorThread.start();
+
+        logger.info("Waiting for task to start");
+
+        // Wait for 5 seconds for the task to be started
+        Awaitility.await().atMost(5, TimeUnit.SECONDS).until(() -> taskStartLatch.getCount() == 0);
+
+        logger.info("Task has started, even though the schema history recovery will take long time");
+
+        // fail the test if task did not start in 5 seconds
+        if (taskStartLatch.getCount() != 0) {
+            throw new AssertionError("Task did not start in 5 seconds after " +
+                    "connector was started. Task's start method should be lightweight and " +
+                    "hence this is not expected.");
+        }
     }
 
     protected String getExpectedQuery(String statement) {

--- a/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogDatabaseSchemaTest.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/connector/binlog/BinlogDatabaseSchemaTest.java
@@ -217,7 +217,7 @@ public abstract class BinlogDatabaseSchemaTest<C extends BinlogConnectorConfig, 
     }
 
     @Test
-    public void shouldAllowDecimalPrecision() {
+    public void shouldAllowDecimalPrecision() throws InterruptedException {
         // Testing.Print.enable();
         final Configuration config = DATABASE.defaultConfig()
                 .with(SchemaHistory.SKIP_UNPARSEABLE_DDL_STATEMENTS, false)
@@ -240,7 +240,7 @@ public abstract class BinlogDatabaseSchemaTest<C extends BinlogConnectorConfig, 
 
     @Test
     @FixFor("DBZ-3622")
-    public void shouldStoreNonCapturedDatabase() {
+    public void shouldStoreNonCapturedDatabase() throws InterruptedException {
         // Testing.Print.enable();
         final Configuration config = DATABASE.defaultConfig()
                 .with(SchemaHistory.SKIP_UNPARSEABLE_DDL_STATEMENTS, false)
@@ -272,7 +272,7 @@ public abstract class BinlogDatabaseSchemaTest<C extends BinlogConnectorConfig, 
 
     @Test
     @FixFor("DBZ-3622")
-    public void shouldNotStoreNonCapturedDatabase() {
+    public void shouldNotStoreNonCapturedDatabase() throws InterruptedException {
         // Testing.Print.enable();
         final Configuration config = DATABASE.defaultConfig()
                 .with(SchemaHistory.SKIP_UNPARSEABLE_DDL_STATEMENTS, false)
@@ -305,7 +305,7 @@ public abstract class BinlogDatabaseSchemaTest<C extends BinlogConnectorConfig, 
 
     @Test
     @FixFor("DBZ-3622")
-    public void shouldStoreNonCapturedTable() {
+    public void shouldStoreNonCapturedTable() throws InterruptedException {
         // Testing.Print.enable();
         final Configuration config = DATABASE.defaultConfigWithoutDatabaseFilter()
                 .with(SchemaHistory.SKIP_UNPARSEABLE_DDL_STATEMENTS, false)
@@ -337,7 +337,7 @@ public abstract class BinlogDatabaseSchemaTest<C extends BinlogConnectorConfig, 
 
     @Test
     @FixFor("DBZ-3622")
-    public void shouldNotStoreNonCapturedTable() {
+    public void shouldNotStoreNonCapturedTable() throws InterruptedException {
         // Testing.Print.enable();
         final Configuration config = DATABASE.defaultConfigWithoutDatabaseFilter()
                 .with(SchemaHistory.SKIP_UNPARSEABLE_DDL_STATEMENTS, false)
@@ -446,7 +446,7 @@ public abstract class BinlogDatabaseSchemaTest<C extends BinlogConnectorConfig, 
         assertThat(schema.tableIds().stream().filter(id -> id.catalog().equals(dbName)).count()).isGreaterThan(0);
     }
 
-    protected void assertHistoryRecorded(Configuration config, P partition, OffsetContext offset) {
+    protected void assertHistoryRecorded(Configuration config, P partition, OffsetContext offset) throws InterruptedException {
         try (S duplicate = getSchema(config)) {
             duplicate.recover(Offsets.of(partition, offset));
 

--- a/debezium-connector-binlog/src/test/java/io/debezium/relational/history/AbstractKafkaSchemaHistoryTest.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/relational/history/AbstractKafkaSchemaHistoryTest.java
@@ -118,7 +118,7 @@ public abstract class AbstractKafkaSchemaHistoryTest<P extends BinlogPartition, 
 
     protected abstract DdlParser getDdlParser();
 
-    private void testHistoryTopicContent(String topicName, boolean skipUnparseableDDL) {
+    private void testHistoryTopicContent(String topicName, boolean skipUnparseableDDL) throws InterruptedException {
         interceptor = new LogInterceptor(KafkaSchemaHistory.class);
         // Start up the history ...
         Configuration config = Configuration.create()
@@ -327,7 +327,7 @@ public abstract class AbstractKafkaSchemaHistoryTest<P extends BinlogPartition, 
     }
 
     @Test
-    public void testExists() {
+    public void testExists() throws InterruptedException {
         String topicName = "exists-schema-changes";
 
         // happy path

--- a/debezium-connector-binlog/src/test/java/io/debezium/relational/history/AbstractKafkaSchemaHistoryTest.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/relational/history/AbstractKafkaSchemaHistoryTest.java
@@ -11,14 +11,18 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
+import java.time.Duration;
+import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.TimeoutException;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.config.ConfigValue;
+import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -110,6 +114,75 @@ public abstract class AbstractKafkaSchemaHistoryTest<P extends BinlogPartition, 
         // Create the empty topic ...
         kafka.createTopic(topicName, 1, 1);
         testHistoryTopicContent(topicName, false);
+    }
+
+    @Test
+    @FixFor("debezium/dbz#2032")
+    void shouldRecoverWhenAnotherConsumerHoldsTheGroupPartition() throws Exception {
+        String topicName = "concurrent-recovery-schema-changes";
+        String historyName = "my-db-history";
+
+        KafkaClusterUtils.createTopic(topicName, 1, (short) 1, kafkaCluster.getBootstrapServers());
+
+        Configuration config = recoveryConfig(topicName, historyName);
+
+        history.configure(config, null, SchemaHistoryMetrics.NOOP, true);
+        history.start();
+        history.initializeStorage();
+        setLogPosition(0);
+        String ddl = "CREATE TABLE foo ( name VARCHAR(255) NOT NULL PRIMARY KEY);";
+        history.record(offsets.getTheOnlyPartition().getSourcePartition(), offsets.getTheOnlyOffset().getOffset(), "db1", ddl);
+        history.stop();
+
+        DdlParser ddlParser = getDdlParser();
+        ddlParser.setCurrentSchema("db1");
+        Tables expected = new Tables();
+        ddlParser.parse(ddl, expected);
+        assertThat(expected.size()).isEqualTo(1);
+
+        // Another consumer joins the recovery group (group.id == history name) and claims the
+        // partition, as a second task would during a Connect rebalance.
+        Configuration squatterConfig = Configuration.create()
+                .with(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaCluster.getBootstrapServers())
+                .with(ConsumerConfig.GROUP_ID_CONFIG, historyName)
+                .with(ConsumerConfig.CLIENT_ID_CONFIG, "squatter")
+                .with(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false)
+                .with(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
+                .with(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class)
+                .with(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class)
+                .build();
+
+        try (KafkaConsumer<String, String> squatter = new KafkaConsumer<>(squatterConfig.asProperties())) {
+            squatter.subscribe(Collections.singletonList(topicName));
+            long deadline = System.currentTimeMillis() + 30000;
+            while (squatter.assignment().isEmpty() && System.currentTimeMillis() < deadline) {
+                squatter.poll(Duration.ofMillis(100));
+            }
+            assertThat(squatter.assignment()).isNotEmpty();
+
+            history = new KafkaSchemaHistory();
+            history.configure(config, null, SchemaHistoryListener.NOOP, true);
+            Tables recovered = new Tables();
+            setLogPosition(100);
+            history.recover(offsets, recovered, getDdlParser());
+
+            assertThat(recovered).isEqualTo(expected);
+        }
+    }
+
+    private Configuration recoveryConfig(String topicName, String historyName) {
+        return Configuration.create()
+                .with(KafkaSchemaHistory.BOOTSTRAP_SERVERS, kafkaCluster.getBootstrapServers())
+                .with(KafkaSchemaHistory.TOPIC, topicName)
+                .with(SchemaHistory.NAME, historyName)
+                .with(KafkaSchemaHistory.RECOVERY_POLL_INTERVAL_MS, 500)
+                .with(KafkaSchemaHistory.consumerConfigPropertyName(
+                        ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG), 100)
+                .with(KafkaSchemaHistory.consumerConfigPropertyName(
+                        ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG), 50000)
+                .with(KafkaSchemaHistory.INTERNAL_CONNECTOR_CLASS, "org.apache.kafka.connect.source.SourceConnector")
+                .with(KafkaSchemaHistory.INTERNAL_CONNECTOR_ID, "dbz-test")
+                .build();
     }
 
     protected abstract P createPartition(String serverName, String databaseName);

--- a/debezium-connector-binlog/src/test/java/io/debezium/relational/history/AbstractSchemaHistoryTest.java
+++ b/debezium-connector-binlog/src/test/java/io/debezium/relational/history/AbstractSchemaHistoryTest.java
@@ -87,14 +87,14 @@ public abstract class AbstractSchemaHistoryTest<C extends SourceConnector> {
         }
     }
 
-    protected Tables recover(long pos, int entry) {
+    protected Tables recover(long pos, int entry) throws InterruptedException {
         Tables result = new Tables();
         history.recover(source1, position("a.log", pos, entry), result, parser);
         return result;
     }
 
     @Test
-    public void shouldRecordChangesAndRecoverToVariousPoints() {
+    public void shouldRecordChangesAndRecoverToVariousPoints() throws InterruptedException {
         record(01, 0, "CREATE TABLE foo ( first VARCHAR(22) NOT NULL );", all, t3, t2, t1, t0);
         record(23, 1, "CREATE TABLE\nperson ( name VARCHAR(22) NOT NULL );", all, t3, t2, t1);
         record(30, 2, "CREATE TABLE address\n( street VARCHAR(22) NOT NULL );", all, t3, t2);

--- a/debezium-connector-mariadb/src/main/java/io/debezium/connector/mariadb/MariaDbConnectorTask.java
+++ b/debezium-connector-mariadb/src/main/java/io/debezium/connector/mariadb/MariaDbConnectorTask.java
@@ -139,9 +139,10 @@ public class MariaDbConnectorTask extends BinlogSourceTask<MariaDbPartition, Mar
 
         MariaDbOffsetContext previousOffset = previousOffsets.getTheOnlyOffset();
 
-        validateAndLoadSchemaHistory(connectorConfig, connection::validateLogPosition, previousOffsets, schema, snapshotter);
+        validateSchemaHistory(connectorConfig, connection::validateLogPosition, previousOffsets, schema, snapshotter);
 
-        LOGGER.info("Reconnecting after finishing schema recovery");
+        LOGGER.info("Reconnecting after validating schema recovery");
+
         try {
             connection.setAutoCommit(false);
         }

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorTask.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorTask.java
@@ -131,9 +131,9 @@ public class MySqlConnectorTask extends BinlogSourceTask<MySqlPartition, MySqlOf
 
         MySqlOffsetContext previousOffset = previousOffsets.getTheOnlyOffset();
 
-        validateAndLoadSchemaHistory(connectorConfig, connection::validateLogPosition, previousOffsets, schema, snapshotter);
+        validateSchemaHistory(connectorConfig, connection::validateLogPosition, previousOffsets, schema, snapshotter);
 
-        LOGGER.info("Reconnecting after finishing schema recovery");
+        LOGGER.info("Reconnecting after validating schema recovery");
 
         try {
             connection.setAutoCommit(false);

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorTask.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorTask.java
@@ -106,7 +106,7 @@ public class OracleConnectorTask extends BaseSourceTask<OraclePartition, OracleO
 
         OracleOffsetContext previousOffset = previousOffsets.getTheOnlyOffset();
 
-        validateAndLoadSchemaHistory(connectorConfig, jdbcConnection::validateLogPosition, previousOffsets, schema, snapshotterService.getSnapshotter());
+        validateSchemaHistory(connectorConfig, jdbcConnection::validateLogPosition, previousOffsets, schema, snapshotterService.getSnapshotter());
 
         taskContext = new OracleTaskContext(connectorConfig, schema);
 

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
@@ -145,7 +145,7 @@ public class PostgresConnectorTask extends BaseSourceTask<PostgresPartition, Pos
                     beanRegistryJdbcConnection.username(), e);
         }
 
-        validateAndLoadSchemaHistory(connectorConfig, jdbcConnection::validateLogPosition, previousOffsets, schema, snapshotter);
+        validateSchemaHistory(connectorConfig, jdbcConnection::validateLogPosition, previousOffsets, schema, snapshotter);
 
         LoggingContext.PreviousContext previousContext = taskContext.configureLoggingContext(CONTEXT_NAME);
 

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorTask.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorTask.java
@@ -106,7 +106,7 @@ public class SqlServerConnectorTask extends BaseSourceTask<SqlServerPartition, S
 
         final SnapshotterService snapshotterService = connectorConfig.getServiceRegistry().tryGetService(SnapshotterService.class);
 
-        validateAndLoadSchemaHistory(connectorConfig, dataConnection::validateLogPosition, offsets, schema,
+        validateSchemaHistory(connectorConfig, dataConnection::validateLogPosition, offsets, schema,
                 snapshotterService.getSnapshotter());
 
         taskContext = new SqlServerTaskContext(connectorConfig, schema);

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectorIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectorIT.java
@@ -3440,12 +3440,12 @@ public class SqlServerConnectorIT extends AbstractAsyncEngineConnectorTest {
         }
 
         @Override
-        public void recover(Offsets<?, ?> offsets, Tables schema, DdlParser ddlParser) {
+        public void recover(Offsets<?, ?> offsets, Tables schema, DdlParser ddlParser) throws InterruptedException {
             delegate.recover(offsets, schema, ddlParser);
         }
 
         @Override
-        public void recover(Map<Map<String, ?>, Map<String, ?>> offsets, Tables schema, DdlParser ddlParser) {
+        public void recover(Map<Map<String, ?>, Map<String, ?>> offsets, Tables schema, DdlParser ddlParser) throws InterruptedException {
             delegate.recover(offsets, schema, ddlParser);
         }
 

--- a/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java
+++ b/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java
@@ -567,6 +567,8 @@ public abstract class CommonConnectorConfig {
     private static final String CONFLUENT_AVRO_CONVERTER = "io.confluent.connect.avro.AvroConverter";
     private static final String APICURIO_AVRO_CONVERTER = "io.apicurio.registry.utils.converter.AvroConverter";
 
+    // This should be less than the value of worker config task.shutdown.graceful.timeout.ms. It
+    // defaults to 5 seconds, hence setting it to 4 seconds.
     public static final long EXECUTOR_SHUTDOWN_TIMEOUT_SEC = 4;
     public static final int DEFAULT_MAX_QUEUE_SIZE = 8192;
     public static final int DEFAULT_MAX_BATCH_SIZE = 2048;

--- a/debezium-core/src/main/java/io/debezium/connector/common/BaseSourceTask.java
+++ b/debezium-core/src/main/java/io/debezium/connector/common/BaseSourceTask.java
@@ -74,9 +74,9 @@ public abstract class BaseSourceTask<P extends Partition, O extends OffsetContex
     private Configuration config;
     private List<SignalChannelReader> signalChannels;
 
-    protected void validateAndLoadSchemaHistory(CommonConnectorConfig config, LogPositionValidator logPositionValidator, Offsets<P, O> previousOffsets,
-                                                DatabaseSchema schema,
-                                                Snapshotter snapshotter) {
+    protected void validateSchemaHistory(CommonConnectorConfig config, LogPositionValidator logPositionValidator, Offsets<P, O> previousOffsets,
+                                         DatabaseSchema schema,
+                                         Snapshotter snapshotter) {
 
         for (Map.Entry<P, O> previousOffset : previousOffsets) {
 
@@ -148,10 +148,6 @@ public abstract class BaseSourceTask<P extends Partition, O extends OffsetContex
                                 + "available on the server. Reconfigure the connector to use a snapshot when needed if you want to recover. " +
                                 "If not the connector will streaming from the last available position in the log");
                     }
-                }
-
-                if (schema.isHistorized()) {
-                    ((HistorizedDatabaseSchema) schema).recover(partition, offset);
                 }
             }
         }

--- a/debezium-core/src/main/java/io/debezium/pipeline/ChangeEventSourceCoordinator.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/ChangeEventSourceCoordinator.java
@@ -50,6 +50,7 @@ import io.debezium.pipeline.spi.Partition;
 import io.debezium.pipeline.spi.SnapshotResult;
 import io.debezium.pipeline.spi.SnapshotResult.SnapshotResultStatus;
 import io.debezium.schema.DatabaseSchema;
+import io.debezium.schema.HistorizedDatabaseSchema;
 import io.debezium.snapshot.SnapshotterService;
 import io.debezium.spi.schema.DataCollectionId;
 import io.debezium.util.Clock;
@@ -138,6 +139,10 @@ public class ChangeEventSourceCoordinator<P extends Partition, O extends OffsetC
 
                     context = new ChangeEventSourceContextImpl();
                     LOGGER.info("Context created");
+
+                    if (schema.isHistorized() && ((HistorizedDatabaseSchema) schema).historyExists()) {
+                        ((HistorizedDatabaseSchema<?>) schema).recover(previousOffsets);
+                    }
 
                     snapshotSource = changeEventSourceFactory.getSnapshotChangeEventSource(snapshotMetrics, notificationService);
                     executeChangeEventSources(taskContext, snapshotSource, previousOffsets, previousLogContext, context);

--- a/debezium-core/src/main/java/io/debezium/pipeline/ChangeEventSourceCoordinator.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/ChangeEventSourceCoordinator.java
@@ -140,7 +140,11 @@ public class ChangeEventSourceCoordinator<P extends Partition, O extends OffsetC
                     context = new ChangeEventSourceContextImpl();
                     LOGGER.info("Context created");
 
-                    if (schema.isHistorized() && ((HistorizedDatabaseSchema) schema).historyExists()) {
+                    // Don't recover while an initial snapshot is still in progress; the resumed
+                    // snapshot rebuilds the schema itself.
+                    boolean initialSnapshotRunning = previousOffsets.getOffsets().values().stream()
+                            .anyMatch(offset -> offset != null && offset.isInitialSnapshotRunning());
+                    if (schema.isHistorized() && !initialSnapshotRunning && ((HistorizedDatabaseSchema) schema).historyExists()) {
                         ((HistorizedDatabaseSchema<?>) schema).recover(previousOffsets);
                     }
 

--- a/debezium-core/src/main/java/io/debezium/pipeline/ChangeEventSourceCoordinator.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/ChangeEventSourceCoordinator.java
@@ -19,6 +19,7 @@ import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
+import org.apache.kafka.common.errors.InterruptException;
 import org.apache.kafka.connect.source.SourceConnector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -151,7 +152,7 @@ public class ChangeEventSourceCoordinator<P extends Partition, O extends OffsetC
                     snapshotSource = changeEventSourceFactory.getSnapshotChangeEventSource(snapshotMetrics, notificationService);
                     executeChangeEventSources(taskContext, snapshotSource, previousOffsets, previousLogContext, context);
                 }
-                catch (InterruptedException e) {
+                catch (InterruptedException | InterruptException e) {
                     Thread.currentThread().interrupt();
                     LOGGER.warn("Change event source executor was interrupted", e);
                 }

--- a/debezium-core/src/main/java/io/debezium/relational/HistorizedRelationalDatabaseSchema.java
+++ b/debezium-core/src/main/java/io/debezium/relational/HistorizedRelationalDatabaseSchema.java
@@ -11,7 +11,6 @@ import java.util.function.Predicate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.debezium.DebeziumException;
 import io.debezium.pipeline.spi.Offsets;
 import io.debezium.relational.Key.KeyMapper;
 import io.debezium.relational.Tables.ColumnNameFilter;
@@ -53,7 +52,7 @@ public abstract class HistorizedRelationalDatabaseSchema extends RelationalDatab
     }
 
     @Override
-    public void recover(Offsets<?, ?> offsets) {
+    public void recover(Offsets<?, ?> offsets) throws InterruptedException {
         final boolean hasNonNullOffsets = offsets.getOffsets()
                 .values()
                 .stream()
@@ -62,11 +61,6 @@ public abstract class HistorizedRelationalDatabaseSchema extends RelationalDatab
         if (!hasNonNullOffsets) {
             // there is nothing to recover
             return;
-        }
-
-        if (!schemaHistory.exists()) {
-            String msg = "The db history topic or its content is fully or partially missing. Please check database schema history topic configuration and re-execute the snapshot.";
-            throw new DebeziumException(msg);
         }
 
         schemaHistory.recover(offsets, tables(), getDdlParser());

--- a/debezium-core/src/main/java/io/debezium/relational/history/AbstractSchemaHistory.java
+++ b/debezium-core/src/main/java/io/debezium/relational/history/AbstractSchemaHistory.java
@@ -87,7 +87,7 @@ public abstract class AbstractSchemaHistory implements SchemaHistory {
     }
 
     @Override
-    public void recover(Map<Map<String, ?>, Map<String, ?>> offsets, Tables schema, DdlParser ddlParser) {
+    public void recover(Map<Map<String, ?>, Map<String, ?>> offsets, Tables schema, DdlParser ddlParser) throws InterruptedException {
         listener.recoveryStarted();
         Map<Document, HistoryRecord> stopPoints = new HashMap<>();
         offsets.forEach((Map<String, ?> source, Map<String, ?> position) -> {
@@ -160,7 +160,7 @@ public abstract class AbstractSchemaHistory implements SchemaHistory {
 
     protected abstract void storeRecord(HistoryRecord record) throws SchemaHistoryException;
 
-    protected abstract void recoverRecords(Consumer<HistoryRecord> records);
+    protected abstract void recoverRecords(Consumer<HistoryRecord> records) throws InterruptedException;
 
     @Override
     public void stop() {

--- a/debezium-core/src/main/java/io/debezium/relational/history/SchemaHistory.java
+++ b/debezium-core/src/main/java/io/debezium/relational/history/SchemaHistory.java
@@ -164,7 +164,7 @@ public interface SchemaHistory {
      * @deprecated Use {@link #recover(Offsets, Tables, DdlParser)} instead.
      */
     @Deprecated
-    default void recover(Map<String, ?> source, Map<String, ?> position, Tables schema, DdlParser ddlParser) {
+    default void recover(Map<String, ?> source, Map<String, ?> position, Tables schema, DdlParser ddlParser) throws InterruptedException {
         recover(Collections.singletonMap(source, position), schema, ddlParser);
     }
 
@@ -181,7 +181,7 @@ public interface SchemaHistory {
      *            may not be null
      * @param ddlParser the DDL parser that can be used to apply DDL statements to the given {@code schema}; may not be null
      */
-    default void recover(Offsets<?, ?> offsets, Tables schema, DdlParser ddlParser) {
+    default void recover(Offsets<?, ?> offsets, Tables schema, DdlParser ddlParser) throws InterruptedException {
         Map<Map<String, ?>, Map<String, ?>> offsetMap = new HashMap<>();
         for (Entry<? extends Partition, ? extends OffsetContext> entry : offsets) {
             if (entry.getValue() != null) {
@@ -196,7 +196,7 @@ public interface SchemaHistory {
      * @deprecated Use {@link #recover(Offsets, Tables, DdlParser)} instead.
      */
     @Deprecated
-    void recover(Map<Map<String, ?>, Map<String, ?>> offsets, Tables schema, DdlParser ddlParser);
+    void recover(Map<Map<String, ?>, Map<String, ?>> offsets, Tables schema, DdlParser ddlParser) throws InterruptedException;
 
     /**
      * Stop recording history and release any resources acquired since {@link #configure(Configuration, HistoryRecordComparator, SchemaHistoryListener, boolean)}.

--- a/debezium-core/src/main/java/io/debezium/schema/HistorizedDatabaseSchema.java
+++ b/debezium-core/src/main/java/io/debezium/schema/HistorizedDatabaseSchema.java
@@ -36,11 +36,11 @@ public interface HistorizedDatabaseSchema<I extends DataCollectionId> extends Da
 
     void applySchemaChange(SchemaChangeEvent schemaChange);
 
-    default void recover(Partition partition, OffsetContext offset) {
+    default void recover(Partition partition, OffsetContext offset) throws InterruptedException {
         recover(Offsets.of(partition, offset));
     }
 
-    void recover(Offsets<?, ?> offsets);
+    void recover(Offsets<?, ?> offsets) throws InterruptedException;
 
     void initializeStorage();
 

--- a/debezium-core/src/test/java/io/debezium/connector/common/BaseSourceTaskSnapshotModesValidationTest.java
+++ b/debezium-core/src/test/java/io/debezium/connector/common/BaseSourceTaskSnapshotModesValidationTest.java
@@ -62,7 +62,7 @@ public class BaseSourceTaskSnapshotModesValidationTest {
         when(snapshotter.shouldSnapshotData(true, true)).thenReturn(false);
         when(snapshotter.shouldSnapshotSchema(true, true)).thenReturn(true);
 
-        assertThatCode(() -> baseSourceTask.validateAndLoadSchemaHistory(commonConnectorConfig, logPositionValidator, previousOffsets, databaseSchema, snapshotter))
+        assertThatCode(() -> baseSourceTask.validateSchemaHistory(commonConnectorConfig, logPositionValidator, previousOffsets, databaseSchema, snapshotter))
                 .doesNotThrowAnyException();
 
     }
@@ -83,7 +83,7 @@ public class BaseSourceTaskSnapshotModesValidationTest {
         when(snapshotter.shouldSnapshotData(true, true)).thenReturn(false);
         when(snapshotter.shouldSnapshotSchema(true, true)).thenReturn(false);
 
-        assertThatCode(() -> baseSourceTask.validateAndLoadSchemaHistory(commonConnectorConfig, logPositionValidator, previousOffsets, databaseSchema, snapshotter))
+        assertThatCode(() -> baseSourceTask.validateSchemaHistory(commonConnectorConfig, logPositionValidator, previousOffsets, databaseSchema, snapshotter))
                 .isInstanceOf(DebeziumException.class)
                 .hasMessage("The connector previously stopped while taking a snapshot, but now the connector is configured "
                         + "to never allow snapshots. Reconfigure the connector to use snapshots initially or when needed.");
@@ -104,7 +104,7 @@ public class BaseSourceTaskSnapshotModesValidationTest {
 
         when(snapshotter.shouldSnapshotOnSchemaError()).thenReturn(true);
 
-        assertThatThrownBy(() -> baseSourceTask.validateAndLoadSchemaHistory(commonConnectorConfig, logPositionValidator, previousOffsets, databaseSchema, snapshotter))
+        assertThatThrownBy(() -> baseSourceTask.validateSchemaHistory(commonConnectorConfig, logPositionValidator, previousOffsets, databaseSchema, snapshotter))
                 .isInstanceOf(DebeziumException.class)
                 .hasMessage("Could not find existing redo log information while attempting schema only recovery snapshot");
 
@@ -124,7 +124,7 @@ public class BaseSourceTaskSnapshotModesValidationTest {
 
         Snapshotter snapshotter = mock(Snapshotter.class);
 
-        baseSourceTask.validateAndLoadSchemaHistory(commonConnectorConfig, logPositionValidator, previousOffsets, databaseSchema, snapshotter);
+        baseSourceTask.validateSchemaHistory(commonConnectorConfig, logPositionValidator, previousOffsets, databaseSchema, snapshotter);
 
         verify(databaseSchema).initializeStorage();
     }
@@ -145,7 +145,7 @@ public class BaseSourceTaskSnapshotModesValidationTest {
         Snapshotter snapshotter = mock(Snapshotter.class);
         when(snapshotter.shouldSnapshotOnSchemaError()).thenReturn(true);
 
-        baseSourceTask.validateAndLoadSchemaHistory(commonConnectorConfig, logPositionValidator, previousOffsets, databaseSchema, snapshotter);
+        baseSourceTask.validateSchemaHistory(commonConnectorConfig, logPositionValidator, previousOffsets, databaseSchema, snapshotter);
 
         verify(databaseSchema).initializeStorage();
 
@@ -167,7 +167,7 @@ public class BaseSourceTaskSnapshotModesValidationTest {
         Snapshotter snapshotter = mock(Snapshotter.class);
         when(snapshotter.shouldSnapshotOnSchemaError()).thenReturn(false);
 
-        assertThatThrownBy(() -> baseSourceTask.validateAndLoadSchemaHistory(commonConnectorConfig, logPositionValidator, previousOffsets, databaseSchema, snapshotter))
+        assertThatThrownBy(() -> baseSourceTask.validateSchemaHistory(commonConnectorConfig, logPositionValidator, previousOffsets, databaseSchema, snapshotter))
                 .isInstanceOf(DebeziumException.class)
                 .hasMessage("The db history topic is missing. You may attempt to recover it by reconfiguring the connector to recovery.");
 
@@ -190,9 +190,7 @@ public class BaseSourceTaskSnapshotModesValidationTest {
         when(databaseSchema.historyExists()).thenReturn(true);
         Snapshotter snapshotter = mock(Snapshotter.class);
 
-        baseSourceTask.validateAndLoadSchemaHistory(commonConnectorConfig, logPositionValidator, previousOffsets, databaseSchema, snapshotter);
-
-        verify(databaseSchema).recover(partition, offset);
+        baseSourceTask.validateSchemaHistory(commonConnectorConfig, logPositionValidator, previousOffsets, databaseSchema, snapshotter);
 
     }
 
@@ -215,7 +213,7 @@ public class BaseSourceTaskSnapshotModesValidationTest {
         when(databaseSchema.historyExists()).thenReturn(true);
         Snapshotter snapshotter = mock(Snapshotter.class);
 
-        baseSourceTask.validateAndLoadSchemaHistory(commonConnectorConfig, logPositionValidator, previousOffsets, databaseSchema, snapshotter);
+        baseSourceTask.validateSchemaHistory(commonConnectorConfig, logPositionValidator, previousOffsets, databaseSchema, snapshotter);
 
         assertThat(logInterceptor.containsWarnMessage("The connector is trying to read redo log starting at " + offset + ", but this is no longer "
                 + "available on the server. Reconfigure the connector to use a snapshot when needed if you want to recover. " +
@@ -241,7 +239,7 @@ public class BaseSourceTaskSnapshotModesValidationTest {
         Snapshotter snapshotter = mock(Snapshotter.class);
         when(snapshotter.shouldSnapshotOnDataError()).thenReturn(true);
 
-        baseSourceTask.validateAndLoadSchemaHistory(commonConnectorConfig, logPositionValidator, previousOffsets, databaseSchema, snapshotter);
+        baseSourceTask.validateSchemaHistory(commonConnectorConfig, logPositionValidator, previousOffsets, databaseSchema, snapshotter);
 
         assertThat(previousOffsets.getTheOnlyOffset()).isNull();
 

--- a/debezium-embedded/src/test/java/io/debezium/embedded/AbstractConnectorTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/embedded/AbstractConnectorTest.java
@@ -301,6 +301,18 @@ public abstract class AbstractConnectorTest implements Testing {
     }
 
     /**
+    * Start the connector using the supplied connector configuration, where upon completion the status of the connector is
+    * logged.
+    *
+    * @param connectorClass    the connector class; may not be null
+    * @param connectorConfig   the configuration for the connector; may not be null
+    * @param connectorCallback {@link io.debezium.engine.DebeziumEngine.ConnectorCallback} instance; may be null
+    */
+    protected void start(Class<? extends SourceConnector> connectorClass, Configuration connectorConfig, DebeziumEngine.ConnectorCallback connectorCallback) {
+        start(connectorClass, connectorConfig, loggingCompletion(), null, connectorCallback);
+    }
+
+    /**
      * Start the connector using the supplied connector configuration, where upon completion the status of the connector is
      * logged. Records arriving after connector stop must not be ignored.
      *
@@ -349,12 +361,30 @@ public abstract class AbstractConnectorTest implements Testing {
      *
      * @param connectorClass the connector class; may not be null
      * @param connectorConfig the configuration for the connector; may not be null
+     * @param isStopRecord the function that will be called to determine if the connector should be stopped before processing
+     *            this record; may be null if not needed
+     * @param callback the function that will be called when the engine fails to start the connector or when the connector
+     *            stops running after completing successfully or due to an error; may be null
+     * @param connectorCallback {@link io.debezium.engine.DebeziumEngine.ConnectorCallback} instance; may be null
+     */
+    protected void start(Class<? extends SourceConnector> connectorClass, Configuration connectorConfig,
+                         DebeziumEngine.CompletionCallback callback, Predicate<SourceRecord> isStopRecord,
+                         DebeziumEngine.ConnectorCallback connectorCallback) {
+        start(connectorClass, connectorConfig, callback, isStopRecord, x -> {
+        }, true, null, connectorCallback);
+    }
+
+    /**
+     * Start the connector using the supplied connector configuration.
+     *
+     * @param connectorClass the connector class; may not be null
+     * @param connectorConfig the configuration for the connector; may not be null
      * @param changeConsumer {@link io.debezium.engine.DebeziumEngine.ChangeConsumer} invoked when a record arrives and is stored in the queue
      */
     protected void start(Class<? extends SourceConnector> connectorClass, Configuration connectorConfig,
                          DebeziumEngine.ChangeConsumer<SourceRecord> changeConsumer) {
         start(connectorClass, connectorConfig, loggingCompletion(), null, x -> {
-        }, true, changeConsumer);
+        }, true, changeConsumer, null);
     }
 
     /**
@@ -372,7 +402,7 @@ public abstract class AbstractConnectorTest implements Testing {
     protected void start(Class<? extends SourceConnector> connectorClass, Configuration connectorConfig,
                          DebeziumEngine.CompletionCallback callback, Predicate<SourceRecord> isStopRecord,
                          Consumer<SourceRecord> recordArrivedListener, boolean ignoreRecordsAfterStop) {
-        start(connectorClass, connectorConfig, callback, isStopRecord, recordArrivedListener, ignoreRecordsAfterStop, null);
+        start(connectorClass, connectorConfig, callback, isStopRecord, recordArrivedListener, ignoreRecordsAfterStop, null, null);
     }
 
     /**
@@ -390,7 +420,8 @@ public abstract class AbstractConnectorTest implements Testing {
      */
     protected void start(Class<? extends SourceConnector> connectorClass, Configuration connectorConfig,
                          DebeziumEngine.CompletionCallback callback, Predicate<SourceRecord> isStopRecord,
-                         Consumer<SourceRecord> recordArrivedListener, boolean ignoreRecordsAfterStop, DebeziumEngine.ChangeConsumer<SourceRecord> changeConsumer) {
+                         Consumer<SourceRecord> recordArrivedListener, boolean ignoreRecordsAfterStop,
+                         DebeziumEngine.ChangeConsumer changeConsumer, DebeziumEngine.ConnectorCallback connectorCallback) {
         Configuration config = Configuration.copy(connectorConfig)
                 .with(EmbeddedEngineConfig.ENGINE_NAME, "testing-connector")
                 .with(EmbeddedEngineConfig.CONNECTOR_CLASS, connectorClass.getName())
@@ -413,10 +444,13 @@ public abstract class AbstractConnectorTest implements Testing {
             Testing.debug("Stopped connector");
         };
 
-        DebeziumEngine.ConnectorCallback connectorCallback = new DebeziumEngine.ConnectorCallback() {
+        DebeziumEngine.ConnectorCallback wrapperConnectorCallback = new DebeziumEngine.ConnectorCallback() {
             @Override
             public void taskStarted() {
                 // if this is called, it means a task has been started successfully so we can continue
+                if (connectorCallback != null) {
+                    connectorCallback.taskStarted();
+                }
                 latch.countDown();
             }
 
@@ -439,7 +473,7 @@ public abstract class AbstractConnectorTest implements Testing {
                 .notifying(getConsumer(isStopRecord, recordArrivedListener, ignoreRecordsAfterStop))
                 .using(this.getClass().getClassLoader())
                 .using(wrapperCallback)
-                .using(connectorCallback);
+                .using(wrapperConnectorCallback);
         if (changeConsumer != null) {
             builder.notifying(changeConsumer);
         }

--- a/debezium-embedded/src/test/java/io/debezium/relational/history/AbstractSchemaHistoryTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/relational/history/AbstractSchemaHistoryTest.java
@@ -76,7 +76,7 @@ public abstract class AbstractSchemaHistoryTest extends AbstractAsyncEngineConne
         Arrays.stream(records).forEach(schemaHistory::storeRecord);
     }
 
-    protected Tables recoverHistory() {
+    protected Tables recoverHistory() throws InterruptedException {
         // Initialize history
         schemaHistory.configure(getHistoryConfiguration(), null, SchemaHistoryMetrics.NOOP, true);
         schemaHistory.start();

--- a/debezium-storage/debezium-storage-file/src/main/java/io/debezium/storage/file/history/DelayingFileBasedSchemaHistory.java
+++ b/debezium-storage/debezium-storage-file/src/main/java/io/debezium/storage/file/history/DelayingFileBasedSchemaHistory.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.storage.file.history;
+
+import java.util.function.Consumer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.annotation.ThreadSafe;
+import io.debezium.config.Configuration;
+import io.debezium.relational.history.HistoryRecord;
+import io.debezium.relational.history.HistoryRecordComparator;
+import io.debezium.relational.history.SchemaHistoryListener;
+
+/**
+ * A {@link io.debezium.relational.history.SchemaHistory} implementation that extends {@link FileSchemaHistory} and
+ * adds configurable delays during recovery for testing purposes.
+ */
+@ThreadSafe
+public final class DelayingFileBasedSchemaHistory extends FileSchemaHistory {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DelayingFileBasedSchemaHistory.class);
+
+    /**
+     * The configuration property that specifies how long to delay when recovering each record.
+     */
+    public static final String RECOVERY_DELAY_MS_PROPERTY = CONFIGURATION_FIELD_PREFIX_STRING + "recovery.delay.ms";
+
+    private long recoveryDelayMs = 0L;
+
+    @Override
+    public void configure(Configuration config, HistoryRecordComparator comparator, SchemaHistoryListener listener, boolean useCatalogBeforeSchema) {
+        super.configure(config, comparator, listener, useCatalogBeforeSchema);
+        recoveryDelayMs = config.getLong(RECOVERY_DELAY_MS_PROPERTY, 0L);
+    }
+
+    @Override
+    protected void recoverRecords(Consumer<HistoryRecord> records) {
+        lock.write(() -> {
+            for (HistoryRecord record : getRecords()) {
+                records.accept(record);
+
+                // Introduce a delay if configured
+                if (recoveryDelayMs > 0) {
+                    try {
+                        LOGGER.info("Sleeping for {} ms to simulate recovery delay", recoveryDelayMs);
+                        Thread.sleep(recoveryDelayMs);
+                    }
+                    catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        throw new RuntimeException("Interrupted while recovering records", e);
+                    }
+                }
+            }
+        });
+    }
+
+    @Override
+    public String toString() {
+        return "delaying-" + super.toString();
+    }
+}

--- a/debezium-storage/debezium-storage-file/src/main/java/io/debezium/storage/file/history/FileSchemaHistory.java
+++ b/debezium-storage/debezium-storage-file/src/main/java/io/debezium/storage/file/history/FileSchemaHistory.java
@@ -36,7 +36,7 @@ import io.debezium.util.Loggings;
  * @author Randall Hauch
  */
 @ThreadSafe
-public final class FileSchemaHistory extends AbstractFileBasedSchemaHistory {
+public class FileSchemaHistory extends AbstractFileBasedSchemaHistory {
     private static final Logger LOGGER = LoggerFactory.getLogger(FileSchemaHistory.class);
 
     public static final Field FILE_PATH = Field.create(SchemaHistory.CONFIGURATION_FIELD_PREFIX_STRING + "file.filename")

--- a/debezium-storage/debezium-storage-kafka/src/main/java/io/debezium/storage/kafka/history/KafkaSchemaHistory.java
+++ b/debezium-storage/debezium-storage-kafka/src/main/java/io/debezium/storage/kafka/history/KafkaSchemaHistory.java
@@ -43,7 +43,6 @@ import org.apache.kafka.common.config.ConfigDef.Importance;
 import org.apache.kafka.common.config.ConfigDef.Type;
 import org.apache.kafka.common.config.ConfigDef.Width;
 import org.apache.kafka.common.config.ConfigResource;
-import org.apache.kafka.common.errors.InterruptException;
 import org.apache.kafka.common.errors.TopicExistsException;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.serialization.StringDeserializer;
@@ -377,11 +376,9 @@ public class KafkaSchemaHistory extends AbstractSchemaHistory {
                 }
             } while (lastProcessedOffset < endOffset - 1);
         }
-        catch (InterruptException | InterruptedException e) {
+        catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            InterruptedException interrupted = new InterruptedException("Interrupted during schema history recovery: " + e.getMessage());
-            interrupted.initCause(e);
-            throw interrupted;
+            throw e;
         }
     }
 

--- a/debezium-storage/debezium-storage-kafka/src/main/java/io/debezium/storage/kafka/history/KafkaSchemaHistory.java
+++ b/debezium-storage/debezium-storage-kafka/src/main/java/io/debezium/storage/kafka/history/KafkaSchemaHistory.java
@@ -374,13 +374,9 @@ public class KafkaSchemaHistory extends AbstractSchemaHistory {
                 }
             } while (lastProcessedOffset < endOffset - 1);
         }
-        catch (InterruptException e) {
+        catch (InterruptException | InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw new InterruptedException("Interrupted while polling Kafka during schema history recovery");
-        }
-        catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw e;
+            throw new InterruptedException("Interrupted during schema history recovery");
         }
     }
 

--- a/debezium-storage/debezium-storage-kafka/src/main/java/io/debezium/storage/kafka/history/KafkaSchemaHistory.java
+++ b/debezium-storage/debezium-storage-kafka/src/main/java/io/debezium/storage/kafka/history/KafkaSchemaHistory.java
@@ -307,9 +307,12 @@ public class KafkaSchemaHistory extends AbstractSchemaHistory {
     @Override
     protected void recoverRecords(Consumer<HistoryRecord> records) throws InterruptedException {
         try (KafkaConsumer<String, String> historyConsumer = new KafkaConsumer<>(consumerConfig.asProperties())) {
-            // Subscribe to the only partition for this topic, and seek to the beginning of that partition ...
-            LOGGER.debug("Subscribing to database schema history topic '{}'", topicName);
-            historyConsumer.subscribe(Collect.arrayListOf(topicName));
+            // Assign the single partition directly instead of subscribing, so overlapping recovery
+            // instances don't contend for a group assignment.
+            LOGGER.debug("Assigning the partition of database schema history topic '{}'", topicName);
+            TopicPartition topicPartition = new TopicPartition(topicName, PARTITION);
+            historyConsumer.assign(Collect.arrayListOf(topicPartition));
+            historyConsumer.seekToBeginning(Collect.arrayListOf(topicPartition));
 
             // Read all messages in the topic ...
             long lastProcessedOffset = UNLIMITED_VALUE;

--- a/debezium-storage/debezium-storage-kafka/src/main/java/io/debezium/storage/kafka/history/KafkaSchemaHistory.java
+++ b/debezium-storage/debezium-storage-kafka/src/main/java/io/debezium/storage/kafka/history/KafkaSchemaHistory.java
@@ -297,8 +297,14 @@ public class KafkaSchemaHistory extends AbstractSchemaHistory {
         }
     }
 
+    private void checkForInterruption() throws InterruptedException {
+        if (Thread.currentThread().isInterrupted()) {
+            throw new InterruptedException("Thread was interrupted during schema history recovery");
+        }
+    }
+
     @Override
-    protected void recoverRecords(Consumer<HistoryRecord> records) {
+    protected void recoverRecords(Consumer<HistoryRecord> records) throws InterruptedException {
         try (KafkaConsumer<String, String> historyConsumer = new KafkaConsumer<>(consumerConfig.asProperties())) {
             // Subscribe to the only partition for this topic, and seek to the beginning of that partition ...
             LOGGER.debug("Subscribing to database schema history topic '{}'", topicName);
@@ -319,11 +325,13 @@ public class KafkaSchemaHistory extends AbstractSchemaHistory {
                 endOffset = getEndOffsetOfDbHistoryTopic(endOffset, historyConsumer);
                 LOGGER.debug("End offset of database schema history topic is {}", endOffset);
 
+                checkForInterruption();
                 // DBZ-1361 not using poll(Duration) to keep compatibility with AK 1.x
                 ConsumerRecords<String, String> recoveredRecords = historyConsumer.poll(this.pollInterval);
                 int numRecordsProcessed = 0;
 
                 for (ConsumerRecord<String, String> record : recoveredRecords) {
+                    checkForInterruption();
                     try {
                         if (lastProcessedOffset < record.offset()) {
                             if (record.value() == null) {
@@ -364,6 +372,10 @@ public class KafkaSchemaHistory extends AbstractSchemaHistory {
                     recoveryAttempts = 0;
                 }
             } while (lastProcessedOffset < endOffset - 1);
+        }
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw e;
         }
     }
 

--- a/debezium-storage/debezium-storage-kafka/src/main/java/io/debezium/storage/kafka/history/KafkaSchemaHistory.java
+++ b/debezium-storage/debezium-storage-kafka/src/main/java/io/debezium/storage/kafka/history/KafkaSchemaHistory.java
@@ -43,6 +43,7 @@ import org.apache.kafka.common.config.ConfigDef.Importance;
 import org.apache.kafka.common.config.ConfigDef.Type;
 import org.apache.kafka.common.config.ConfigDef.Width;
 import org.apache.kafka.common.config.ConfigResource;
+import org.apache.kafka.common.errors.InterruptException;
 import org.apache.kafka.common.errors.TopicExistsException;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.serialization.StringDeserializer;
@@ -372,6 +373,10 @@ public class KafkaSchemaHistory extends AbstractSchemaHistory {
                     recoveryAttempts = 0;
                 }
             } while (lastProcessedOffset < endOffset - 1);
+        }
+        catch (InterruptException e) {
+            Thread.currentThread().interrupt();
+            throw new InterruptedException("Interrupted while polling Kafka during schema history recovery");
         }
         catch (InterruptedException e) {
             Thread.currentThread().interrupt();

--- a/debezium-storage/debezium-storage-kafka/src/main/java/io/debezium/storage/kafka/history/KafkaSchemaHistory.java
+++ b/debezium-storage/debezium-storage-kafka/src/main/java/io/debezium/storage/kafka/history/KafkaSchemaHistory.java
@@ -376,7 +376,9 @@ public class KafkaSchemaHistory extends AbstractSchemaHistory {
         }
         catch (InterruptException | InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw new InterruptedException("Interrupted during schema history recovery");
+            InterruptedException interrupted = new InterruptedException("Interrupted during schema history recovery: " + e.getMessage());
+            interrupted.initCause(e);
+            throw interrupted;
         }
     }
 

--- a/debezium-storage/debezium-storage-tests/src/test/java/io/debezium/storage/AbstractSchemaHistoryTest.java
+++ b/debezium-storage/debezium-storage-tests/src/test/java/io/debezium/storage/AbstractSchemaHistoryTest.java
@@ -87,14 +87,14 @@ public abstract class AbstractSchemaHistoryTest {
         }
     }
 
-    protected Tables recover(long pos, int entry) {
+    protected Tables recover(long pos, int entry) throws InterruptedException {
         Tables result = new Tables();
         history.recover(source1, position("a.log", pos, entry), result, parser);
         return result;
     }
 
     @Test
-    public void shouldRecordChangesAndRecoverToVariousPoints() {
+    public void shouldRecordChangesAndRecoverToVariousPoints() throws InterruptedException {
         record(01, 0, "CREATE TABLE foo ( first VARCHAR(22) NOT NULL );", all, t3, t2, t1, t0);
         record(23, 1, "CREATE TABLE\nperson ( name VARCHAR(22) NOT NULL );", all, t3, t2, t1);
         record(30, 2, "CREATE TABLE address\n( street VARCHAR(22) NOT NULL );", all, t3, t2);


### PR DESCRIPTION
cherry picked from commit 42e27799ec35da3bd5c0e076e37c6f35ea7dbbb6

Moves schema-history recovery out of task `start()` into the `ChangeEventSourceCoordinator`

Ref : https://confluentinc.atlassian.net/wiki/spaces/~71202058214a37466c4fe2a2e8416eef27b952/pages/5693407292/Debezium+Schema+History+Recovery+Consumer-Group+Starvation+Race

### Manual testing : 
Introduced 5 sec sleep between every schema history record read for the purpose of testing.

**Local using KDP**
Tested the original connector restart having a large schema history topic. Task was not in any state for the duration of schema history recovery - no metrics seen.
Also saw the failure : 
<img width="1120" height="524" alt="Screenshot 2026-06-11 at 4 24 56 PM" src="https://github.com/user-attachments/assets/63cf72ef-206d-4b8d-9a47-5eba31a9e1a1" />

Tested connector restart with this PR's change - having large schema history topic. Task was in RUNNING state and metrics were visible. Above error was not seen.

**On devel canary**
Tested the original connector restart and roll having a large schema history topic. No metrics seen, task was being shown as RUNNING on the Grafana dashboard. Saw this during some restarts.
```
Caused by: java.lang.IllegalStateException: The database schema history couldn't be recovered. Consider to increase the value for schema.history.internal.kafka.recovery.poll.interval.ms
```

Tested connector restart with this PR's change - having large schema history topic. Task was in RUNNING state and metrics were visible. Above error was not seen even after multiple restarts.