### PR TITLE
Fix debezium kafka storage build- remove extra pom

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -182,16 +182,11 @@ blocks:
             # Build debezium-storage-kafka with original groupId (io.debezium) to keep dependencies intact
             - mvn -U -Dmaven.wagon.http.retryHandler.count=10 --batch-mode install -Passembly -pl debezium-storage/debezium-storage-kafka -am -DskipTests -DskipITs
             - export STORAGE_KAFKA_DIR=debezium-storage/debezium-storage-kafka
-            # Create a modified POM with io.confluent groupId for deployment
-            - cp ${STORAGE_KAFKA_DIR}/pom.xml ${STORAGE_KAFKA_DIR}/target/debezium-storage-kafka-${DEBEZIUM_VERSION}.pom
-            # Add explicit groupId and version after modelVersion (since they're inherited from parent)
-            - sed -i '/<\/modelVersion>/a\    <groupId>io.confluent</groupId>\n    <version>'"${DEBEZIUM_VERSION}"'</version>' ${STORAGE_KAFKA_DIR}/target/debezium-storage-kafka-${DEBEZIUM_VERSION}.pom
             # Deploy main JAR with io.confluent groupId
             - mvn deploy:deploy-file
               -Durl=https://confluent-519856050701.d.codeartifact.us-west-2.amazonaws.com/maven/maven-snapshots/
               -DrepositoryId=confluent-codeartifact-internal
               -Dfile=${STORAGE_KAFKA_DIR}/target/debezium-storage-kafka-${DEBEZIUM_VERSION}.jar
-              -DpomFile=${STORAGE_KAFKA_DIR}/target/debezium-storage-kafka-${DEBEZIUM_VERSION}.pom
               -DgroupId=io.confluent
               -DartifactId=debezium-storage-kafka
               -Dversion=${DEBEZIUM_VERSION}


### PR DESCRIPTION
Debezium kafka storage build and push failed with 
```
Failed to execute goal org.apache.maven.plugins:maven-deploy-plugin:2.8.2:deploy-file (default-cli) on project debezium-build-parent: Failed to deploy artifacts: Could not transfer artifact io.confluent:debezium-storage-kafka:pom:3.1.2.Final-27 from/to confluent-codeartifact-internal (https://confluent-519856050701.d.codeartifact.us-west-2.amazonaws.com/maven/maven-snapshots/): status code: 409, reason phrase: Conflict (409) -> [Help 1]
```

The storage deploy passed `-DpomFile` on the main-jar deploy-file, while a subsequent classifier deploy-file regenerated a different minimal pom for the same version. CodeArtifact versions are immutable, so the second pom was rejected with 409.

Removed `-DpomFile` so the storage deploy generates a single minimal pom making the storage block match the core block exactly.