### PR TITLE
CC-42073: Add MongoDB streaming ConnectedCode metric

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/metrics/MongoDbStreamingChangeEventSourceMetrics.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/metrics/MongoDbStreamingChangeEventSourceMetrics.java
@@ -46,6 +46,11 @@ public class MongoDbStreamingChangeEventSourceMetrics extends DefaultStreamingCh
     }
 
     @Override
+    public int getConnectedCode() {
+        return isConnected() ? 1 : 0;
+    }
+
+    @Override
     public long getNumberOfPrimaryElections() {
         return numberOfPrimaryElections.get();
     }

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/metrics/MongoDbStreamingChangeEventSourceMetricsMXBean.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/metrics/MongoDbStreamingChangeEventSourceMetricsMXBean.java
@@ -14,6 +14,15 @@ import io.debezium.pipeline.metrics.StreamingChangeEventSourceMetricsMXBean;
  */
 public interface MongoDbStreamingChangeEventSourceMetricsMXBean extends StreamingChangeEventSourceMetricsMXBean {
 
+    /**
+     * Numeric surrogate for {@link #isConnected()} (1 = connected, 0 = disconnected), additive
+     * alongside the existing boolean attribute. The JMX-to-telemetry pipeline cannot ship a native
+     * boolean attribute as a GAUGE_INT64 metric, so this exposes the same state as an integer for
+     * the streaming_is_connected telemetry metric to be sourced from, without changing the type of
+     * the existing Connected attribute (which is already relied upon by Confluent Platform users).
+     */
+    int getConnectedCode();
+
     long getNumberOfDisconnects();
 
     long getNumberOfPrimaryElections();

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoMetricsIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoMetricsIT.java
@@ -138,6 +138,7 @@ public class MongoMetricsIT extends AbstractMongoConnectorIT {
 
         assertThat(mBeanServer.getAttribute(objectName, "SourceEventPosition")).isNotNull();
         assertThat(mBeanServer.getAttribute(objectName, "Connected")).isEqualTo(true);
+        assertThat(mBeanServer.getAttribute(objectName, "ConnectedCode")).isEqualTo(1);
         assertThat(mBeanServer.getAttribute(objectName, "CapturedTables")).isEqualTo(new String[]{});
         assertThat(mBeanServer.getAttribute(objectName, "LastEvent")).isNotNull();
         assertThat(mBeanServer.getAttribute(objectName, "TotalNumberOfEventsSeen")).isEqualTo(6L);


### PR DESCRIPTION
## Summary
- `streaming_is_connected` never emitted data for the MongoDB CDC connector in Confluent Cloud telemetry, even though the underlying JMX `Connected` attribute was correctly `true`/`false`. The telemetry catalog declares this metric as `GAUGE_INT64`, but the JMX attribute is a native `boolean`, and the JMX-to-telemetry shipping pipeline cannot ship a boolean as an int64 gauge.
- Initial approach changed the shared `Connected`/`isConnected()` JMX attribute's type from `boolean` to `long` at the core level. Reverted that — this attribute is already relied upon by existing Confluent Platform (self-managed) deployments, and changing its type would break their monitoring/dashboards.
- Instead, added a new, additive `ConnectedCode` attribute scoped to the MongoDB connector only (`MongoDbStreamingChangeEventSourceMetricsMXBean`/`MongoDbStreamingChangeEventSourceMetrics`), mirroring the pattern the Spanner CDC connector already uses successfully. The existing `Connected` boolean attribute is untouched for every connector, including MongoDB.
- Updated `cc-docker-connect`'s `debezium-jmx-v2.yaml` MongoDB streaming rule to source the `is_connected` telemetry metric from `ConnectedCode` instead of `Connected`. No other connector's mapping changed.
- JIRA: https://confluentinc.atlassian.net/browse/CC-42073

## Test plan
- [x] Added `ConnectedCode` assertion alongside the existing `Connected` assertion in `MongoMetricsIT`
- [x] Compiled `debezium-connector-mongodb` cleanly
- [ ] Full `MongoMetricsIT` testcontainers run (blocked locally by a Docker Desktop API-version incompatibility unrelated to this change; recommend running in CI)