### PR TITLE
Add ConnectedCode numeric companion metric so is_connected emits via OTel JMX (Spanner)

### DIFF
--- a/debezium-core/src/main/java/io/debezium/pipeline/meters/ConnectionMeter.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/meters/ConnectionMeter.java
@@ -23,6 +23,11 @@ public class ConnectionMeter implements ConnectionMetricsMXBean {
         return this.connected.get();
     }
 
+    @Override
+    public int getConnectedCode() {
+        return this.connected.get() ? 1 : 0;
+    }
+
     public void connected(boolean connected) {
         this.connected.set(connected);
     }

--- a/debezium-core/src/main/java/io/debezium/pipeline/metrics/DefaultStreamingChangeEventSourceMetrics.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/metrics/DefaultStreamingChangeEventSourceMetrics.java
@@ -57,6 +57,11 @@ public class DefaultStreamingChangeEventSourceMetrics<P extends Partition> exten
     }
 
     @Override
+    public int getConnectedCode() {
+        return connectionMeter.getConnectedCode();
+    }
+
+    @Override
     public String[] getCapturedTables() {
         return streamingMeter.getCapturedTables();
     }

--- a/debezium-core/src/main/java/io/debezium/pipeline/metrics/traits/ConnectionMetricsMXBean.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/metrics/traits/ConnectionMetricsMXBean.java
@@ -11,4 +11,7 @@ package io.debezium.pipeline.metrics.traits;
 public interface ConnectionMetricsMXBean {
 
     boolean isConnected();
+
+    /** Numeric companion to {@link #isConnected()}: 1 when connected, 0 otherwise. */
+    int getConnectedCode();
 }


### PR DESCRIPTION
## Problem

`is_connected` (`debezium.spanner.streaming.is_connected`) does not reach Druid for the Spanner CDC connector, even though the value is populated (`Connected: true` on the live MBean). The OpenTelemetry JMX agent **silently drops boolean/String MBean attributes**, so the boolean `Connected` attribute is never emitted.

## Fix

Add a numeric companion attribute **`ConnectedCode`** (`1` = connected, `0` = disconnected) alongside `isConnected()`, so the OTel JMX agent can scrape it.

| File | Change |
|---|---|
| `ConnectionMetricsMXBean` | declare `int getConnectedCode()` |
| `ConnectionMeter` | `return connected.get() ? 1 : 0` |
| `DefaultStreamingChangeEventSourceMetrics` | delegate to the meter |

`SpannerStreamingChangeEventSourceMetrics` inherits this via `DefaultStreamingChangeEventSourceMetrics`, so **no connector-side change is required**.

## Follow-ups (separate repos, after a new debezium-core build)
1. `debezium-connector-spanner`: bump `version.debezium.core` to the build that includes this.
2. `cc-docker-connect` `debezium-spanner-jmx.yaml`: map `ConnectedCode` → `is_connected` (replacing the boolean `Connected`).