### PR TITLE
Snapshot overrides log fixes

### DIFF
--- a/debezium-core/src/main/java/io/debezium/relational/RelationalDatabaseConnectorConfig.java
+++ b/debezium-core/src/main/java/io/debezium/relational/RelationalDatabaseConnectorConfig.java
@@ -839,14 +839,14 @@ public abstract class RelationalDatabaseConnectorConfig extends CommonConnectorC
         int errors = 0;
         if (!Strings.isNullOrBlank(config.getString(SNAPSHOT_SELECT_STATEMENT_OVERRIDES_BY_TABLE))) {
             problems.accept(field, overridesJson,
-                    "Cannot be set together with '" + SNAPSHOT_SELECT_STATEMENT_OVERRIDES_BY_TABLE.name() + "'; use only one");
+                    "Only '" + SNAPSHOT_SELECT_STATEMENT_OVERRIDES_BY_TABLE.name() + "' can be set");
             errors++;
         }
         try {
             DocumentReader.defaultReader().read(overridesJson);
         }
         catch (Exception e) {
-            problems.accept(field, overridesJson, "It's not a valid JSON");
+            problems.accept(field, overridesJson, "It must be a valid JSON object");
             errors++;
         }
         return errors;

--- a/debezium-core/src/main/java/io/debezium/relational/RelationalDatabaseConnectorConfig.java
+++ b/debezium-core/src/main/java/io/debezium/relational/RelationalDatabaseConnectorConfig.java
@@ -846,7 +846,7 @@ public abstract class RelationalDatabaseConnectorConfig extends CommonConnectorC
             DocumentReader.defaultReader().read(overridesJson);
         }
         catch (Exception e) {
-            problems.accept(field, overridesJson, "It must be a valid JSON object");
+            problems.accept(field, overridesJson, "It's not a valid JSON object");
             errors++;
         }
         return errors;

--- a/debezium-core/src/main/java/io/debezium/relational/RelationalSnapshotChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/relational/RelationalSnapshotChangeEventSource.java
@@ -273,7 +273,6 @@ public abstract class RelationalSnapshotChangeEventSource<P extends Partition, O
 
         List<String> dataCollectionsToBeSnapshotted = connectorConfig.getDataCollectionsToBeSnapshotted();
         Map<DataCollectionId, String> snapshotSelectOverridesByTable = connectorConfig.getSnapshotSelectOverridesByTable();
-        warnOnUnmatchedSnapshotSelectOverrides(snapshotSelectOverridesByTable);
 
         boolean offsetExists = previousOffset != null;
         boolean snapshotInProgress = false;
@@ -302,16 +301,23 @@ public abstract class RelationalSnapshotChangeEventSource<P extends Partition, O
     }
 
     /**
-     * Logs a warning for any snapshot select statement override whose table is not matched by the configured table
-     * filters ({@code table.include.list}/{@code table.exclude.list}). Such an override can never be applied because
-     * the table will not be among the captured tables, so the snapshot would silently fall back to a full-table select.
+     * Logs a warning for any snapshot select statement override whose table is not among the captured tables. Such an
+     * override can never be applied, so the table would silently fall back to a full-table snapshot. The matching mirrors
+     * {@link #getSnapshotSelectOverridesByTable(TableId, Map)}, including the catalog-stripped lookup, to avoid false
+     * warnings for overrides keyed without a catalog.
      */
-    private void warnOnUnmatchedSnapshotSelectOverrides(Map<DataCollectionId, String> snapshotSelectOverridesByTable) {
-        for (DataCollectionId dataCollectionId : snapshotSelectOverridesByTable.keySet()) {
-            if (dataCollectionId instanceof TableId
-                    && !connectorConfig.getTableFilters().dataCollectionFilter().isIncluded((TableId) dataCollectionId)) {
-                LOGGER.warn("Snapshot select statement override is configured for table '{}', but this table is not matched by "
-                        + "'table.include.list'/'table.exclude.list'; the override will be ignored.", dataCollectionId);
+    private void warnOnUnmatchedSnapshotSelectOverrides(RelationalSnapshotContext<P, O> snapshotContext,
+                                                        Map<DataCollectionId, String> snapshotSelectOverridesByTable) {
+        Set<TableId> capturedTables = snapshotContext.capturedTables;
+        Set<TableId> capturedTablesWithoutCatalog = capturedTables.stream()
+                .map(tableId -> new TableId(null, tableId.schema(), tableId.table()))
+                .collect(Collectors.toSet());
+
+        for (DataCollectionId overrideTable : snapshotSelectOverridesByTable.keySet()) {
+            boolean captured = capturedTables.contains(overrideTable) || capturedTablesWithoutCatalog.contains(overrideTable);
+            if (!captured) {
+                LOGGER.warn("Snapshot select statement override is configured for table '{}', which is not among the captured "
+                        + "tables; the override will be ignored.", overrideTable);
             }
         }
     }
@@ -499,6 +505,8 @@ public abstract class RelationalSnapshotChangeEventSource<P extends Partition, O
                                   Queue<JdbcConnection> connectionPool, Map<DataCollectionId, String> snapshotSelectOverridesByTable)
             throws Exception {
         tryStartingSnapshot(snapshotContext);
+
+        warnOnUnmatchedSnapshotSelectOverrides(snapshotContext, snapshotSelectOverridesByTable);
 
         SnapshotReceiver<P> snapshotReceiver = dispatcher.getSnapshotChangeEventReceiver();
 

--- a/debezium-core/src/main/java/io/debezium/relational/RelationalSnapshotChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/relational/RelationalSnapshotChangeEventSource.java
@@ -302,9 +302,9 @@ public abstract class RelationalSnapshotChangeEventSource<P extends Partition, O
 
     /**
      * Logs a warning for any snapshot select statement override whose table is not among the captured tables. Such an
-     * override can never be applied, so the table would silently fall back to a full-table snapshot. The matching mirrors
-     * {@link #getSnapshotSelectOverridesByTable(TableId, Map)}, including the catalog-stripped lookup, to avoid false
-     * warnings for overrides keyed without a catalog.
+     * override can never be applied, since the table is not snapshotted at all, so the override is silently ignored. The
+     * matching mirrors {@link #getSnapshotSelectOverridesByTable(TableId, Map)}, including the catalog-stripped lookup, to
+     * avoid false warnings for overrides keyed without a catalog.
      */
     private void warnOnUnmatchedSnapshotSelectOverrides(RelationalSnapshotContext<P, O> snapshotContext,
                                                         Map<DataCollectionId, String> snapshotSelectOverridesByTable) {
@@ -522,9 +522,6 @@ public abstract class RelationalSnapshotChangeEventSource<P extends Partition, O
             if (selectStatement.isPresent()) {
                 LOGGER.info("For table '{}' using select statement: '{}'", tableId, maybeRedactSensitiveData(selectStatement.get()));
                 queryTables.put(tableId, selectStatement.get());
-                if (getSnapshotSelectOverridesByTable(tableId, snapshotSelectOverridesByTable) != null) {
-                    snapshotContext.tablesWithSnapshotSelectOverride.add(tableId);
-                }
 
                 final OptionalLong rowCount = rowCountForTable(tableId);
                 rowCountTables.put(tableId, rowCount);
@@ -773,6 +770,7 @@ public abstract class RelationalSnapshotChangeEventSource<P extends Partition, O
 
         String overriddenSelect = getSnapshotSelectOverridesByTable(tableId, snapshotSelectOverridesByTable);
         if (overriddenSelect != null) {
+            snapshotContext.tablesWithSnapshotSelectOverride.add(tableId);
             return Optional.of(enhanceOverriddenSelect(snapshotContext, overriddenSelect, tableId));
         }
 

--- a/debezium-core/src/main/java/io/debezium/relational/RelationalSnapshotChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/relational/RelationalSnapshotChangeEventSource.java
@@ -273,6 +273,7 @@ public abstract class RelationalSnapshotChangeEventSource<P extends Partition, O
 
         List<String> dataCollectionsToBeSnapshotted = connectorConfig.getDataCollectionsToBeSnapshotted();
         Map<DataCollectionId, String> snapshotSelectOverridesByTable = connectorConfig.getSnapshotSelectOverridesByTable();
+        warnOnUnmatchedSnapshotSelectOverrides(snapshotSelectOverridesByTable);
 
         boolean offsetExists = previousOffset != null;
         boolean snapshotInProgress = false;
@@ -298,6 +299,21 @@ public abstract class RelationalSnapshotChangeEventSource<P extends Partition, O
         return new SnapshottingTask(shouldSnapshotSchema, shouldSnapshotData,
                 dataCollectionsToBeSnapshotted, snapshotSelectOverridesByTable,
                 false);
+    }
+
+    /**
+     * Logs a warning for any snapshot select statement override whose table is not matched by the configured table
+     * filters ({@code table.include.list}/{@code table.exclude.list}). Such an override can never be applied because
+     * the table will not be among the captured tables, so the snapshot would silently fall back to a full-table select.
+     */
+    private void warnOnUnmatchedSnapshotSelectOverrides(Map<DataCollectionId, String> snapshotSelectOverridesByTable) {
+        for (DataCollectionId dataCollectionId : snapshotSelectOverridesByTable.keySet()) {
+            if (dataCollectionId instanceof TableId
+                    && !connectorConfig.getTableFilters().dataCollectionFilter().isIncluded((TableId) dataCollectionId)) {
+                LOGGER.warn("Snapshot select statement override is configured for table '{}', but this table is not matched by "
+                        + "'table.include.list'/'table.exclude.list'; the override will be ignored.", dataCollectionId);
+            }
+        }
     }
 
     /**
@@ -498,6 +514,9 @@ public abstract class RelationalSnapshotChangeEventSource<P extends Partition, O
             if (selectStatement.isPresent()) {
                 LOGGER.info("For table '{}' using select statement: '{}'", tableId, maybeRedactSensitiveData(selectStatement.get()));
                 queryTables.put(tableId, selectStatement.get());
+                if (getSnapshotSelectOverridesByTable(tableId, snapshotSelectOverridesByTable) != null) {
+                    snapshotContext.tablesWithSnapshotSelectOverride.add(tableId);
+                }
 
                 final OptionalLong rowCount = rowCountForTable(tableId);
                 rowCountTables.put(tableId, rowCount);
@@ -668,6 +687,9 @@ public abstract class RelationalSnapshotChangeEventSource<P extends Partition, O
             }
             else {
                 setSnapshotMarker(offset, firstTable, lastTable, false, true);
+                if (snapshotContext.tablesWithSnapshotSelectOverride.contains(table.id())) {
+                    LOGGER.warn("Snapshot select statement override for table '{}' matched 0 rows", table.id());
+                }
             }
 
             LOGGER.info("\t Finished exporting {} records for table '{}' ({} of {} tables); total duration '{}'",
@@ -850,6 +872,7 @@ public abstract class RelationalSnapshotChangeEventSource<P extends Partition, O
 
         public Set<TableId> capturedTables;
         public Set<TableId> capturedSchemaTables;
+        public final Set<TableId> tablesWithSnapshotSelectOverride = new HashSet<>();
 
         public RelationalSnapshotContext(P partition, String catalogName, boolean onDemand) {
             super(partition);

--- a/debezium-core/src/test/java/io/debezium/relational/RelationalDatabaseConnectorConfigTest.java
+++ b/debezium-core/src/test/java/io/debezium/relational/RelationalDatabaseConnectorConfigTest.java
@@ -120,7 +120,23 @@ public class RelationalDatabaseConnectorConfigTest {
         List<String> errors = validated.get(RelationalDatabaseConnectorConfig.SNAPSHOT_SELECT_STATEMENT_OVERRIDES_DATA_MAP.name())
                 .errorMessages();
         assertThat(errors).hasSize(1);
-        assertThat(errors.get(0)).contains("It's not a valid JSON");
+        assertThat(errors.get(0)).contains("It must be a valid JSON object");
+    }
+
+    @Test
+    public void validatorRejectsJsonThatIsNotAnObject() {
+        Configuration config = Configuration.create()
+                .with(RelationalDatabaseConnectorConfig.SNAPSHOT_SELECT_STATEMENT_OVERRIDES_DATA_MAP,
+                        "[\"db.table1\"]")
+                .build();
+
+        Map<String, ConfigValue> validated = config.validate(
+                Field.setOf(RelationalDatabaseConnectorConfig.SNAPSHOT_SELECT_STATEMENT_OVERRIDES_DATA_MAP));
+
+        List<String> errors = validated.get(RelationalDatabaseConnectorConfig.SNAPSHOT_SELECT_STATEMENT_OVERRIDES_DATA_MAP.name())
+                .errorMessages();
+        assertThat(errors).hasSize(1);
+        assertThat(errors.get(0)).contains("It must be a valid JSON object");
     }
 
     @Test
@@ -139,7 +155,7 @@ public class RelationalDatabaseConnectorConfigTest {
         List<String> errors = validated.get(RelationalDatabaseConnectorConfig.SNAPSHOT_SELECT_STATEMENT_OVERRIDES_DATA_MAP.name())
                 .errorMessages();
         assertThat(errors).hasSize(1);
-        assertThat(errors.get(0)).contains("Cannot be set together with 'snapshot.select.statement.overrides'");
+        assertThat(errors.get(0)).contains("Only 'snapshot.select.statement.overrides' can be set");
     }
 
     @Test

--- a/debezium-core/src/test/java/io/debezium/relational/RelationalDatabaseConnectorConfigTest.java
+++ b/debezium-core/src/test/java/io/debezium/relational/RelationalDatabaseConnectorConfigTest.java
@@ -120,7 +120,7 @@ public class RelationalDatabaseConnectorConfigTest {
         List<String> errors = validated.get(RelationalDatabaseConnectorConfig.SNAPSHOT_SELECT_STATEMENT_OVERRIDES_DATA_MAP.name())
                 .errorMessages();
         assertThat(errors).hasSize(1);
-        assertThat(errors.get(0)).contains("It must be a valid JSON object");
+        assertThat(errors.get(0)).contains("It's not a valid JSON object");
     }
 
     @Test
@@ -136,7 +136,7 @@ public class RelationalDatabaseConnectorConfigTest {
         List<String> errors = validated.get(RelationalDatabaseConnectorConfig.SNAPSHOT_SELECT_STATEMENT_OVERRIDES_DATA_MAP.name())
                 .errorMessages();
         assertThat(errors).hasSize(1);
-        assertThat(errors.get(0)).contains("It must be a valid JSON object");
+        assertThat(errors.get(0)).contains("It's not a valid JSON object");
     }
 
     @Test


### PR DESCRIPTION
-Added some logs for table spelling errors in snapshot overrides and for zero matched row.
- Some validation messages improvements.

<img width="1367" height="176" alt="image" src="https://github.com/user-attachments/assets/1e7b9a75-10b5-42f0-950c-ed75980cbde7" />


<img width="1364" height="201" alt="image" src="https://github.com/user-attachments/assets/2be10d90-4d2e-427d-b9bf-de0d4a6f85b0" />
