### PR TITLE
Smart Snapshot: SQL Server multi-task snapshot (Connector-managed, per-database)

### DIFF
--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerChangeEventSourceFactory.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerChangeEventSourceFactory.java
@@ -54,6 +54,10 @@ public class SqlServerChangeEventSourceFactory implements ChangeEventSourceFacto
     @Override
     public SnapshotChangeEventSource<SqlServerPartition, SqlServerOffsetContext> getSnapshotChangeEventSource(SnapshotProgressListener<SqlServerPartition> snapshotProgressListener,
                                                                                                               NotificationService<SqlServerPartition, SqlServerOffsetContext> notificationService) {
+        if (configuration.isSmartSnapshotEnabled() && configuration.getSmartSnapshotEpoch() != null) {
+            return new SqlServerSmartSnapshotChangeEventSource(configuration, connectionFactory, schema, dispatcher, clock, snapshotProgressListener,
+                    notificationService, snapshotterService);
+        }
         return new SqlServerSnapshotChangeEventSource(configuration, connectionFactory, schema, dispatcher, clock, snapshotProgressListener, notificationService,
                 snapshotterService);
     }

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnector.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnector.java
@@ -15,6 +15,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
@@ -25,8 +26,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.debezium.DebeziumException;
+import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
 import io.debezium.connector.common.RelationalBaseSourceConnector;
+import io.debezium.pipeline.source.snapshot.KafkaLogSnapshotCoordination;
+import io.debezium.pipeline.source.snapshot.SmartSnapshotConnectorCoordinator;
+import io.debezium.pipeline.source.snapshot.SnapshotCoordination;
+import io.debezium.pipeline.source.snapshot.SnapshotLifecycleManager;
 import io.debezium.relational.RelationalDatabaseConnectorConfig;
 import io.debezium.relational.TableId;
 import io.debezium.util.ThreadNameContext;
@@ -44,6 +50,13 @@ public class SqlServerConnector extends RelationalBaseSourceConnector {
 
     private Map<String, String> properties;
 
+    /*
+     * Smart-snapshot (multi-task) coordinators, one per database. SQL Server is multi-database, so each
+     * database coordinates its own snapshot independently (own consistent LSN, own write barrier, own epoch).
+     * Empty/null when smart.snapshot is disabled or every database's snapshot is already complete.
+     */
+    private volatile Map<String, SmartSnapshotConnectorCoordinator> smartSnapshotCoordinators;
+
     @Override
     public String version() {
         return Module.version();
@@ -52,6 +65,46 @@ public class SqlServerConnector extends RelationalBaseSourceConnector {
     @Override
     public void start(Map<String, String> props) {
         this.properties = Collections.unmodifiableMap(new HashMap<>(props));
+
+        final Configuration config = Configuration.from(properties);
+        if (!config.getBoolean(CommonConnectorConfig.SMART_SNAPSHOT_ENABLED)) {
+            return;
+        }
+
+        final SqlServerConnectorConfig connectorConfig = new SqlServerConnectorConfig(config);
+        final String serverName = connectorConfig.getLogicalName();
+        final String bootstrapServers = connectorConfig.getSmartSnapshotCoordinationBootstrapServers();
+        final boolean shouldStream = connectorConfig.getSnapshotMode() != SqlServerConnectorConfig.SnapshotMode.INITIAL_ONLY;
+
+        // All captured tables across all databases (catalog-qualified), grouped per database below.
+        final List<TableId> allTables = getMatchingCollections(config);
+        final Map<String, SmartSnapshotConnectorCoordinator> coordinators = new ConcurrentHashMap<>();
+
+        for (String databaseName : connectorConfig.getDatabaseNames()) {
+            List<TableId> dbTables = allTables.stream()
+                    .filter(t -> databaseName.equals(t.catalog()))
+                    .collect(Collectors.toList());
+            if (dbTables.isEmpty()) {
+                continue;
+            }
+
+            String coordinationTopic = serverName + "." + databaseName + ".snapshot-coordination";
+            String clientIdSuffix = serverName + "-" + databaseName + "-coordination-connector";
+            SnapshotCoordination coordination = new KafkaLogSnapshotCoordination(bootstrapServers, coordinationTopic, clientIdSuffix);
+            SnapshotLifecycleManager lifecycle = new SqlServerSnapshotLifecycleManager(connectorConfig, databaseName);
+            SmartSnapshotConnectorCoordinator coordinator = new SmartSnapshotConnectorCoordinator(
+                    coordination, lifecycle, context(), serverName, databaseName);
+
+            coordinator.start(dbTables, shouldStream);
+            if (coordinator.isComplete()) {
+                coordinator.stop();
+            }
+            else {
+                coordinators.put(databaseName, coordinator);
+            }
+        }
+
+        this.smartSnapshotCoordinators = coordinators;
     }
 
     @Override
@@ -66,6 +119,29 @@ public class SqlServerConnector extends RelationalBaseSourceConnector {
         }
 
         final SqlServerConnectorConfig config = new SqlServerConnectorConfig(Configuration.from(properties));
+
+        // Smart snapshot (multi-task) path: while any database's snapshot is still active, return the
+        // per-database sharded task configs from each coordinator. Each task is DB-exclusive (database.names
+        // is pinned to its single database). Once every coordinator reports complete (all return null), we
+        // fall through to the normal per-database streaming layout below (downscale).
+        if (Configuration.from(properties).getBoolean(CommonConnectorConfig.SMART_SNAPSHOT_ENABLED) && maxTasks > 1
+                && smartSnapshotCoordinators != null && !smartSnapshotCoordinators.isEmpty()) {
+            final boolean shouldStream = config.getSnapshotMode() != SqlServerConnectorConfig.SnapshotMode.INITIAL_ONLY;
+            final List<Map<String, String>> smartConfigs = new ArrayList<>();
+            for (Map.Entry<String, SmartSnapshotConnectorCoordinator> entry : smartSnapshotCoordinators.entrySet()) {
+                Map<String, String> baseProps = new HashMap<>(properties);
+                // DB-exclusive: every task this coordinator emits serves only its single database.
+                baseProps.put(DATABASE_NAMES.name(), entry.getKey());
+                List<Map<String, String>> dbConfigs = entry.getValue().taskConfigs(maxTasks, baseProps, shouldStream);
+                if (dbConfigs != null) {
+                    smartConfigs.addAll(dbConfigs);
+                }
+            }
+            if (!smartConfigs.isEmpty()) {
+                return smartConfigs;
+            }
+            // all coordinators complete → downscale to the normal streaming layout
+        }
 
         try (SqlServerConnection connection = connect(config)) {
             return buildTaskConfigs(connection, config, maxTasks);
@@ -108,6 +184,11 @@ public class SqlServerConnector extends RelationalBaseSourceConnector {
 
     @Override
     public void stop() {
+        Map<String, SmartSnapshotConnectorCoordinator> coordinators = this.smartSnapshotCoordinators;
+        this.smartSnapshotCoordinators = null;
+        if (coordinators != null) {
+            coordinators.values().forEach(SmartSnapshotConnectorCoordinator::stop);
+        }
     }
 
     @Override
@@ -140,7 +221,7 @@ public class SqlServerConnector extends RelationalBaseSourceConnector {
                         LOGGER.debug("Successfully tested connection for {} with user '{}'", connection.connectionString(), username);
                     }
                     LOGGER.info("Checking database existence and connected principal's access to CDC table based on "
-                        + "configured snapshot mode");
+                            + "configured snapshot mode");
                     final List<String> noAccessDatabaseNames = new ArrayList<>();
                     for (String databaseName : sqlServerConfig.getDatabaseNames()) {
                         if (sqlServerConfig.getSnapshotMode() == SqlServerConnectorConfig.SnapshotMode.INITIAL_ONLY) {

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnector.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnector.java
@@ -57,6 +57,12 @@ public class SqlServerConnector extends RelationalBaseSourceConnector {
      */
     private volatile Map<String, SmartSnapshotConnectorCoordinator> smartSnapshotCoordinators;
 
+    /*
+     * Captured-table count per database, recorded at start(). Used in taskConfigs() to derive the snapshot
+     * task count (ceil(count / smart.snapshot.tables.per.task)) independently of the user's tasks.max.
+     */
+    private volatile Map<String, Integer> smartSnapshotDbTableCounts;
+
     @Override
     public String version() {
         return Module.version();
@@ -79,6 +85,7 @@ public class SqlServerConnector extends RelationalBaseSourceConnector {
         // All captured tables across all databases (catalog-qualified), grouped per database below.
         final List<TableId> allTables = getMatchingCollections(config);
         final Map<String, SmartSnapshotConnectorCoordinator> coordinators = new ConcurrentHashMap<>();
+        final Map<String, Integer> tableCounts = new ConcurrentHashMap<>();
 
         for (String databaseName : connectorConfig.getDatabaseNames()) {
             List<TableId> dbTables = allTables.stream()
@@ -87,6 +94,7 @@ public class SqlServerConnector extends RelationalBaseSourceConnector {
             if (dbTables.isEmpty()) {
                 continue;
             }
+            tableCounts.put(databaseName, dbTables.size());
 
             String coordinationTopic = serverName + "." + databaseName + ".snapshot-coordination";
             String clientIdSuffix = serverName + "-" + databaseName + "-coordination-connector";
@@ -105,6 +113,7 @@ public class SqlServerConnector extends RelationalBaseSourceConnector {
         }
 
         this.smartSnapshotCoordinators = coordinators;
+        this.smartSnapshotDbTableCounts = tableCounts;
     }
 
     @Override
@@ -127,12 +136,19 @@ public class SqlServerConnector extends RelationalBaseSourceConnector {
         if (Configuration.from(properties).getBoolean(CommonConnectorConfig.SMART_SNAPSHOT_ENABLED) && maxTasks > 1
                 && smartSnapshotCoordinators != null && !smartSnapshotCoordinators.isEmpty()) {
             final boolean shouldStream = config.getSnapshotMode() != SqlServerConnectorConfig.SnapshotMode.INITIAL_ONLY;
+            final int tablesPerTask = config.getSmartSnapshotTablesPerTask();
             final List<Map<String, String>> smartConfigs = new ArrayList<>();
             for (Map.Entry<String, SmartSnapshotConnectorCoordinator> entry : smartSnapshotCoordinators.entrySet()) {
                 Map<String, String> baseProps = new HashMap<>(properties);
                 // DB-exclusive: every task this coordinator emits serves only its single database.
                 baseProps.put(DATABASE_NAMES.name(), entry.getKey());
-                List<Map<String, String>> dbConfigs = entry.getValue().taskConfigs(maxTasks, baseProps, shouldStream);
+                // Table-driven count: ceil(#tables / tablesPerTask), independent of the user's tasks.max
+                // (the snapshot is temporarily wider than tasks.max — requires tasks.max.enforce=false, and
+                // streaming downscales back to the user's tasks.max). Passed as the coordinator's maxTasks so
+                // its min(maxTasks, #tables) yields exactly the derived count.
+                int tableCount = smartSnapshotDbTableCounts.getOrDefault(entry.getKey(), 0);
+                int effectiveMaxTasks = Math.max(1, (int) Math.ceil((double) tableCount / tablesPerTask));
+                List<Map<String, String>> dbConfigs = entry.getValue().taskConfigs(effectiveMaxTasks, baseProps, shouldStream);
                 if (dbConfigs != null) {
                     smartConfigs.addAll(dbConfigs);
                 }

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnector.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnector.java
@@ -78,6 +78,23 @@ public class SqlServerConnector extends RelationalBaseSourceConnector {
         }
 
         final SqlServerConnectorConfig connectorConfig = new SqlServerConnectorConfig(config);
+
+        // Smart snapshot relies on SQL Server SNAPSHOT isolation: sharded tasks open their own
+        // snapshot-isolation transaction (and skip table locking) to pin the Connector-captured L_db. Under
+        // any other mode a task would read current committed state and silently ignore L_db, producing an
+        // inconsistent snapshot. Fail fast rather than corrupt data.
+        if (connectorConfig.getSnapshotIsolationMode() != SqlServerConnectorConfig.SnapshotIsolationMode.SNAPSHOT) {
+            throw new DebeziumException("smart.snapshot.enabled=true requires snapshot.isolation.mode=snapshot (and the "
+                    + "database option ALLOW_SNAPSHOT_ISOLATION ON), but snapshot.isolation.mode="
+                    + connectorConfig.getSnapshotIsolationMode().getValue());
+        }
+        // Fan-out returns ceil(#tables / tables.per.task) configs per database, which routinely exceeds
+        // tasks.max; AK >= 3.7 fails the connector for that unless tasks.max.enforce=false.
+        if (!"false".equalsIgnoreCase(properties.getOrDefault("tasks.max.enforce", "true"))) {
+            LOGGER.warn("smart.snapshot fan-out can return more tasks than tasks.max; set tasks.max.enforce=false "
+                    + "or the Kafka Connect runtime (>= 3.7) will reject the connector.");
+        }
+
         final String serverName = connectorConfig.getLogicalName();
         final String bootstrapServers = connectorConfig.getSmartSnapshotCoordinationBootstrapServers();
         final boolean shouldStream = connectorConfig.getSnapshotMode() != SqlServerConnectorConfig.SnapshotMode.INITIAL_ONLY;

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorConfig.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorConfig.java
@@ -32,6 +32,7 @@ import io.debezium.connector.AbstractSourceInfo;
 import io.debezium.connector.SourceInfoStructMaker;
 import io.debezium.document.Document;
 import io.debezium.jdbc.JdbcConfiguration;
+import io.debezium.pipeline.source.snapshot.SmartSnapshotConnectorCoordinator;
 import io.debezium.relational.ColumnFilterMode;
 import io.debezium.relational.HistorizedRelationalDatabaseConnectorConfig;
 import io.debezium.relational.RelationalDatabaseConnectorConfig;
@@ -811,6 +812,29 @@ public class SqlServerConnectorConfig extends HistorizedRelationalDatabaseConnec
      */
     public boolean isCredentialProviderConfigured() {
         return credsProvider != null;
+    }
+
+    /**
+     * Smart-snapshot coordination round for this task, or null when not a smart-snapshot sharded task.
+     * Distinguishes sharded snapshot tasks (which carry an epoch) from normal tasks that also carry a task id.
+     */
+    public Integer getSmartSnapshotEpoch() {
+        String epochStr = getConfig().getString(SmartSnapshotConnectorCoordinator.EPOCH_KEY);
+        return epochStr != null ? Integer.parseInt(epochStr) : null;
+    }
+
+    /**
+     * The task id assigned by the Connector, or null if absent.
+     */
+    public String getTaskId() {
+        return getConfig().getString(ConfigurationNames.TASK_ID_PROPERTY_NAME);
+    }
+
+    /**
+     * Whether smart (multi-task) snapshot is enabled for this connector.
+     */
+    public boolean isSmartSnapshotEnabled() {
+        return getConfig().getBoolean(CommonConnectorConfig.SMART_SNAPSHOT_ENABLED);
     }
 
     /**

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorTask.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorTask.java
@@ -6,6 +6,7 @@
 package io.debezium.connector.sqlserver;
 
 import java.sql.SQLException;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -29,12 +30,16 @@ import io.debezium.document.DocumentReader;
 import io.debezium.jdbc.DefaultMainConnectionProvidingConnectionFactory;
 import io.debezium.jdbc.MainConnectionProvidingConnectionFactory;
 import io.debezium.pipeline.ChangeEventSourceCoordinator;
+import io.debezium.pipeline.CommonOffsetContext;
 import io.debezium.pipeline.DataChangeEvent;
 import io.debezium.pipeline.ErrorHandler;
 import io.debezium.pipeline.EventDispatcher;
 import io.debezium.pipeline.GuardrailValidator;
 import io.debezium.pipeline.notification.NotificationService;
 import io.debezium.pipeline.signal.SignalProcessor;
+import io.debezium.pipeline.source.snapshot.KafkaLogSnapshotCoordination;
+import io.debezium.pipeline.source.snapshot.SmartSnapshotConnectorCoordinator;
+import io.debezium.pipeline.source.snapshot.SnapshotCoordination;
 import io.debezium.pipeline.spi.Offsets;
 import io.debezium.relational.TableId;
 import io.debezium.schema.SchemaFactory;
@@ -98,6 +103,15 @@ public class SqlServerConnectorTask extends BaseSourceTask<SqlServerPartition, S
         Offsets<SqlServerPartition, SqlServerOffsetContext> offsets = getPreviousOffsets(
                 new SqlServerPartition.Provider(connectorConfig),
                 new SqlServerOffsetContext.Loader(connectorConfig));
+
+        // Post-downscale streaming task: smart snapshot completed and we are now the normal streaming task.
+        // The sharded snapshot tasks wrote their completion under per-(server,database,task) offsets, so there
+        // is no {server,database} resume offset in connect-offsets. Seed each owned database's resume position
+        // from its coordination topic (L_db) so streaming continues from incrementLsn(L_db) instead of
+        // re-snapshotting. (A smart-snapshot sharded task carries an epoch; the streaming task does not.)
+        if (connectorConfig.isSmartSnapshotEnabled() && connectorConfig.getSmartSnapshotEpoch() == null) {
+            seedStreamingOffsetsFromCoordination(connectorConfig, offsets);
+        }
 
         // Manual Bean Registration
         connectorConfig.getBeanRegistry().add(StandardBeanNames.CONFIGURATION, config);
@@ -166,24 +180,74 @@ public class SqlServerConnectorTask extends BaseSourceTask<SqlServerPartition, S
         NotificationService<SqlServerPartition, SqlServerOffsetContext> notificationService = new NotificationService<>(getNotificationChannels(),
                 connectorConfig, SchemaFactory.get(), dispatcher::enqueueNotification);
 
-        ChangeEventSourceCoordinator<SqlServerPartition, SqlServerOffsetContext> coordinator = new SqlServerChangeEventSourceCoordinator(
-                offsets,
-                errorHandler,
-                SqlServerConnector.class,
-                connectorConfig,
-                new SqlServerChangeEventSourceFactory(connectorConfig, connectionFactory, metadataConnection, errorHandler, dispatcher, clock, schema,
-                        notificationService, snapshotterService),
-                new SqlServerMetricsFactory(offsets.getPartitions()),
-                dispatcher,
-                schema,
-                clock,
-                signalProcessor,
-                notificationService,
-                snapshotterService);
+        SqlServerChangeEventSourceFactory changeEventSourceFactory = new SqlServerChangeEventSourceFactory(connectorConfig, connectionFactory, metadataConnection,
+                errorHandler, dispatcher, clock, schema, notificationService, snapshotterService);
+        SqlServerMetricsFactory metricsFactory = new SqlServerMetricsFactory(offsets.getPartitions());
+
+        ChangeEventSourceCoordinator<SqlServerPartition, SqlServerOffsetContext> coordinator;
+        if (connectorConfig.isSmartSnapshotEnabled() && connectorConfig.getSmartSnapshotEpoch() != null) {
+            // Smart-snapshot sharded task: snapshot-only, reading the Connector-prepared L_db per database
+            // from the coordination topic.
+            int epoch = connectorConfig.getSmartSnapshotEpoch();
+            String serverName = connectorConfig.getLogicalName();
+            String databaseName = connectorConfig.getDatabaseNames().get(0);
+            String coordinationTopic = serverName + "." + databaseName + ".snapshot-coordination";
+            String clientIdSuffix = serverName + "-" + databaseName + "-coordination-task-" + connectorConfig.getTaskId();
+            SnapshotCoordination snapshotCoordination = new KafkaLogSnapshotCoordination(
+                    connectorConfig.getSmartSnapshotCoordinationBootstrapServers(), coordinationTopic, clientIdSuffix);
+            LOGGER.info("Smart snapshot [task-{}]: starting snapshot-only coordinator (db={}, epoch={})",
+                    connectorConfig.getTaskId(), databaseName, epoch);
+            coordinator = new SqlServerSmartSnapshotChangeEventSourceCoordinator(
+                    offsets, errorHandler, SqlServerConnector.class, connectorConfig, changeEventSourceFactory, metricsFactory,
+                    dispatcher, schema, clock, signalProcessor, notificationService, snapshotterService,
+                    epoch, snapshotCoordination, connectorConfig.getTaskId());
+        }
+        else {
+            coordinator = new SqlServerChangeEventSourceCoordinator(
+                    offsets, errorHandler, SqlServerConnector.class, connectorConfig, changeEventSourceFactory, metricsFactory,
+                    dispatcher, schema, clock, signalProcessor, notificationService, snapshotterService);
+        }
 
         coordinator.start(taskContext, this.queue, metadataProvider);
 
         return coordinator;
+    }
+
+    /**
+     * Seeds streaming resume offsets for a post-downscale streaming task from the per-database coordination
+     * topic. For each owned database that has no resume offset in connect-offsets, reads the completed
+     * smart-snapshot's consistent position (L_db) and installs an offset with {@code snapshot_completed=true}
+     * so streaming continues from {@code incrementLsn(L_db)} rather than re-snapshotting.
+     */
+    private void seedStreamingOffsetsFromCoordination(SqlServerConnectorConfig connectorConfig,
+                                                      Offsets<SqlServerPartition, SqlServerOffsetContext> offsets) {
+        String serverName = connectorConfig.getLogicalName();
+        String bootstrapServers = connectorConfig.getSmartSnapshotCoordinationBootstrapServers();
+        Map<SqlServerPartition, SqlServerOffsetContext> seeded = new HashMap<>();
+        for (Map.Entry<SqlServerPartition, SqlServerOffsetContext> entry : offsets) {
+            if (entry.getValue() != null) {
+                continue;
+            }
+            SqlServerPartition partition = entry.getKey();
+            String databaseName = partition.getDatabaseName();
+            String coordinationTopic = serverName + "." + databaseName + ".snapshot-coordination";
+            String clientIdSuffix = serverName + "-" + databaseName + "-coordination-streaming";
+            SnapshotCoordination coordination = new KafkaLogSnapshotCoordination(bootstrapServers, coordinationTopic, clientIdSuffix);
+            try {
+                coordination.start();
+                Map<String, Object> data = coordination.readSync(partition.getSharedSourcePartition());
+                if (data != null && Boolean.TRUE.equals(data.get(CommonOffsetContext.SNAPSHOT_COMPLETED_KEY))
+                        && data.get(SmartSnapshotConnectorCoordinator.SLOT_LSN_KEY) != null) {
+                    Lsn lsn = Lsn.valueOf(String.valueOf(data.get(SmartSnapshotConnectorCoordinator.SLOT_LSN_KEY)));
+                    LOGGER.info("Smart snapshot: seeding streaming resume offset for db={} from coordination topic, L_db={}", databaseName, lsn);
+                    seeded.put(partition, new SqlServerOffsetContext(connectorConfig, TxLogPosition.valueOf(lsn), null, true));
+                }
+            }
+            finally {
+                coordination.stop();
+            }
+        }
+        offsets.getOffsets().putAll(seeded);
     }
 
     @Override

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerOffsetContext.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerOffsetContext.java
@@ -15,6 +15,7 @@ import io.debezium.connector.AbstractSourceInfo;
 import io.debezium.connector.SnapshotRecord;
 import io.debezium.connector.SnapshotType;
 import io.debezium.pipeline.CommonOffsetContext;
+import io.debezium.pipeline.source.snapshot.SmartSnapshotConnectorCoordinator;
 import io.debezium.pipeline.source.snapshot.incremental.IncrementalSnapshotContext;
 import io.debezium.pipeline.spi.OffsetContext;
 import io.debezium.pipeline.txmetadata.TransactionContext;
@@ -31,6 +32,13 @@ public class SqlServerOffsetContext extends CommonOffsetContext<SourceInfo> {
      * The index of the current event within the current transaction.
      */
     private long eventSerialNo;
+
+    /**
+     * Smart-snapshot coordination round. Non-null only for multi-task smart-snapshot tasks; lets the
+     * Connector monitor distinguish completions of the current round from stale per-task offsets of a
+     * previous round.
+     */
+    private Integer epoch;
 
     public SqlServerOffsetContext(SqlServerConnectorConfig connectorConfig, TxLogPosition position, SnapshotType snapshot,
                                   boolean snapshotCompleted, long eventSerialNo, TransactionContext transactionContext,
@@ -69,7 +77,19 @@ public class SqlServerOffsetContext extends CommonOffsetContext<SourceInfo> {
         offset.put(SourceInfo.CHANGE_LSN_KEY,
                 sourceInfo.getChangeLsn() == null ? null : sourceInfo.getChangeLsn().toString());
         offset.put(SourceInfo.EVENT_SERIAL_NO_KEY, eventSerialNo);
+        if (epoch != null) {
+            offset.put(SmartSnapshotConnectorCoordinator.EPOCH_KEY, epoch);
+            offset.put(SNAPSHOT_COMPLETED_KEY, snapshotCompleted);
+        }
         return sourceInfo.isSnapshot() ? offset : incrementalSnapshotContext.store(transactionContext.store(offset));
+    }
+
+    public void setEpoch(Integer epoch) {
+        this.epoch = epoch;
+    }
+
+    public Integer getEpoch() {
+        return epoch;
     }
 
     @Override

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerPartition.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerPartition.java
@@ -20,8 +20,10 @@ import io.debezium.util.Collect;
 public class SqlServerPartition extends AbstractPartition implements Partition {
     private static final String SERVER_PARTITION_KEY = "server";
     private static final String DATABASE_PARTITION_KEY = "database";
+    private static final String TASK_PARTITION_KEY = "task";
 
     private final String serverName;
+    private final String taskId;
     private final Map<String, String> sourcePartition;
     private final List<Map<String, String>> supportedFormats;
     private final int hashCode;
@@ -31,10 +33,22 @@ public class SqlServerPartition extends AbstractPartition implements Partition {
     }
 
     public SqlServerPartition(String serverName, String databaseName, boolean multiPartitionMode) {
+        this(serverName, databaseName, multiPartitionMode, null);
+    }
+
+    /**
+     * @param taskId non-null only for multi-task smart-snapshot sharded tasks; when set, the source
+     *               partition becomes {server, database, task} so each shard tracks its own completion
+     *               offset. Streaming (and every non-smart-snapshot path) keeps the legacy {server, database}.
+     */
+    public SqlServerPartition(String serverName, String databaseName, boolean multiPartitionMode, String taskId) {
         super(databaseName);
         this.serverName = serverName;
+        this.taskId = taskId;
 
-        this.sourcePartition = Collect.hashMapOf(SERVER_PARTITION_KEY, serverName, DATABASE_PARTITION_KEY, databaseName);
+        this.sourcePartition = taskId != null
+                ? Collect.hashMapOf(SERVER_PARTITION_KEY, serverName, DATABASE_PARTITION_KEY, databaseName, TASK_PARTITION_KEY, taskId)
+                : Collect.hashMapOf(SERVER_PARTITION_KEY, serverName, DATABASE_PARTITION_KEY, databaseName);
 
         // for connectors working in single-partition mode the format of a partition has been changed in Debezium 2.0,
         // the legacy/old format of the partition should still be supported along with the new format
@@ -42,7 +56,7 @@ public class SqlServerPartition extends AbstractPartition implements Partition {
         this.supportedFormats = multiPartitionMode ? Collections.singletonList(this.sourcePartition)
                 : Arrays.asList(this.sourcePartition, Collect.hashMapOf(SERVER_PARTITION_KEY, serverName));
 
-        this.hashCode = Objects.hash(serverName, databaseName);
+        this.hashCode = Objects.hash(serverName, databaseName, taskId);
     }
 
     @Override
@@ -62,6 +76,14 @@ public class SqlServerPartition extends AbstractPartition implements Partition {
         return databaseName;
     }
 
+    /**
+     * Returns the shared (per-database) source partition key {server, database} without the task id.
+     * Used to read the streaming resume position / coordination data after downscale.
+     */
+    public Map<String, String> getSharedSourcePartition() {
+        return Collect.hashMapOf(SERVER_PARTITION_KEY, serverName, DATABASE_PARTITION_KEY, databaseName);
+    }
+
     @Override
     public boolean equals(Object obj) {
         if (this == obj) {
@@ -71,7 +93,8 @@ public class SqlServerPartition extends AbstractPartition implements Partition {
             return false;
         }
         final SqlServerPartition other = (SqlServerPartition) obj;
-        return Objects.equals(serverName, other.serverName) && Objects.equals(databaseName, other.databaseName);
+        return Objects.equals(serverName, other.serverName) && Objects.equals(databaseName, other.databaseName)
+                && Objects.equals(taskId, other.taskId);
     }
 
     @Override
@@ -95,9 +118,12 @@ public class SqlServerPartition extends AbstractPartition implements Partition {
         public Set<SqlServerPartition> getPartitions() {
             String serverName = connectorConfig.getLogicalName();
             boolean multiPartitionMode = connectorConfig.getDatabaseNames().size() > 1;
+            // Only smart-snapshot sharded tasks (which carry an epoch) get the task-scoped {server,database,task}
+            // partition. Normal tasks also carry a task id but no epoch, so they keep the legacy {server,database}.
+            String taskId = connectorConfig.getSmartSnapshotEpoch() != null ? connectorConfig.getTaskId() : null;
 
             return connectorConfig.getDatabaseNames().stream()
-                    .map(databaseName -> new SqlServerPartition(serverName, databaseName, multiPartitionMode))
+                    .map(databaseName -> new SqlServerPartition(serverName, databaseName, multiPartitionMode, taskId))
                     .collect(Collectors.toSet());
         }
     }

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerSmartSnapshotChangeEventSource.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerSmartSnapshotChangeEventSource.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.sqlserver;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.jdbc.MainConnectionProvidingConnectionFactory;
+import io.debezium.pipeline.EventDispatcher;
+import io.debezium.pipeline.notification.NotificationService;
+import io.debezium.pipeline.source.snapshot.SmartSnapshotConnectorCoordinator;
+import io.debezium.pipeline.source.snapshot.SnapshotCoordination;
+import io.debezium.pipeline.source.spi.SnapshotProgressListener;
+import io.debezium.relational.TableId;
+import io.debezium.snapshot.SnapshotterService;
+import io.debezium.util.Clock;
+
+/**
+ * Multi-task ("smart snapshot") variant of {@link SqlServerSnapshotChangeEventSource}.
+ * <p>
+ * The Connector (via {@code SmartSnapshotConnectorCoordinator} + {@link SqlServerSnapshotLifecycleManager})
+ * holds the {@code TABLOCKX} write barrier and has captured the consistent position {@code L_db}. This task
+ * therefore:
+ * <ul>
+ * <li>uses {@code L_db} (read from the coordination topic, supplied via {@link #setSmartSnapshotLsn}) as its
+ * snapshot offset instead of capturing a fresh max LSN;</li>
+ * <li>opens its own {@code snapshot}-isolation transaction (handled by the base {@code connectionCreated}
+ * when {@code snapshot.isolation.mode=snapshot}, which smart snapshot requires) — SQL Server has no
+ * exportable snapshot to join by name;</li>
+ * <li>skips table locking (the Connector holds the barrier);</li>
+ * <li>signals {@code transaction_started} once its schema read is done, so the Connector can release the
+ * barrier ({@code onAllTasksJoined}).</li>
+ * </ul>
+ */
+public class SqlServerSmartSnapshotChangeEventSource extends SqlServerSnapshotChangeEventSource {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SqlServerSmartSnapshotChangeEventSource.class);
+
+    private final SqlServerConnectorConfig connectorConfig;
+    private final String taskId;
+
+    private String smartSnapshotLsn;
+    private SnapshotCoordination snapshotCoordination;
+    private int epoch;
+
+    public SqlServerSmartSnapshotChangeEventSource(SqlServerConnectorConfig connectorConfig,
+                                                   MainConnectionProvidingConnectionFactory<SqlServerConnection> connectionFactory,
+                                                   SqlServerDatabaseSchema schema, EventDispatcher<SqlServerPartition, TableId> dispatcher, Clock clock,
+                                                   SnapshotProgressListener<SqlServerPartition> snapshotProgressListener,
+                                                   NotificationService<SqlServerPartition, SqlServerOffsetContext> notificationService,
+                                                   SnapshotterService snapshotterService) {
+        super(connectorConfig, connectionFactory, schema, dispatcher, clock, snapshotProgressListener, notificationService, snapshotterService);
+        this.connectorConfig = connectorConfig;
+        this.taskId = connectorConfig.getTaskId();
+    }
+
+    public void setSmartSnapshotLsn(String lsn) {
+        this.smartSnapshotLsn = lsn;
+    }
+
+    public void setSnapshotCoordination(SnapshotCoordination coordination, int epoch) {
+        this.snapshotCoordination = coordination;
+        this.epoch = epoch;
+    }
+
+    @Override
+    protected void determineSnapshotOffset(RelationalSnapshotContext<SqlServerPartition, SqlServerOffsetContext> ctx,
+                                           SqlServerOffsetContext previousOffset)
+            throws Exception {
+        // Use the Connector's consistent position (L_db), not a fresh max LSN.
+        SqlServerOffsetContext offset = new SqlServerOffsetContext(
+                connectorConfig,
+                TxLogPosition.valueOf(Lsn.valueOf(smartSnapshotLsn)),
+                null,
+                false);
+        offset.setEpoch(epoch);
+        ctx.offset = offset;
+        LOGGER.info("Smart snapshot [task-{}]: snapshot offset set to L_db={}, epoch={}", taskId, smartSnapshotLsn, epoch);
+    }
+
+    @Override
+    protected void lockTablesForSchemaSnapshot(ChangeEventSourceContext sourceContext,
+                                               RelationalSnapshotContext<SqlServerPartition, SqlServerOffsetContext> snapshotContext) {
+        LOGGER.info("Smart snapshot [task-{}]: skipping table locking (Connector holds the TABLOCKX barrier)", taskId);
+    }
+
+    @Override
+    protected void releaseSchemaSnapshotLocks(RelationalSnapshotContext<SqlServerPartition, SqlServerOffsetContext> snapshotContext)
+            throws java.sql.SQLException {
+        // Schema has been read; signal the Connector that this task has joined the snapshot (opened its
+        // snapshot-isolation transaction), so the Connector can release the write barrier once all join.
+        if (snapshotCoordination != null) {
+            try {
+                Map<String, Object> signal = new HashMap<>();
+                signal.put("transaction_started", true);
+                signal.put(SmartSnapshotConnectorCoordinator.EPOCH_KEY, epoch);
+                snapshotCoordination.write(snapshotContext.partition.getSourcePartition(), signal);
+                LOGGER.info("Smart snapshot [task-{}]: signaled transaction_started (schema read done)", taskId);
+            }
+            catch (Exception e) {
+                LOGGER.warn("Smart snapshot [task-{}]: failed to write transaction_started signal", taskId, e);
+            }
+        }
+        super.releaseSchemaSnapshotLocks(snapshotContext);
+    }
+}

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerSmartSnapshotChangeEventSourceCoordinator.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerSmartSnapshotChangeEventSourceCoordinator.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.sqlserver;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.kafka.connect.source.SourceConnector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.DebeziumException;
+import io.debezium.config.CommonConnectorConfig;
+import io.debezium.connector.common.CdcSourceTaskContext;
+import io.debezium.pipeline.ErrorHandler;
+import io.debezium.pipeline.EventDispatcher;
+import io.debezium.pipeline.metrics.spi.ChangeEventSourceMetricsFactory;
+import io.debezium.pipeline.notification.NotificationService;
+import io.debezium.pipeline.signal.SignalProcessor;
+import io.debezium.pipeline.source.snapshot.SmartSnapshotConnectorCoordinator;
+import io.debezium.pipeline.source.snapshot.SnapshotCoordination;
+import io.debezium.pipeline.source.spi.ChangeEventSource.ChangeEventSourceContext;
+import io.debezium.pipeline.source.spi.ChangeEventSourceFactory;
+import io.debezium.pipeline.source.spi.SnapshotChangeEventSource;
+import io.debezium.pipeline.spi.Offsets;
+import io.debezium.pipeline.spi.SnapshotResult;
+import io.debezium.schema.DatabaseSchema;
+import io.debezium.snapshot.SnapshotterService;
+import io.debezium.util.Clock;
+import io.debezium.util.LoggingContext;
+
+/**
+ * Multi-task ("smart snapshot") coordinator for SQL Server. Unlike the base coordinator it runs the snapshot
+ * <b>only</b> (no streaming): it reads the Connector-prepared consistent position {@code L_db} (and epoch)
+ * from the coordination topic, hands it to the {@link SqlServerSmartSnapshotChangeEventSource}, and snapshots
+ * this task's table shard. The task then idles until the Connector monitor detects completion of all tasks
+ * and downscales to the normal streaming layout.
+ */
+public class SqlServerSmartSnapshotChangeEventSourceCoordinator extends SqlServerChangeEventSourceCoordinator {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SqlServerSmartSnapshotChangeEventSourceCoordinator.class);
+    private static final int RETRY_COUNT = 30;
+
+    private final int epoch;
+    private final SnapshotCoordination snapshotCoordination;
+    private final String taskId;
+
+    public SqlServerSmartSnapshotChangeEventSourceCoordinator(Offsets<SqlServerPartition, SqlServerOffsetContext> previousOffsets, ErrorHandler errorHandler,
+                                                              Class<? extends SourceConnector> connectorType,
+                                                              CommonConnectorConfig connectorConfig,
+                                                              ChangeEventSourceFactory<SqlServerPartition, SqlServerOffsetContext> changeEventSourceFactory,
+                                                              ChangeEventSourceMetricsFactory<SqlServerPartition> changeEventSourceMetricsFactory,
+                                                              EventDispatcher<SqlServerPartition, ?> eventDispatcher,
+                                                              DatabaseSchema<?> schema,
+                                                              Clock clock,
+                                                              SignalProcessor<SqlServerPartition, SqlServerOffsetContext> signalProcessor,
+                                                              NotificationService<SqlServerPartition, SqlServerOffsetContext> notificationService,
+                                                              SnapshotterService snapshotterService,
+                                                              int epoch,
+                                                              SnapshotCoordination snapshotCoordination,
+                                                              String taskId) {
+        super(previousOffsets, errorHandler, connectorType, connectorConfig, changeEventSourceFactory, changeEventSourceMetricsFactory,
+                eventDispatcher, schema, clock, signalProcessor, notificationService, snapshotterService);
+        this.epoch = epoch;
+        this.snapshotCoordination = snapshotCoordination;
+        this.taskId = taskId;
+    }
+
+    @Override
+    protected void executeChangeEventSources(CdcSourceTaskContext taskContext, SnapshotChangeEventSource<SqlServerPartition, SqlServerOffsetContext> snapshotSource,
+                                             Offsets<SqlServerPartition, SqlServerOffsetContext> previousOffsets,
+                                             AtomicReference<LoggingContext.PreviousContext> previousLogContext,
+                                             ChangeEventSourceContext context)
+            throws InterruptedException {
+
+        snapshotCoordination.start();
+        final SqlServerSmartSnapshotChangeEventSource smartSource = (SqlServerSmartSnapshotChangeEventSource) snapshotSource;
+
+        // A smart-snapshot task is DB-exclusive, so there is normally a single partition; iterate defensively.
+        for (Map.Entry<SqlServerPartition, SqlServerOffsetContext> entry : previousOffsets) {
+            SqlServerPartition partition = entry.getKey();
+            SqlServerOffsetContext previousOffset = entry.getValue();
+            previousLogContext.set(taskContext.configureLoggingContext("snapshot", partition));
+
+            // A per-task offset from a previous coordination round is stale; drop it.
+            if (previousOffset != null) {
+                Integer offsetEpoch = previousOffset.getEpoch();
+                if (offsetEpoch != null && !offsetEpoch.equals(epoch)) {
+                    LOGGER.info("Smart snapshot [task-{}]: epoch mismatch (offset={}, config={}), clearing offset", taskId, offsetEpoch, epoch);
+                    previousOffsets.resetOffset(partition);
+                    previousOffset = null;
+                }
+            }
+            if (previousOffset != null) {
+                previousOffset.setEpoch(epoch);
+            }
+
+            String lsn = awaitConsistentPosition(partition);
+            smartSource.setSmartSnapshotLsn(lsn);
+            smartSource.setSnapshotCoordination(snapshotCoordination, epoch);
+
+            LOGGER.info("Smart snapshot [task-{}]: db={}, L_db={}, epoch={}, running snapshot-only",
+                    taskId, partition.getDatabaseName(), lsn, epoch);
+            SnapshotResult<SqlServerOffsetContext> result = doSnapshot(snapshotSource, context, partition, previousOffset);
+            LOGGER.info("Smart snapshot [task-{}]: snapshot completed status={}", taskId, result.getStatus());
+        }
+
+        // No streaming. The task idles; the Connector monitor detects completion and triggers downscale.
+        LOGGER.info("Smart snapshot [task-{}]: snapshot phase finished, idling until downscale", taskId);
+    }
+
+    /**
+     * Polls the coordination topic for this database's prepared consistent position (L_db) at the current epoch.
+     */
+    private String awaitConsistentPosition(SqlServerPartition partition) throws InterruptedException {
+        Map<String, String> shared = partition.getSharedSourcePartition();
+        for (int attempt = 0; attempt < RETRY_COUNT; attempt++) {
+            Map<String, Object> coordData = snapshotCoordination.read(shared);
+            if (coordData != null && coordData.get(SmartSnapshotConnectorCoordinator.SLOT_LSN_KEY) != null) {
+                Integer coordEpoch = SmartSnapshotConnectorCoordinator.readEpoch(coordData);
+                if (coordEpoch != null && coordEpoch == epoch) {
+                    return String.valueOf(coordData.get(SmartSnapshotConnectorCoordinator.SLOT_LSN_KEY));
+                }
+            }
+            LOGGER.info("Smart snapshot [task-{}]: waiting for snapshot preparation (attempt {}/{})", taskId, attempt + 1, RETRY_COUNT);
+            Thread.sleep(2000);
+        }
+        throw new DebeziumException("Smart snapshot [task-" + taskId + "]: timed out waiting for snapshot preparation for db="
+                + partition.getDatabaseName());
+    }
+}

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerSmartSnapshotChangeEventSourceCoordinator.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerSmartSnapshotChangeEventSourceCoordinator.java
@@ -5,6 +5,8 @@
  */
 package io.debezium.connector.sqlserver;
 
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -15,6 +17,7 @@ import org.slf4j.LoggerFactory;
 import io.debezium.DebeziumException;
 import io.debezium.config.CommonConnectorConfig;
 import io.debezium.connector.common.CdcSourceTaskContext;
+import io.debezium.pipeline.CommonOffsetContext;
 import io.debezium.pipeline.ErrorHandler;
 import io.debezium.pipeline.EventDispatcher;
 import io.debezium.pipeline.metrics.spi.ChangeEventSourceMetricsFactory;
@@ -98,6 +101,23 @@ public class SqlServerSmartSnapshotChangeEventSourceCoordinator extends SqlServe
                 previousOffset.setEpoch(epoch);
             }
 
+            // Detect a restart of this task within the current epoch via its own coordination record.
+            Map<String, Object> ownRecord = snapshotCoordination.read(partition.getSourcePartition());
+            Integer recordEpoch = SmartSnapshotConnectorCoordinator.readEpoch(ownRecord);
+            boolean sameEpoch = recordEpoch != null && recordEpoch == epoch;
+            if (sameEpoch && Boolean.TRUE.equals(ownRecord.get(CommonOffsetContext.SNAPSHOT_COMPLETED_KEY))) {
+                // Already finished this shard for this epoch (restart after completion): idle, don't re-snapshot.
+                LOGGER.info("Smart snapshot [task-{}]: shard already completed for epoch {}, idling", taskId, epoch);
+                continue;
+            }
+            if (sameEpoch && Boolean.TRUE.equals(ownRecord.get("transaction_started"))) {
+                // Restart after joining but before completing: the write barrier may already be released, so we
+                // cannot re-pin the same L_db. Signal a full-DB restart (requiresFullRestartOnTaskFailure=true).
+                LOGGER.warn("Smart snapshot [task-{}]: restart after join detected, signaling restart_needed", taskId);
+                writeCoordination(partition, "restart_needed");
+                continue;
+            }
+
             String lsn = awaitConsistentPosition(partition);
             smartSource.setSmartSnapshotLsn(lsn);
             smartSource.setSnapshotCoordination(snapshotCoordination, epoch);
@@ -106,10 +126,33 @@ public class SqlServerSmartSnapshotChangeEventSourceCoordinator extends SqlServe
                     taskId, partition.getDatabaseName(), lsn, epoch);
             SnapshotResult<SqlServerOffsetContext> result = doSnapshot(snapshotSource, context, partition, previousOffset);
             LOGGER.info("Smart snapshot [task-{}]: snapshot completed status={}", taskId, result.getStatus());
+
+            // Publish completion on the coordination topic (immediate, and covers empty/zero-row shards that
+            // never flush a data offset). Keep transaction_started set so the monitor's join check still sees it.
+            if (result.isCompletedOrSkipped()) {
+                writeCoordination(partition, "transaction_started", CommonOffsetContext.SNAPSHOT_COMPLETED_KEY);
+            }
         }
 
         // No streaming. The task idles; the Connector monitor detects completion and triggers downscale.
         LOGGER.info("Smart snapshot [task-{}]: snapshot phase finished, idling until downscale", taskId);
+    }
+
+    /**
+     * Writes a per-task coordination record setting each named flag to {@code true} plus the current epoch.
+     */
+    private void writeCoordination(SqlServerPartition partition, String... trueFlags) {
+        try {
+            Map<String, Object> record = new HashMap<>();
+            for (String flag : trueFlags) {
+                record.put(flag, true);
+            }
+            record.put(SmartSnapshotConnectorCoordinator.EPOCH_KEY, epoch);
+            snapshotCoordination.write(partition.getSourcePartition(), record);
+        }
+        catch (Exception e) {
+            LOGGER.warn("Smart snapshot [task-{}]: failed to write coordination record {}", taskId, Arrays.toString(trueFlags), e);
+        }
     }
 
     /**

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerSnapshotLifecycleManager.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerSnapshotLifecycleManager.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.sqlserver;
+
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.DebeziumException;
+import io.debezium.pipeline.source.snapshot.SnapshotLifecycleManager;
+import io.debezium.relational.TableId;
+
+/**
+ * SQL Server implementation of {@link SnapshotLifecycleManager}, scoped to a single database.
+ * <p>
+ * SQL Server has no exportable snapshot (no {@code pg_export_snapshot()} / {@code SET TRANSACTION SNAPSHOT}),
+ * so this follows the <b>MySQL-style lock path</b> rather than the Postgres snapshot-name path:
+ * <ul>
+ * <li>{@link #prepareSnapshot} holds a {@code TABLOCKX} write barrier on <b>all</b> the database's captured
+ * tables (in one open transaction on a dedicated lock-holder connection) and captures the consistent
+ * position {@code L_db = fn_cdc_get_max_lsn()}. The barrier freezes writes so every task that opens its own
+ * {@code snapshot}-isolation transaction while it is held pins the identical committed state.</li>
+ * <li>{@link #snapshotName()} is {@code null} — tasks join by opening their own {@code snapshot}-isolation
+ * transaction, not by name.</li>
+ * <li>{@link #onAllTasksJoined()} releases the barrier (like MySQL {@code UNLOCK TABLES}).</li>
+ * <li>{@link #requiresFullRestartOnTaskFailure()} is {@code true} — once the barrier is released a failed
+ * task cannot re-pin {@code L_db}, so the whole database re-coordinates with a new epoch.</li>
+ * </ul>
+ * One instance exists per database (the Connector creates one {@code SmartSnapshotConnectorCoordinator} per
+ * database).
+ */
+public class SqlServerSnapshotLifecycleManager implements SnapshotLifecycleManager {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SqlServerSnapshotLifecycleManager.class);
+
+    private final SqlServerConnectorConfig connectorConfig;
+    private final String databaseName;
+
+    // Holds the TABLOCKX write barrier (open transaction) and keeps the consistent point frozen until all
+    // tasks have joined; kept open afterwards purely so isValid() can health-check it.
+    private SqlServerConnection lockHolderConnection;
+    private volatile boolean barrierReleased;
+    private Lsn currentMaxLsn;
+
+    public SqlServerSnapshotLifecycleManager(SqlServerConnectorConfig connectorConfig, String databaseName) {
+        this.connectorConfig = connectorConfig;
+        this.databaseName = databaseName;
+    }
+
+    @Override
+    public SnapshotSetup prepareSnapshot(List<TableId> tables, boolean shouldStream) {
+        List<TableId> dbTables = tables.stream()
+                .filter(t -> databaseName.equals(t.catalog()))
+                .collect(Collectors.toList());
+
+        try {
+            lockHolderConnection = new SqlServerConnection(connectorConfig, null, Collections.emptySet(), false);
+            lockHolderConnection.connection().setAutoCommit(false);
+            lockAllTables(dbTables);
+
+            // Capture the consistent position after the write barrier is held so no commit can land between
+            // the capture and the tasks pinning their snapshot-isolation view.
+            currentMaxLsn = lockHolderConnection.getMaxLsn(databaseName);
+            barrierReleased = false;
+            LOGGER.info("Smart snapshot [db={}]: locked {} tables, consistent position (max LSN)={}",
+                    databaseName, dbTables.size(), currentMaxLsn);
+            return new SnapshotSetup(null, currentMaxLsn == null ? null : currentMaxLsn.toString());
+        }
+        catch (SQLException e) {
+            releaseSnapshot();
+            throw new DebeziumException("Smart snapshot [db=" + databaseName + "]: failed to prepare snapshot", e);
+        }
+    }
+
+    private void lockAllTables(List<TableId> tables) throws SQLException {
+        LOGGER.info("Smart snapshot [db={}]: acquiring TABLOCKX on {} tables", databaseName, tables.size());
+        try (Statement statement = lockHolderConnection.connection().createStatement()) {
+            statement.execute("SET LOCK_TIMEOUT " + connectorConfig.snapshotLockTimeout().toMillis());
+            for (TableId tableId : tables) {
+                String quoted = lockHolderConnection.quotedTableIdString(tableId);
+                // TOP(0): acquire the exclusive table lock without scanning rows; held until the transaction
+                // is rolled back (onAllTasksJoined) or the connection is closed (releaseSnapshot).
+                statement.executeQuery("SELECT TOP(0) * FROM " + quoted + " WITH (TABLOCKX)").close();
+            }
+        }
+    }
+
+    @Override
+    public void onAllTasksJoined() {
+        // All tasks have opened their snapshot-isolation transactions; the write barrier can be released
+        // (their MVCC views are now pinned). Roll back to drop the TABLOCKX locks but keep the connection
+        // open so isValid() can still health-check it.
+        SqlServerConnection conn = this.lockHolderConnection;
+        if (conn != null && !barrierReleased) {
+            try {
+                conn.connection().rollback();
+                barrierReleased = true;
+                LOGGER.info("Smart snapshot [db={}]: all tasks joined, released TABLOCKX write barrier", databaseName);
+            }
+            catch (SQLException e) {
+                LOGGER.warn("Smart snapshot [db={}]: error releasing write barrier", databaseName, e);
+            }
+        }
+    }
+
+    @Override
+    public boolean requiresFullRestartOnTaskFailure() {
+        // No exportable snapshot to re-attach to; once the barrier is released a failed task cannot re-pin
+        // the same L_db, so a single task failure requires re-coordinating the whole database (new epoch).
+        return true;
+    }
+
+    @Override
+    public void releaseSnapshot() {
+        SqlServerConnection conn = this.lockHolderConnection;
+        this.lockHolderConnection = null;
+        if (conn != null) {
+            try {
+                conn.close();
+            }
+            catch (Exception e) {
+                LOGGER.warn("Smart snapshot [db={}]: error closing lock holder connection", databaseName, e);
+            }
+        }
+        currentMaxLsn = null;
+        barrierReleased = false;
+    }
+
+    @Override
+    public boolean isValid() {
+        SqlServerConnection conn = this.lockHolderConnection;
+        if (conn == null) {
+            return false;
+        }
+        try {
+            conn.execute("SELECT 1");
+            return true;
+        }
+        catch (SQLException e) {
+            return false;
+        }
+    }
+
+    @Override
+    public String snapshotName() {
+        // SQL Server has no exportable snapshot; tasks open their own snapshot-isolation transaction.
+        return null;
+    }
+
+    @Override
+    public String consistentPosition() {
+        return currentMaxLsn == null ? null : currentMaxLsn.toString();
+    }
+}

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerSnapshotLifecycleManager.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerSnapshotLifecycleManager.java
@@ -141,8 +141,10 @@ public class SqlServerSnapshotLifecycleManager implements SnapshotLifecycleManag
             return false;
         }
         try {
-            conn.execute("SELECT 1");
-            return true;
+            // MUST be a non-committing check: the lock holder runs autoCommit(false) and the TABLOCKX write
+            // barrier is held by its open transaction. JdbcConnection.execute(...) commits, which would
+            // silently drop the barrier; Connection.isValid() does not touch the transaction.
+            return conn.connection().isValid(5);
         }
         catch (SQLException e) {
             return false;

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerPartitionTest.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerPartitionTest.java
@@ -5,6 +5,10 @@
  */
 package io.debezium.connector.sqlserver;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
 import io.debezium.connector.common.AbstractPartitionTest;
 
 public class SqlServerPartitionTest extends AbstractPartitionTest<SqlServerPartition> {
@@ -17,5 +21,33 @@ public class SqlServerPartitionTest extends AbstractPartitionTest<SqlServerParti
     @Override
     protected SqlServerPartition createPartition2() {
         return new SqlServerPartition("server2", "database2");
+    }
+
+    @Test
+    public void nonSmartSnapshotPartitionUsesLegacyKey() {
+        // No task id -> legacy {server, database} key (unchanged for existing/streaming connectors).
+        SqlServerPartition partition = new SqlServerPartition("server1", "database1", true);
+        assertThat(partition.getSourcePartition()).containsOnlyKeys("server", "database");
+        assertThat(partition.getSourcePartition()).containsEntry("server", "server1").containsEntry("database", "database1");
+    }
+
+    @Test
+    public void smartSnapshotShardedPartitionAddsTaskKey() {
+        // A sharded smart-snapshot task tracks its own completion under {server, database, task}.
+        SqlServerPartition partition = new SqlServerPartition("server1", "database1", true, "2");
+        assertThat(partition.getSourcePartition()).containsOnlyKeys("server", "database", "task");
+        assertThat(partition.getSourcePartition()).containsEntry("task", "2");
+        // The shared key (used for streaming resume / coordination) never carries the task id.
+        assertThat(partition.getSharedSourcePartition()).containsOnlyKeys("server", "database");
+    }
+
+    @Test
+    public void taskIdDistinguishesPartitions() {
+        SqlServerPartition task0 = new SqlServerPartition("server1", "database1", true, "0");
+        SqlServerPartition task1 = new SqlServerPartition("server1", "database1", true, "1");
+        SqlServerPartition noTask = new SqlServerPartition("server1", "database1", true);
+        assertThat(task0).isNotEqualTo(task1);
+        assertThat(task0).isNotEqualTo(noTask);
+        assertThat(task0).isEqualTo(new SqlServerPartition("server1", "database1", true, "0"));
     }
 }

--- a/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java
+++ b/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java
@@ -928,6 +928,19 @@ public abstract class CommonConnectorConfig extends AbstractConfig {
             .withDescription("A list of host/port pairs for the Kafka cluster hosting the snapshot "
                     + "coordination topic. Required when smart.snapshot.enabled=true and tasks.max > 1.");
 
+    public static final Field SMART_SNAPSHOT_TABLES_PER_TASK = Field.create("smart.snapshot.tables.per.task")
+            .withDisplayName("Smart snapshot tables per task")
+            .withType(Type.INT)
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_SNAPSHOT, 25))
+            .withWidth(Width.SHORT)
+            .withImportance(Importance.MEDIUM)
+            .withDefault(2)
+            .withValidation(Field::isPositiveInteger)
+            .withDescription("Target number of tables each task snapshots during a smart (multi-task) snapshot. "
+                    + "The snapshot task count is derived from the table count (ceil(tables / this)), not from "
+                    + "tasks.max. Raise it to bound the number of snapshot tasks on wide schemas. "
+                    + "Only applies when smart.snapshot.enabled=true and tasks.max > 1.");
+
     public static final Field DND_DELAY_MS = Field.create("dnd.delay.ms")
             .withDisplayName("DND delay (ms)")
             .withType(Type.LONG)
@@ -1450,6 +1463,7 @@ public abstract class CommonConnectorConfig extends AbstractConfig {
                     SMART_SNAPSHOT_ENABLED,
                     DND_DELAY_MS,
                     SMART_SNAPSHOT_COORDINATION_BOOTSTRAP_SERVERS,
+                    SMART_SNAPSHOT_TABLES_PER_TASK,
                     SNAPSHOT_MODE_CUSTOM_NAME,
                     SNAPSHOT_MODE_CONFIGURATION_BASED_SNAPSHOT_DATA,
                     SNAPSHOT_MODE_CONFIGURATION_BASED_SNAPSHOT_SCHEMA,
@@ -1727,6 +1741,10 @@ public abstract class CommonConnectorConfig extends AbstractConfig {
 
     public String getSmartSnapshotCoordinationBootstrapServers() {
         return smartSnapshotCoordinationBootstrapServers;
+    }
+
+    public int getSmartSnapshotTablesPerTask() {
+        return getConfig().getInteger(SMART_SNAPSHOT_TABLES_PER_TASK);
     }
 
     public String getSnapshotModeCustomName() {

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/SmartSnapshotConnectorCoordinator.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/SmartSnapshotConnectorCoordinator.java
@@ -24,7 +24,6 @@ import io.debezium.config.ConfigurationNames;
 import io.debezium.connector.AbstractSourceInfo;
 import io.debezium.pipeline.CommonOffsetContext;
 import io.debezium.relational.TableId;
-import io.debezium.util.Collect;
 
 public class SmartSnapshotConnectorCoordinator {
 
@@ -39,6 +38,13 @@ public class SmartSnapshotConnectorCoordinator {
     private final SnapshotLifecycleManager snapshotLifecycleManager;
     private final ConnectorContext connectorContext;
     private final String serverName;
+    /*
+     * Optional database scope. Single-database connectors (Postgres) leave this null, keeping the
+     * coordination/offset keys as {server[,task]}. Multi-database connectors (SQL Server) instantiate one
+     * coordinator per database and pass the database here so all keys become {server,database[,task]},
+     * matching the per-(server,database,task) offset partitions the tasks actually write.
+     */
+    private final String database;
 
     /*
      * Performs 4 monitoring operations:
@@ -116,10 +122,40 @@ public class SmartSnapshotConnectorCoordinator {
                                              SnapshotLifecycleManager snapshotLifecycleManager,
                                              ConnectorContext connectorContext,
                                              String serverName) {
+        this(snapshotCoordination, snapshotLifecycleManager, connectorContext, serverName, null);
+    }
+
+    public SmartSnapshotConnectorCoordinator(SnapshotCoordination snapshotCoordination,
+                                             SnapshotLifecycleManager snapshotLifecycleManager,
+                                             ConnectorContext connectorContext,
+                                             String serverName,
+                                             String database) {
         this.snapshotCoordination = snapshotCoordination;
         this.snapshotLifecycleManager = snapshotLifecycleManager;
         this.connectorContext = connectorContext;
         this.serverName = serverName;
+        this.database = database;
+    }
+
+    /**
+     * Coordination/offset key for the shared (per-database) record: {server[,database]}.
+     */
+    private Map<String, String> sharedKey() {
+        Map<String, String> key = new HashMap<>();
+        key.put("server", serverName);
+        if (database != null) {
+            key.put("database", database);
+        }
+        return key;
+    }
+
+    /**
+     * Coordination/offset key for a per-task record: {server[,database],task}.
+     */
+    private Map<String, String> taskKey(int taskIndex) {
+        Map<String, String> key = sharedKey();
+        key.put("task", String.valueOf(taskIndex));
+        return key;
     }
 
     /**
@@ -132,7 +168,7 @@ public class SmartSnapshotConnectorCoordinator {
         // This handles streaming offsets where snapshot_completed field is absent
         SourceConnectorContext srcContext = (SourceConnectorContext) connectorContext;
         Map<String, Object> existingOffset = srcContext.offsetStorageReader().offset(
-                Collect.hashMapOf("server", serverName));
+                sharedKey());
         boolean offsetExists = existingOffset != null;
         boolean snapshotInProgress = offsetExists && isSnapshotInProgress(existingOffset);
 
@@ -145,7 +181,7 @@ public class SmartSnapshotConnectorCoordinator {
         snapshotCoordination.start();
 
         // Check coordination topic: if previous multi-task snapshot completed
-        Map<String, String> sharedPartition = Collect.hashMapOf("server", serverName);
+        Map<String, String> sharedPartition = sharedKey();
         Map<String, Object> sharedOffset = snapshotCoordination.read(sharedPartition);
 
         if (sharedOffset != null
@@ -187,7 +223,7 @@ public class SmartSnapshotConnectorCoordinator {
                 snapshotLifecycleManager.releaseSnapshot();
                 // Write completion to coordination topic (streaming task reads LSN from here)
                 try {
-                    Map<String, String> sp = Collect.hashMapOf("server", serverName);
+                    Map<String, String> sp = sharedKey();
                     Map<String, Object> coordData = new HashMap<>();
                     coordData.put(SLOT_LSN_KEY, finalPosition);
                     coordData.put(CommonOffsetContext.SNAPSHOT_COMPLETED_KEY, true);
@@ -284,7 +320,7 @@ public class SmartSnapshotConnectorCoordinator {
                 SnapshotLifecycleManager.SnapshotSetup setup = snapshotLifecycleManager.prepareSnapshot(tables, shouldStream);
 
                 // Write snapshot info to coordination topic
-                Map<String, String> sharedPartition = Collect.hashMapOf("server", serverName);
+                Map<String, String> sharedPartition = sharedKey();
                 Map<String, Object> coordData = new HashMap<>();
                 coordData.put(SLOT_LSN_KEY, setup.consistentPosition());
                 coordData.put(SNAPSHOT_NAME_KEY, setup.snapshotName());
@@ -354,8 +390,7 @@ public class SmartSnapshotConnectorCoordinator {
                 if (!allTasksJoined && snapshotLifecycleManager != null) {
                     boolean allJoined = true;
                     for (int i = 0; i < lastNumTasks; i++) {
-                        Map<String, String> taskPartition = Collect.hashMapOf(
-                                "server", serverName, "task", String.valueOf(i));
+                        Map<String, String> taskPartition = taskKey(i);
                         Map<String, Object> taskCoord = snapshotCoordination.read(taskPartition);
                         if (taskCoord == null
                                 || !Boolean.TRUE.equals(taskCoord.get("transaction_started"))) {
@@ -373,8 +408,7 @@ public class SmartSnapshotConnectorCoordinator {
                 // 4. Check per-task restart_needed (MySQL: task can't rejoin snapshot)
                 if (snapshotLifecycleManager.requiresFullRestartOnTaskFailure()) {
                     for (int i = 0; i < lastNumTasks; i++) {
-                        Map<String, String> taskPartition = Collect.hashMapOf(
-                                "server", serverName, "task", String.valueOf(i));
+                        Map<String, String> taskPartition = taskKey(i);
                         Map<String, Object> taskCoord = snapshotCoordination.read(taskPartition);
                         if (taskCoord != null
                                 && Boolean.TRUE.equals(taskCoord.get("restart_needed"))) {
@@ -392,13 +426,12 @@ public class SmartSnapshotConnectorCoordinator {
                 // 5. Check all tasks completed
                 SourceConnectorContext srcContext = (SourceConnectorContext) connectorContext;
                 boolean allComplete = true;
-                Map<String, String> sharedPartition = Collect.hashMapOf("server", serverName);
+                Map<String, String> sharedPartition = sharedKey();
                 Map<String, Object> sharedOffset = snapshotCoordination.read(sharedPartition);
                 Integer expectedEpoch = readEpoch(sharedOffset);
 
                 for (int i = 0; i < lastNumTasks; i++) {
-                    Map<String, String> taskPartition = Collect.hashMapOf(
-                            "server", serverName, "task", String.valueOf(i));
+                    Map<String, String> taskPartition = taskKey(i);
                     Map<String, Object> taskOffset = srcContext.offsetStorageReader().offset(taskPartition);
                     if (taskOffset == null) {
                         allComplete = false;

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/SmartSnapshotConnectorCoordinator.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/SmartSnapshotConnectorCoordinator.java
@@ -29,6 +29,10 @@ public class SmartSnapshotConnectorCoordinator {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SmartSnapshotConnectorCoordinator.class);
     private static final long MONITOR_POLL_INTERVAL_MS = 30_000;
+    // Bound how long the leader waits for all tasks to signal transaction_started. If a task crashes before
+    // joining, the join never completes and (for lock-based connectors) the write barrier would be held
+    // indefinitely; on timeout we force a restart at a higher epoch.
+    private static final long JOIN_TIMEOUT_MS = 5 * 60_000;
 
     public static final String EPOCH_KEY = "epoch";
     public static final String SNAPSHOT_NAME_KEY = "snapshot_name";
@@ -101,6 +105,10 @@ public class SmartSnapshotConnectorCoordinator {
      * transaction_started to the coordination topic
      */
     private volatile boolean allTasksJoined;
+
+    // Deadline (epoch millis) by which all tasks must signal transaction_started; set when taskConfigs() lays
+    // out a round. See JOIN_TIMEOUT_MS.
+    private volatile long joinDeadlineMs;
 
     // tables to be snapshot, set during connector start
     private volatile List<TableId> snapshotTables;
@@ -257,6 +265,7 @@ public class SmartSnapshotConnectorCoordinator {
         int numTasks = Math.min(maxTasks, tables.size());
         this.lastNumTasks = numTasks;
         this.allTasksJoined = false;
+        this.joinDeadlineMs = System.currentTimeMillis() + JOIN_TIMEOUT_MS;
 
         List<List<TableId>> tablesByTask = new ArrayList<>();
         for (int i = 0; i < numTasks; i++) {
@@ -403,6 +412,14 @@ public class SmartSnapshotConnectorCoordinator {
                         snapshotLifecycleManager.onAllTasksJoined();
                         allTasksJoined = true;
                     }
+                    else if (System.currentTimeMillis() > joinDeadlineMs) {
+                        // A task likely crashed before joining; the join (and any held write barrier) would
+                        // otherwise wait forever. Force a restart at a higher epoch.
+                        LOGGER.warn("Smart snapshot: not all tasks joined within {} ms, forcing restart", JOIN_TIMEOUT_MS);
+                        smartSnapshotState = SmartSnapshotState.RESTART;
+                        connectorContext.requestTaskReconfiguration();
+                        continue;
+                    }
                 }
 
                 // 4. Check per-task restart_needed (MySQL: task can't rejoin snapshot)
@@ -432,15 +449,13 @@ public class SmartSnapshotConnectorCoordinator {
 
                 for (int i = 0; i < lastNumTasks; i++) {
                     Map<String, String> taskPartition = taskKey(i);
-                    Map<String, Object> taskOffset = srcContext.offsetStorageReader().offset(taskPartition);
-                    if (taskOffset == null) {
-                        allComplete = false;
-                        break;
-                    }
-                    boolean done = Boolean.TRUE.equals(
-                            taskOffset.get(CommonOffsetContext.SNAPSHOT_COMPLETED_KEY));
-                    Integer taskEpoch = readEpoch(taskOffset);
-                    if (!done || (expectedEpoch != null && !expectedEpoch.equals(taskEpoch))) {
+                    // A task's completion may be visible either as a committed connect-offsets entry or as a
+                    // per-task record on the coordination topic (the latter is written explicitly, so it also
+                    // covers empty/zero-row shards that never flush a data offset, and avoids the
+                    // offset.flush.interval.ms delay).
+                    boolean done = isTaskComplete(srcContext.offsetStorageReader().offset(taskPartition), expectedEpoch)
+                            || isTaskComplete(snapshotCoordination.read(taskPartition), expectedEpoch);
+                    if (!done) {
                         allComplete = false;
                         break;
                     }
@@ -495,5 +510,16 @@ public class SmartSnapshotConnectorCoordinator {
         return (offset != null && offset.get(EPOCH_KEY) != null)
                 ? ((Number) offset.get(EPOCH_KEY)).intValue()
                 : null;
+    }
+
+    /**
+     * A per-task record (from connect-offsets or the coordination topic) marks completion when it has
+     * {@code snapshot_completed=true} and, if an expected epoch is known, a matching epoch.
+     */
+    private static boolean isTaskComplete(Map<String, Object> record, Integer expectedEpoch) {
+        if (record == null || !Boolean.TRUE.equals(record.get(CommonOffsetContext.SNAPSHOT_COMPLETED_KEY))) {
+            return false;
+        }
+        return expectedEpoch == null || expectedEpoch.equals(readEpoch(record));
     }
 }

--- a/debezium-core/src/test/java/io/debezium/pipeline/source/snapshot/SmartSnapshotConnectorCoordinatorTest.java
+++ b/debezium-core/src/test/java/io/debezium/pipeline/source/snapshot/SmartSnapshotConnectorCoordinatorTest.java
@@ -19,6 +19,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Supplier;
 
 import org.apache.kafka.connect.source.SourceConnectorContext;
 import org.apache.kafka.connect.storage.OffsetStorageReader;
@@ -99,6 +100,24 @@ public class SmartSnapshotConnectorCoordinatorTest {
         assertThat(coordinator.isComplete()).isTrue();
     }
 
+    @Test
+    public void databaseScopedCoordinatorWritesSharedRecordUnderDatabaseKey() throws Exception {
+        // A multi-database connector (SQL Server) scopes one coordinator per database, so the shared
+        // coordination record is keyed {server, database} rather than the single-database {server} shape.
+        InMemorySnapshotCoordination coordination = new InMemorySnapshotCoordination();
+        coordinator = new SmartSnapshotConnectorCoordinator(
+                coordination, lifecycleReturning("snap", "0x00000000000000D4"), contextWithNoOffsets(), "srv", "db1");
+        coordinator.start(tables(3), true);
+
+        // The background preparation thread publishes the consistent position under {server, database}.
+        Map<String, Object> shared = awaitNonNull(() -> coordination.read(key("server", "srv", "database", "db1")));
+        assertThat(shared.get(SmartSnapshotConnectorCoordinator.SLOT_LSN_KEY)).isEqualTo("0x00000000000000D4");
+        assertThat(shared.get(SmartSnapshotConnectorCoordinator.EPOCH_KEY)).isEqualTo(1);
+
+        // ...and not under the bare {server} key (the Postgres/single-database shape).
+        assertThat(coordination.read(key("server", "srv"))).isNull();
+    }
+
     // ---- helpers ----
 
     private static SourceConnectorContext contextWithNoOffsets() {
@@ -131,5 +150,16 @@ public class SmartSnapshotConnectorCoordinatorTest {
             map.put(kv[i], kv[i + 1]);
         }
         return map;
+    }
+
+    private static Map<String, Object> awaitNonNull(Supplier<Map<String, Object>> supplier) throws InterruptedException {
+        for (int i = 0; i < 50; i++) {
+            Map<String, Object> value = supplier.get();
+            if (value != null) {
+                return value;
+            }
+            Thread.sleep(100);
+        }
+        throw new AssertionError("coordination value was not written within the timeout");
     }
 }


### PR DESCRIPTION
Draft: onboards the **SQL Server** connector to the smart-snapshot (task scale-up during snapshot, scale-down to streaming) framework from #467 (Connector-managed "Approach 2"), adapted for SQL Server's **multi-database** model.

**Stacked on #472** (shared test infra) → which is stacked on #467. Review/merge in that order.

### Core (backward-compatible)
- `SmartSnapshotConnectorCoordinator`: optional `database` so coordination/offset keys become `{server[,database][,task]}`. Postgres passes `null` → unchanged.
- New config `smart.snapshot.tables.per.task` (CommonConnectorConfig, default 2).

### SQL Server — maps to the MySQL/lock path, not the Postgres snapshot-name path
SQL Server has no exportable snapshot (`SET TRANSACTION SNAPSHOT`), so:
- **`SqlServerSnapshotLifecycleManager`** (new, per-database): holds `TABLOCKX` on all the DB's captured tables in one open txn and captures `L_db = fn_cdc_get_max_lsn`; `snapshotName()=null`; `onAllTasksJoined()` releases the barrier; `requiresFullRestartOnTaskFailure()=true`.
- **`SqlServerConnector`**: one coordinator **per database** (own `L_db`/lock/epoch). `taskConfigs()` delegates per-DB (DB-exclusive tasks), falling through to today's per-database layout on downscale.
- **Allocation is table-driven, ~2 tables/task**: snapshot task count per DB = `ceil(#tables / smart.snapshot.tables.per.task)`, **independent of `tasks.max`** (the snapshot is temporarily wider than `tasks.max`; streaming downscales back to it). Requires `tasks.max.enforce=false` when the derived count exceeds `tasks.max`.
- **`SqlServerSmartSnapshotChangeEventSource` / `...Coordinator`** (new): snapshot-only task that reads `L_db` from the coordination topic, opens its own `snapshot`-isolation txn, skips locking, signals `transaction_started`.
- **`SqlServerConnectorTask`**: injects the smart coordinator for sharded tasks; seeds post-downscale streaming offsets from the coordination topic per DB.
- **`SqlServerOffsetContext`** adds `epoch`; **`SqlServerPartition`** adds the `{server,database,task}` key, **gated on `epoch` presence** to avoid changing existing connectors' offsets (SQL Server's `taskConfigs` always sets `task.id`, so `task.id` alone is not a safe discriminator).

### Tests
- Reuses `InMemorySnapshotCoordination` from #472.
- `SmartSnapshotConnectorCoordinatorTest` extended with a **database-scoped key** test (`{server,database}` shared record).
- `SqlServerPartitionTest`: `{server,database,task}` key shape + the epoch-gated regression guard.
- Compiles + checkstyle clean; unit tests green.

### Status / not yet done
- **No end-to-end ITs yet** — the fan-out → monitor → downscale → stream loop needs an `EmbeddedConnectCluster`-based harness (next PR; see `sqlserver-smart-snapshot-test-plan.md`).
- Requires `snapshot.isolation.mode=snapshot` + DB-side `ALLOW_SNAPSHOT_ISOLATION=ON`.
- Duplicate semantics are at-least-once (inherent CDC-capture-lag handoff window), not hard zero-dup — see the design doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)