### PR TITLE
[DO NOT MERGE] DBZ-9558 repro: run Postgres IT on JDK 24

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -29,7 +29,15 @@ global_job_config:
       # (ChronoLocalDateTime.toLocalDate() returns null -> NPE in Timestamp.toEpochMillis).
       # Reporter only ever hit it on x86 CI (GitHub Actions); this semaphore agent
       # is x86-64 (s1-prod-ubuntu24-04-amd64-1), matching that environment.
-      - sem-version java 24
+      #
+      # `sem-version java 24` is NOT available on this agent (LTS only: 8/11/17/21),
+      # so install Eclipse Temurin 24 (x64) directly. Semaphore persists shell env
+      # across commands in a job, so JAVA_HOME/PATH carry into the mvn step below.
+      - curl -fsSL -o /tmp/jdk24.tar.gz "https://api.adoptium.net/v3/binary/latest/24/ga/linux/x64/jdk/hotspot/normal/eclipse"
+      - mkdir -p "$HOME/jdk24" && tar -xzf /tmp/jdk24.tar.gz -C "$HOME/jdk24" --strip-components=1
+      - export JAVA_HOME="$HOME/jdk24"
+      - export PATH="$JAVA_HOME/bin:$PATH"
+      - java -version
       - . cache-maven restore
 
 blocks:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -24,7 +24,12 @@ global_job_config:
   prologue:
     commands:
       - checkout
-      - sem-version java 21
+      # DBZ-9558 REPRO EXPERIMENT (DO NOT MERGE): run the Postgres connector IT
+      # suite on JDK 24 to reproduce the JDK-23+ timestamp NPE
+      # (ChronoLocalDateTime.toLocalDate() returns null -> NPE in Timestamp.toEpochMillis).
+      # Reporter only ever hit it on x86 CI (GitHub Actions); this semaphore agent
+      # is x86-64 (s1-prod-ubuntu24-04-amd64-1), matching that environment.
+      - sem-version java 24
       - . cache-maven restore
 
 blocks:
@@ -35,66 +40,11 @@ blocks:
       when: "change_in('/', {exclude: ['/.deployed-versions/', '.github/']})"
     task:
       jobs:
-        - name: MySQL 9.1 (mysql-ci-gtids)
-          commands:
-            - mvn -Dcloud -Dversion.mysql.server=9.1 -Pmysql-ci-gtids -Dformat.skip=true -DfailFlakyTests=false -pl debezium-connector-mysql -am -U -Dmaven.wagon.http.retryHandler.count=10 --batch-mode --no-transfer-progress verify
-            - . cve-scan
-            - . cache-maven store
-        - name: MySQL 9.1 (mysql-ci)
-          commands:
-            - mvn -Dcloud -Dversion.mysql.server=9.1 -Pmysql-ci -Dformat.skip=true -DfailFlakyTests=false -pl debezium-connector-mysql -am -U -Dmaven.wagon.http.retryHandler.count=10 --batch-mode --no-transfer-progress verify
-            - . cve-scan
-            - . cache-maven store
-        - name: MySQL 9.1 (mysql-ci-percona)
-          commands:
-            - mvn -Dcloud -Dversion.mysql.server=9.1 -Pmysql-ci-percona -Dformat.skip=true -DfailFlakyTests=false -pl debezium-connector-mysql -am -U -Dmaven.wagon.http.retryHandler.count=10 --batch-mode --no-transfer-progress verify
-            - . cve-scan
-            - . cache-maven store
-        - name: MySQL 9.1 (mysql-ci-ssl)
-          commands:
-            - mvn -Dcloud -Dversion.mysql.server=9.1 -Pmysql-ci-ssl -Dformat.skip=true -DfailFlakyTests=false -pl debezium-connector-mysql -am -U -Dmaven.wagon.http.retryHandler.count=10 --batch-mode --no-transfer-progress verify
-            - . cve-scan
-            - . cache-maven store
-        - name: MySQL 8.4 (mysql-ci-gtids)
-          commands:
-            - mvn -Dcloud -Dversion.mysql.server=8.4 -Pmysql-ci-gtids -Dformat.skip=true -DfailFlakyTests=false -pl debezium-connector-mysql -am -U -Dmaven.wagon.http.retryHandler.count=10 --batch-mode --no-transfer-progress verify
-            - . cve-scan
-            - . cache-maven store
-        - name: MySQL 8.4 (mysql-ci)
-          commands:
-            - mvn -Dcloud -Dversion.mysql.server=8.4 -Pmysql-ci -Dformat.skip=true -DfailFlakyTests=false -pl debezium-connector-mysql -am -U -Dmaven.wagon.http.retryHandler.count=10 --batch-mode --no-transfer-progress verify
-            - . cve-scan
-            - . cache-maven store
-        - name: MySQL 8.4 (mysql-ci-percona)
-          commands:
-            - mvn -Dcloud -Dversion.mysql.server=8.4 -Pmysql-ci-percona -Dformat.skip=true -DfailFlakyTests=false -pl debezium-connector-mysql -am -U -Dmaven.wagon.http.retryHandler.count=10 --batch-mode --no-transfer-progress verify
-            - . cve-scan
-            - . cache-maven store
-        - name: MySQL 8.4 (mysql-ci-ssl)
-          commands:
-            - mvn -Dcloud -Dversion.mysql.server=8.4 -Pmysql-ci-ssl -Dformat.skip=true -DfailFlakyTests=false -pl debezium-connector-mysql -am -U -Dmaven.wagon.http.retryHandler.count=10 --batch-mode --no-transfer-progress verify
-            - . cve-scan
-            - . cache-maven store
-        - name: MariaDB 11.4 (mariadb-ci)
-          commands:
-            - mvn -Dcloud -Pmariadb-ci -Dformat.skip=true -DfailFlakyTests=false -pl debezium-connector-mariadb -am -U -Dmaven.wagon.http.retryHandler.count=10 --batch-mode --no-transfer-progress verify
-            - . cve-scan
-            - . cache-maven store
-        - name: MariaDB 11.4 (mariadb-ci-ssl)
-          commands:
-            - mvn -Dcloud -Pmariadb-ci-ssl -Dformat.skip=true -DfailFlakyTests=false -pl debezium-connector-mariadb -am -U -Dmaven.wagon.http.retryHandler.count=10 --batch-mode --no-transfer-progress verify
-            - . cve-scan
-            - . cache-maven store
-        - name: MariaDB 11.4 (mariadb-ci-gtids)
-          commands:
-            - mvn -Dcloud -Pmariadb-ci-gtids -Dformat.skip=true -DfailFlakyTests=false -pl debezium-connector-mariadb -am -U -Dmaven.wagon.http.retryHandler.count=10 --batch-mode --no-transfer-progress verify
-            - . cve-scan
-            - . cache-maven store
-        - name: MongoDB
-          commands:
-            - mvn -Dcloud -Passembly -Dformat.skip=true -DfailFlakyTests=false -pl debezium-connector-mongodb -am -U -Dmaven.wagon.http.retryHandler.count=10 --batch-mode --no-transfer-progress verify
-            - . cve-scan
-            - . cache-maven store
+        # DBZ-9558 repro: Postgres pgoutput lanes only, on JDK 24. The connector IT
+        # suite streams timestamp(3)/timestamp(6) inserts through
+        # JdbcValueConverters -> Timestamp.toEpochMillis / MicroTimestamp.toEpochMicros,
+        # which is where the JDK-23+ NPE surfaces. Running several lanes gives the
+        # flaky (JIT-timing-dependent) bug more chances to fire.
         - name: Postgres 12 (assembly,postgres-12)
           commands:
             - mvn -Dcloud -Passembly,postgres-12 -Dformat.skip=true -DfailFlakyTests=false -pl debezium-connector-postgres -am -U -Dmaven.wagon.http.retryHandler.count=10 --batch-mode --no-transfer-progress verify
@@ -108,11 +58,6 @@ blocks:
         - name: Postgres 18 (assembly,postgres-18,pgoutput-decoder)
           commands:
             - mvn -Dcloud -Passembly,postgres-18,pgoutput-decoder -Dformat.skip=true -DfailFlakyTests=false -pl debezium-connector-postgres -am -U -Dmaven.wagon.http.retryHandler.count=10 --batch-mode --no-transfer-progress verify
-            - . cve-scan
-            - . cache-maven store
-        - name: SqlServer
-          commands:
-            - mvn -Dcloud -Passembly -Dformat.skip=true -DfailFlakyTests=false -pl debezium-connector-sqlserver -am -U -Dmaven.wagon.http.retryHandler.count=10 --batch-mode --no-transfer-progress verify
             - . cve-scan
             - . cache-maven store
       env_vars:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -48,24 +48,28 @@ blocks:
       when: "change_in('/', {exclude: ['/.deployed-versions/', '.github/']})"
     task:
       jobs:
-        # DBZ-9558 repro: Postgres pgoutput lanes only, on JDK 24. The connector IT
-        # suite streams timestamp(3)/timestamp(6) inserts through
-        # JdbcValueConverters -> Timestamp.toEpochMillis / MicroTimestamp.toEpochMicros,
-        # which is where the JDK-23+ NPE surfaces. Running several lanes gives the
-        # flaky (JIT-timing-dependent) bug more chances to fire.
+        # DBZ-9558 repro (run #3), on JDK 24. Narrowed to:
+        #   -Dtest=Dbz9558Jdk24TimestampNpeReproTest  : high-volume multi-threaded hammer on
+        #       Timestamp.toEpochMillis / MicroTimestamp.toEpochMicros (max C2 JIT pressure;
+        #       native x86-64 is the one variable our arm64/Rosetta attempts never satisfied).
+        #   -Dit.test=RecordsStreamProducerIT,PostgresTemporalPrecisionHandlingIT : the existing
+        #       streaming timestamp ITs, for faithful call-site fidelity via pgoutput.
+        # Narrowing also dodges the unrelated flaky BlockingSnapshotIT (toMap-null NPE) that
+        # aborted run #2, and keeps the log under Semaphore's 16MB cap so results are visible.
+        # 3 lanes = 3 parallel JIT attempts across PG 12/17/18.
         - name: Postgres 12 (assembly,postgres-12)
           commands:
-            - mvn -Dcloud -Passembly,postgres-12 -Dformat.skip=true -DfailFlakyTests=false -pl debezium-connector-postgres -am -U -Dmaven.wagon.http.retryHandler.count=10 --batch-mode --no-transfer-progress verify
+            - mvn -Dcloud -Passembly,postgres-12 -Dformat.skip=true -DfailFlakyTests=false -pl debezium-connector-postgres -am -Dtest=Dbz9558Jdk24TimestampNpeReproTest -Dit.test=RecordsStreamProducerIT,PostgresTemporalPrecisionHandlingIT -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false -Dfailsafe.failIfNoSpecifiedTests=false -U -Dmaven.wagon.http.retryHandler.count=10 --batch-mode --no-transfer-progress verify
             - . cve-scan
             - . cache-maven store
         - name: Postgres 17 (assembly,postgres-17,pgoutput-decoder)
           commands:
-            - mvn -Dcloud -Passembly,postgres-17,pgoutput-decoder -Dformat.skip=true -DfailFlakyTests=false -pl debezium-connector-postgres -am -U -Dmaven.wagon.http.retryHandler.count=10 --batch-mode --no-transfer-progress verify
+            - mvn -Dcloud -Passembly,postgres-17,pgoutput-decoder -Dformat.skip=true -DfailFlakyTests=false -pl debezium-connector-postgres -am -Dtest=Dbz9558Jdk24TimestampNpeReproTest -Dit.test=RecordsStreamProducerIT,PostgresTemporalPrecisionHandlingIT -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false -Dfailsafe.failIfNoSpecifiedTests=false -U -Dmaven.wagon.http.retryHandler.count=10 --batch-mode --no-transfer-progress verify
             - . cve-scan
             - . cache-maven store
         - name: Postgres 18 (assembly,postgres-18,pgoutput-decoder)
           commands:
-            - mvn -Dcloud -Passembly,postgres-18,pgoutput-decoder -Dformat.skip=true -DfailFlakyTests=false -pl debezium-connector-postgres -am -U -Dmaven.wagon.http.retryHandler.count=10 --batch-mode --no-transfer-progress verify
+            - mvn -Dcloud -Passembly,postgres-18,pgoutput-decoder -Dformat.skip=true -DfailFlakyTests=false -pl debezium-connector-postgres -am -Dtest=Dbz9558Jdk24TimestampNpeReproTest -Dit.test=RecordsStreamProducerIT,PostgresTemporalPrecisionHandlingIT -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false -Dfailsafe.failIfNoSpecifiedTests=false -U -Dmaven.wagon.http.retryHandler.count=10 --batch-mode --no-transfer-progress verify
             - . cve-scan
             - . cache-maven store
       env_vars:

--- a/debezium-core/src/test/java/io/debezium/time/Dbz9558Jdk24TimestampNpeReproTest.java
+++ b/debezium-core/src/test/java/io/debezium/time/Dbz9558Jdk24TimestampNpeReproTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.time;
+
+import static org.junit.Assert.fail;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.Test;
+
+/**
+ * DBZ-9558 best-effort reproducer (DO NOT MERGE).
+ *
+ * <p>On JDK 23+ the C2 JIT can miscompile {@link java.time.chrono.ChronoLocalDateTime#toEpochSecond()}
+ * so that {@code toLocalDate()} spuriously returns {@code null}, producing:
+ *
+ * <pre>
+ * java.lang.NullPointerException: Cannot invoke "java.time.chrono.ChronoLocalDate.toEpochDay()"
+ *   because the return value of "java.time.chrono.ChronoLocalDateTime.toLocalDate()" is null
+ *     at java.base/java.time.chrono.ChronoLocalDateTime.toEpochSecond(...)
+ *     at io.debezium.time.Timestamp.toEpochMillis(Timestamp.java:77)
+ * </pre>
+ *
+ * The upstream bug (DBZ-9558) is non-deterministic and was only ever observed on x86-64 CI, never
+ * locally and never on arm64. This test brute-forces the exact conversion methods
+ * ({@link Timestamp#toEpochMillis} / {@link MicroTimestamp#toEpochMicros}) plus the raw JDK path
+ * from the stack trace, across all available cores for a long time, to give C2 the chance to reach
+ * the miscompiled state. If the NPE fires, the test fails and captures the environment.
+ *
+ * This is a probabilistic reproducer, not a deterministic assertion: a green run does NOT prove the
+ * bug is absent, it only means C2 did not miscompile within the iteration budget on this run.
+ */
+public class Dbz9558Jdk24TimestampNpeReproTest {
+
+    private static final int THREADS = Math.max(4, Runtime.getRuntime().availableProcessors());
+    private static final long ITERATIONS_PER_THREAD = 150_000_000L;
+
+    private static volatile long SINK;
+
+    @Test
+    public void hammerTimestampConversionForJdk23Npe() throws Exception {
+        // reporter's value: 1989-04-21 00:00:00.0
+        final long base = java.sql.Timestamp.valueOf("1989-04-21 00:00:00.0").getTime();
+        final AtomicReference<Throwable> firstFailure = new AtomicReference<>();
+
+        System.out.println("[DBZ-9558] hammering " + THREADS + " threads x " + ITERATIONS_PER_THREAD
+                + " iters on java " + System.getProperty("java.version")
+                + " (" + System.getProperty("java.vm.name") + "), arch=" + System.getProperty("os.arch"));
+
+        final Thread[] workers = new Thread[THREADS];
+        for (int t = 0; t < THREADS; t++) {
+            workers[t] = new Thread(() -> {
+                long acc = 0L;
+                try {
+                    for (long i = 0; i < ITERATIONS_PER_THREAD && firstFailure.get() == null; i++) {
+                        // vary the value so it is not constant-folded; keep it a valid timestamp
+                        final java.sql.Timestamp sql = new java.sql.Timestamp(base + (i & 0xFFFF));
+
+                        // millis path: JdbcValueConverters -> Timestamp.toEpochMillis (precision <= 3)
+                        acc ^= Timestamp.toEpochMillis(sql, null);
+                        // micros path: JdbcValueConverters -> MicroTimestamp.toEpochMicros (precision 4-6)
+                        acc ^= MicroTimestamp.toEpochMicros(sql, null);
+                        // raw JDK frames from the reported stack: LocalDateTime -> Instant
+                        final LocalDateTime ldt = sql.toLocalDateTime();
+                        acc ^= ldt.toInstant(ZoneOffset.UTC).toEpochMilli();
+                    }
+                }
+                catch (Throwable ex) {
+                    firstFailure.compareAndSet(null, ex);
+                }
+                SINK += acc; // publish so the JIT cannot dead-code-eliminate the loop body
+            }, "dbz9558-hammer-" + t);
+            workers[t].start();
+        }
+        for (Thread w : workers) {
+            w.join();
+        }
+
+        final Throwable failure = firstFailure.get();
+        if (failure != null) {
+            // If this is the ChronoLocalDateTime.toLocalDate() NPE, DBZ-9558 reproduced on this env.
+            failure.printStackTrace();
+            fail("DBZ-9558 REPRODUCED on java " + System.getProperty("java.version")
+                    + " arch=" + System.getProperty("os.arch") + " sink=" + SINK + " : " + failure);
+        }
+        System.out.println("[DBZ-9558] no NPE this run (sink=" + SINK + "); C2 did not miscompile within budget");
+    }
+}


### PR DESCRIPTION
## ⚠️ DO NOT MERGE — CI reproduction experiment for DBZ-9558

This PR exists **only to try to reproduce [DBZ-9558](https://issues.redhat.com/browse/DBZ-9558)** (the JDK-23+ Postgres timestamp NPE) in CI. It must not be merged.

### The bug
On JDK 23+, streaming a `timestamp` value intermittently throws:

```
java.lang.NullPointerException: Cannot invoke "java.time.chrono.ChronoLocalDate.toEpochDay()"
  because the return value of "java.time.chrono.ChronoLocalDateTime.toLocalDate()" is null
    at java.base/java.time.chrono.ChronoLocalDateTime.toEpochSecond(...)
    at io.debezium.time.Timestamp.toEpochMillis(Timestamp.java:77)
    at io.debezium.jdbc.JdbcValueConverters.convertTimestampToEpochMillisAsDate(...)
```

It's a JDK JIT-level defect (`toLocalDate()` spuriously returns null). Per the reporter it reproduces **only on x86 CI (GitHub Actions), never locally**, and it's non-deterministic (JIT-timing dependent). We could not reproduce it locally on arm64 (~1M timestamps streamed through a live connector on JDK 24, 0 NPE).

### What this PR does
Branched off the **unfixed** `v3.2.5-hotfix-x` (so the NPE can fire) and:
- Prologue `sem-version java 21` → **`sem-version java 24`**.
- Trimmed the Test block to the **3 Postgres lanes (pgoutput)** — the reporter's connector — for a fast, focused run. Each lane's IT suite streams `timestamp(3)`/`timestamp(6)` inserts through `Timestamp.toEpochMillis` / `MicroTimestamp.toEpochMicros`. Multiple lanes give the flaky bug more chances to fire.

The semaphore agent is **`s1-prod-ubuntu24-04-amd64-1` (x86-64)** — matching the only environment the bug has been seen in.

### Success criterion
A Postgres lane failing with the `ChronoLocalDateTime.toLocalDate()` NPE = reproduced. All green = not reproduced on this agent/JDK/suite (informs whether the fix in #475 is needed defensively vs. proven-against-a-repro).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
