### PR TITLE
INC-12079: Redact sensitive values from shared-code logs and exceptions

### DIFF
--- a/debezium-core/src/main/java/io/debezium/jdbc/JdbcValueConverters.java
+++ b/debezium-core/src/main/java/io/debezium/jdbc/JdbcValueConverters.java
@@ -666,8 +666,8 @@ public class JdbcValueConverters implements ValueConverterProvider {
                 r.deliver(Date.toEpochDay(data, adjuster));
             }
             catch (IllegalArgumentException e) {
-                logger.warn("Unexpected JDBC DATE value for field {} with schema {}: class={}, value={}", fieldDefn.name(),
-                        fieldDefn.schema(), data.getClass(), data);
+                logger.warn("Unexpected JDBC DATE value for field {} with schema {}: class={}", fieldDefn.name(),
+                        fieldDefn.schema(), data.getClass());
             }
         });
     }
@@ -696,8 +696,8 @@ public class JdbcValueConverters implements ValueConverterProvider {
                 r.deliver(new java.util.Date(epochMillis));
             }
             catch (IllegalArgumentException e) {
-                logger.warn("Unexpected JDBC DATE value for field {} with schema {}: class={}, value={}", fieldDefn.name(),
-                        fieldDefn.schema(), data.getClass(), data);
+                logger.warn("Unexpected JDBC DATE value for field {} with schema {}: class={}", fieldDefn.name(),
+                        fieldDefn.schema(), data.getClass());
             }
         });
     }
@@ -831,8 +831,8 @@ public class JdbcValueConverters implements ValueConverterProvider {
      * @see #convertBinaryToBytes(Column, Field, Object)
      */
     protected byte[] unexpectedBinary(Object value, Field fieldDefn) {
-        logger.warn("Unexpected JDBC BINARY value for field {} with schema {}: class={}, value={}", fieldDefn.name(),
-                fieldDefn.schema(), value.getClass(), value);
+        logger.warn("Unexpected JDBC BINARY value for field {} with schema {}: class={}", fieldDefn.name(),
+                fieldDefn.schema(), value.getClass());
         return null;
     }
 

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotChangeEventSource.java
@@ -159,7 +159,7 @@ public abstract class AbstractIncrementalSnapshotChangeEventSource<P extends Par
         }
         if (key instanceof Struct) {
             if (window.remove((Struct) key) != null) {
-                LOGGER.info("Removed '{}' from window", key);
+                LOGGER.info("Removed key from window");
             }
         }
     }

--- a/debezium-core/src/main/java/io/debezium/relational/history/KafkaDatabaseHistory.java
+++ b/debezium-core/src/main/java/io/debezium/relational/history/KafkaDatabaseHistory.java
@@ -336,10 +336,10 @@ public class KafkaDatabaseHistory extends AbstractDatabaseHistory {
                         }
                     }
                     catch (final IOException e) {
-                        LOGGER.error("Error while deserializing history record '{}'", record, e);
+                        LOGGER.error("Error while deserializing history record", e);
                     }
                     catch (final Exception e) {
-                        LOGGER.error("Unexpected exception while processing record '{}'", record, e);
+                        LOGGER.error("Unexpected exception while processing record", e);
                         throw e;
                     }
                 }

--- a/debezium-core/src/main/java/io/debezium/time/Conversions.java
+++ b/debezium-core/src/main/java/io/debezium/time/Conversions.java
@@ -50,7 +50,7 @@ public final class Conversions {
             return ((java.sql.Date) obj).toLocalDate();
         }
         if (obj instanceof java.sql.Time) {
-            throw new IllegalArgumentException("Unable to convert to LocalDate from a java.sql.Time value '" + obj + "'");
+            throw new IllegalArgumentException("Unable to convert to LocalDate from a java.sql.Time value of type " + obj.getClass().getName());
         }
         if (obj instanceof java.util.Date) {
             java.util.Date date = (java.util.Date) obj;
@@ -66,7 +66,7 @@ public final class Conversions {
             // Assume the value is the epoch day number
             return LocalDate.ofEpochDay((Integer) obj);
         }
-        throw new IllegalArgumentException("Unable to convert to LocalDate from unexpected value '" + obj + "' of type " + obj.getClass().getName());
+        throw new IllegalArgumentException("Unable to convert to LocalDate from unexpected value of type " + obj.getClass().getName());
     }
 
     @SuppressWarnings("deprecation")
@@ -81,7 +81,7 @@ public final class Conversions {
             return ((LocalDateTime) obj).toLocalTime();
         }
         if (obj instanceof java.sql.Date) {
-            throw new IllegalArgumentException("Unable to convert to LocalDate from a java.sql.Date value '" + obj + "'");
+            throw new IllegalArgumentException("Unable to convert to LocalDate from a java.sql.Date value of type " + obj.getClass().getName());
         }
         if (obj instanceof java.sql.Time) {
             java.sql.Time time = (java.sql.Time) obj;
@@ -117,7 +117,7 @@ public final class Conversions {
                 throw new IllegalArgumentException("Time values must use number of milliseconds greater than 0 and less than 86400000000000");
             }
         }
-        throw new IllegalArgumentException("Unable to convert to LocalTime from unexpected value '" + obj + "' of type " + obj.getClass().getName());
+        throw new IllegalArgumentException("Unable to convert to LocalTime from unexpected value of type " + obj.getClass().getName());
     }
 
     @SuppressWarnings("deprecation")
@@ -176,7 +176,7 @@ public final class Conversions {
                     date.getSeconds(),
                     nanosOfSecond);
         }
-        throw new IllegalArgumentException("Unable to convert to LocalTime from unexpected value '" + obj + "' of type " + obj.getClass().getName());
+        throw new IllegalArgumentException("Unable to convert to LocalTime from unexpected value of type " + obj.getClass().getName());
     }
 
     public static long toEpochMicros(Instant instant) {

--- a/debezium-core/src/main/java/io/debezium/time/ZonedTime.java
+++ b/debezium-core/src/main/java/io/debezium/time/ZonedTime.java
@@ -83,7 +83,7 @@ public class ZonedTime {
         if (value instanceof java.util.Date) { // or JDBC subtypes
             return toIsoString((java.util.Date) value, defaultZone, adjuster);
         }
-        throw new IllegalArgumentException("Unable to convert to OffsetTime from unexpected value '" + value + "' of type " + value.getClass().getName());
+        throw new IllegalArgumentException("Unable to convert to OffsetTime from unexpected value of type " + value.getClass().getName());
     }
 
     /**

--- a/debezium-core/src/main/java/io/debezium/time/ZonedTimestamp.java
+++ b/debezium-core/src/main/java/io/debezium/time/ZonedTimestamp.java
@@ -94,7 +94,7 @@ public class ZonedTimestamp {
             return toIsoString((java.util.Date) value, defaultZone, adjuster);
         }
         throw new IllegalArgumentException(
-                "Unable to convert to OffsetDateTime from unexpected value '" + value + "' of type " + value.getClass().getName());
+                "Unable to convert to OffsetDateTime from unexpected value of type " + value.getClass().getName());
     }
 
     /**


### PR DESCRIPTION
## Summary
- Follow-up to the INC-12079 log-leak audit of this repo @ `v1.9.6-hotfix-x` (commit `e13ad5c0b`). The audit flagged several logging/exception sites in shared `debezium-core` code that echo raw column values, primary keys, or Kafka records that can carry customer PII.
- Redacts 4 files:
  - `JdbcValueConverters` — WARN logs on unexpected JDBC DATE/BINARY values no longer include the raw `data`/`value`, only field name, schema, and class.
  - `time/Conversions`, `time/ZonedTime`, `time/ZonedTimestamp` — `IllegalArgumentException` messages for unconvertible date/time values no longer embed the raw value, only its type.
  - `AbstractIncrementalSnapshotChangeEventSource` — the `"Removed key from window"` INFO log during incremental-snapshot deduplication no longer includes the primary-key `Struct`.
  - `KafkaDatabaseHistory` — ERROR logs on history-record deserialization failure no longer include the full `ConsumerRecord`.
- No behavior change beyond the log/exception text — same control flow, same exceptions thrown; only the sensitive parameter is dropped from the message, matching the established v1.9.6 style from #445/#453/#454.

## Test plan
- [x] `mvn -pl debezium-core -am compile` — builds cleanly
- [x] `mvn -pl debezium-connector-sqlserver -am compile` — builds cleanly against the updated core
- [x] `ConversionsTest` (debezium-core): 20/20 pass
- [x] `KafkaDatabaseHistoryTest` (debezium-connector-mysql, exercises the exact changed log line via `shouldIgnoreUnparseableMessages`): 8/8 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)