### PR TITLE
DBZ-9558 / dbz#1732: guard Timestamp & MicroTimestamp against JDK 23+/24 NPE (v3.2.5-hotfix-x)

### DIFF
--- a/debezium-core/src/main/java/io/debezium/time/MicroTimestamp.java
+++ b/debezium-core/src/main/java/io/debezium/time/MicroTimestamp.java
@@ -71,7 +71,6 @@ public class MicroTimestamp {
             dateTime = dateTime.with(adjuster);
         }
 
-        // Fix rare JDK issue (JDK 23+) where ChronoLocalDateTime.toLocalDate() is null; see debezium/dbz#1732 (same root cause as DBZ-9558)
         try {
             return Conversions.toEpochMicros(dateTime.toInstant(ZoneOffset.UTC));
         }

--- a/debezium-core/src/main/java/io/debezium/time/MicroTimestamp.java
+++ b/debezium-core/src/main/java/io/debezium/time/MicroTimestamp.java
@@ -70,7 +70,16 @@ public class MicroTimestamp {
         if (adjuster != null) {
             dateTime = dateTime.with(adjuster);
         }
-        return Conversions.toEpochMicros(dateTime.toInstant(ZoneOffset.UTC));
+
+        // Fix rare JDK issue (JDK 23+) where ChronoLocalDateTime.toLocalDate() is null; see debezium/dbz#1732 (same root cause as DBZ-9558)
+        try {
+            return Conversions.toEpochMicros(dateTime.toInstant(ZoneOffset.UTC));
+        }
+        catch (NullPointerException e) {
+            // Fallback for NPE from ChronoLocalDateTime#toLocalDate, see debezium/dbz#1732
+            var ignored = dateTime.toString();
+            return Conversions.toEpochMicros(dateTime.toInstant(ZoneOffset.UTC));
+        }
     }
 
     private MicroTimestamp() {

--- a/debezium-core/src/main/java/io/debezium/time/Timestamp.java
+++ b/debezium-core/src/main/java/io/debezium/time/Timestamp.java
@@ -74,7 +74,6 @@ public class Timestamp {
             dateTime = dateTime.with(adjuster);
         }
 
-        // Fix rare JDK issue (JDK 23+) where a component of ChronoLocalDateTime is null; see DBZ-9558
         try {
             return dateTime.toInstant(ZoneOffset.UTC).toEpochMilli();
         }

--- a/debezium-core/src/main/java/io/debezium/time/Timestamp.java
+++ b/debezium-core/src/main/java/io/debezium/time/Timestamp.java
@@ -74,7 +74,15 @@ public class Timestamp {
             dateTime = dateTime.with(adjuster);
         }
 
-        return dateTime.toInstant(ZoneOffset.UTC).toEpochMilli();
+        // Fix rare JDK issue (JDK 23+) where a component of ChronoLocalDateTime is null; see DBZ-9558
+        try {
+            return dateTime.toInstant(ZoneOffset.UTC).toEpochMilli();
+        }
+        catch (NullPointerException e) {
+            // Fallback for NPE from ChronoLocalDateTime#toLocalDate, see DBZ-9558
+            var ignored = dateTime.toString();
+            return dateTime.toInstant(ZoneOffset.UTC).toEpochMilli();
+        }
     }
 
     private Timestamp() {


### PR DESCRIPTION
## What
Backport the upstream JDK 23+/24 timestamp-NPE fixes onto `v3.2.5-hotfix-x`, guarding **both** `Timestamp.toEpochMillis` and `MicroTimestamp.toEpochMicros`.

## Why (INC-11471 / CC-42356)
On **JDK 24**, `ChronoLocalDateTime` can have a lazily-computed component return `null`, throwing an NPE inside the `Instant` conversion. In production this surfaced as **FM Postgres CDC (Debezium V2) tasks failing** with an NPE in `io.debezium.time.MicroTimestamp.toEpochMicros()` (masked as `DataException: Invalid value: null used for required field`) after Connect moved from JDK 21 → JDK 24 in the ce-kafka 8.3 base bump.

## The gap this closes
Upstream fixed this in **two methods, in two different releases** — and our FM connectors are on **3.2.5**, so we have **neither**:

| NPE method | Upstream issue / PR | Fixed upstream in |
|---|---|---|
| `Timestamp.toEpochMillis` | **DBZ-9558** (PR debezium/debezium#6828) | **3.3.2.Final** |
| `MicroTimestamp.toEpochMicros` ← *our incident* | **debezium/dbz#1732** (landed as commit [`49ad32bb`](https://github.com/debezium/debezium/commit/49ad32bb0cbee1b67864a673b90868c8d3074c7b)) | **3.5.0.Final** |

Note the incident's exact method (`MicroTimestamp.toEpochMicros`) was only fixed in **3.5.0.Final** — i.e. the originally-proposed "upgrade to ≥3.3.2.Final" would **not** have fixed it. This hotfix applies both guards now without a minor-version bump.

## How
Same self-contained pattern as upstream: on `NullPointerException`, call `dateTime.toString()` to materialize the lazily-computed field, then retry the conversion. No new imports, no API/3.3.x dependencies. (`debezium-core`, +19/-2.)

## Validation
- [ ] CI build/tests on this branch
- [ ] Manual: JDK 24 + Postgres `timestamp`/`timestamp(6)` columns through streaming + incremental snapshot (the INC-11471 repro)

## Follow-up
Promote via `debezium-v2-private` → `cc-docker-connect` once merged. Tracking: **CC-42356**.
