### PR TITLE
CC-42217: Do not apply column include/exclude list to the signal data collection

### DIFF
--- a/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java
+++ b/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java
@@ -1665,7 +1665,9 @@ public abstract class CommonConnectorConfig {
         }
         List<org.apache.kafka.connect.data.Field> fields = event.schema().fields();
         if (fields.size() != 3) {
-            LOGGER.warn("The signal event '{}' should have 3 fields but has {}", maybeRedactSensitiveData(event), fields.size());
+            LOGGER.warn("The signal event '{}' should have exactly 3 fields (id, type, data) but found {}. "
+                    + "When column.include.list or column.exclude.list is configured, ensure the signal data "
+                    + "collection's id, type and data columns are not filtered out.", maybeRedactSensitiveData(event), fields.size());
             return Optional.empty();
         }
         return Optional.of(new String[]{

--- a/debezium-core/src/main/java/io/debezium/relational/RelationalDatabaseConnectorConfig.java
+++ b/debezium-core/src/main/java/io/debezium/relational/RelationalDatabaseConnectorConfig.java
@@ -700,6 +700,10 @@ public abstract class RelationalDatabaseConnectorConfig extends CommonConnectorC
         return getConfig().getString(TABLE_INCLUDE_LIST);
     }
 
+    public String columnIncludeList() {
+        return getConfig().getString(COLUMN_INCLUDE_LIST);
+    }
+
     public ColumnNameFilter getColumnFilter() {
         return columnFilter;
     }

--- a/debezium-core/src/main/java/io/debezium/relational/RelationalDatabaseSchema.java
+++ b/debezium-core/src/main/java/io/debezium/relational/RelationalDatabaseSchema.java
@@ -19,6 +19,7 @@ import io.debezium.relational.Tables.TableFilter;
 import io.debezium.relational.mapping.ColumnMappers;
 import io.debezium.schema.DatabaseSchema;
 import io.debezium.spi.topic.TopicNamingStrategy;
+import io.debezium.util.Strings;
 
 /**
  * A {@link DatabaseSchema} of a relational database such as Postgres. Provides information about the physical structure
@@ -28,6 +29,9 @@ import io.debezium.spi.topic.TopicNamingStrategy;
  */
 public abstract class RelationalDatabaseSchema implements DatabaseSchema<TableId> {
     private final static Logger LOG = LoggerFactory.getLogger(RelationalDatabaseSchema.class);
+
+    // The columns a signal data collection must expose (id, type, data) for source-channel signals to be parsed.
+    private static final Set<String> SIGNAL_REQUIRED_COLUMNS = Set.of("id", "type", "data");
 
     private final TopicNamingStrategy<TableId> topicNamingStrategy;
     private final TableSchemaBuilder schemaBuilder;
@@ -46,12 +50,27 @@ public abstract class RelationalDatabaseSchema implements DatabaseSchema<TableId
         this.topicNamingStrategy = topicNamingStrategy;
         this.schemaBuilder = schemaBuilder;
         this.tableFilter = tableFilter;
-        this.columnFilter = columnFilter;
+        this.columnFilter = overrideColumnFilter(config, columnFilter);
         this.columnMappers = ColumnMappers.create(config);
         this.customKeysMapper = customKeysMapper;
 
         this.schemasByTableId = new SchemasByTableId(tableIdCaseInsensitive);
         this.tables = new Tables(tableIdCaseInsensitive);
+    }
+
+    /**
+     * Wraps the configured column filter so that the required columns of the signal data collection
+     * ({@code id}, {@code type}, {@code data}) are always included when {@code column.include.list} is used.
+     */
+    static ColumnNameFilter overrideColumnFilter(RelationalDatabaseConnectorConfig config, ColumnNameFilter columnFilter) {
+        final boolean includeListMode = !Strings.isNullOrEmpty(
+                config.getConfig().getString(RelationalDatabaseConnectorConfig.COLUMN_INCLUDE_LIST));
+        if (columnFilter != null && includeListMode && !Strings.isNullOrBlank(config.getSignalingDataCollectionId())) {
+            return (catalogName, schemaName, tableName, columnName) -> (SIGNAL_REQUIRED_COLUMNS.contains(columnName.toLowerCase())
+                    && config.isSignalDataCollection(new TableId(catalogName, schemaName, tableName)))
+                    || columnFilter.matches(catalogName, schemaName, tableName, columnName);
+        }
+        return columnFilter;
     }
 
     @Override

--- a/debezium-core/src/main/java/io/debezium/relational/RelationalDatabaseSchema.java
+++ b/debezium-core/src/main/java/io/debezium/relational/RelationalDatabaseSchema.java
@@ -66,6 +66,9 @@ public abstract class RelationalDatabaseSchema implements DatabaseSchema<TableId
         final boolean includeListMode = !Strings.isNullOrEmpty(
                 config.getConfig().getString(RelationalDatabaseConnectorConfig.COLUMN_INCLUDE_LIST));
         if (columnFilter != null && includeListMode && !Strings.isNullOrBlank(config.getSignalingDataCollectionId())) {
+            LOG.info("column.include.list is configured with a signal data collection ('{}'); retaining its required columns {} "
+                    + "in the schema so source-channel signals are not dropped.",
+                    config.getSignalingDataCollectionId(), SIGNAL_REQUIRED_COLUMNS);
             return (catalogName, schemaName, tableName, columnName) -> (SIGNAL_REQUIRED_COLUMNS.contains(columnName.toLowerCase())
                     && config.isSignalDataCollection(new TableId(catalogName, schemaName, tableName)))
                     || columnFilter.matches(catalogName, schemaName, tableName, columnName);

--- a/debezium-core/src/main/java/io/debezium/relational/RelationalDatabaseSchema.java
+++ b/debezium-core/src/main/java/io/debezium/relational/RelationalDatabaseSchema.java
@@ -5,6 +5,7 @@
  */
 package io.debezium.relational;
 
+import java.util.Locale;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -63,13 +64,12 @@ public abstract class RelationalDatabaseSchema implements DatabaseSchema<TableId
      * ({@code id}, {@code type}, {@code data}) are always included when {@code column.include.list} is used.
      */
     static ColumnNameFilter overrideColumnFilter(RelationalDatabaseConnectorConfig config, ColumnNameFilter columnFilter) {
-        final boolean includeListMode = !Strings.isNullOrEmpty(
-                config.getConfig().getString(RelationalDatabaseConnectorConfig.COLUMN_INCLUDE_LIST));
+        final boolean includeListMode = !Strings.isNullOrEmpty(config.columnIncludeList());
         if (columnFilter != null && includeListMode && !Strings.isNullOrBlank(config.getSignalingDataCollectionId())) {
-            LOG.info("column.include.list is configured with a signal data collection ('{}'); retaining its required columns {} "
-                    + "in the schema so source-channel signals are not dropped.",
-                    config.getSignalingDataCollectionId(), SIGNAL_REQUIRED_COLUMNS);
-            return (catalogName, schemaName, tableName, columnName) -> (SIGNAL_REQUIRED_COLUMNS.contains(columnName.toLowerCase())
+            LOG.info("Column include list is configured with a signal data collection; the required signal columns {} "
+                    + "of that collection ('{}') will always be included in the schema.",
+                    SIGNAL_REQUIRED_COLUMNS, config.getSignalingDataCollectionId());
+            return (catalogName, schemaName, tableName, columnName) -> (SIGNAL_REQUIRED_COLUMNS.contains(columnName.toLowerCase(Locale.ROOT))
                     && config.isSignalDataCollection(new TableId(catalogName, schemaName, tableName)))
                     || columnFilter.matches(catalogName, schemaName, tableName, columnName);
         }

--- a/debezium-core/src/test/java/io/debezium/relational/TableSchemaBuilderTest.java
+++ b/debezium-core/src/test/java/io/debezium/relational/TableSchemaBuilderTest.java
@@ -22,6 +22,7 @@ import org.apache.kafka.connect.source.SourceRecord;
 import org.junit.Before;
 import org.junit.Test;
 
+import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.CommonConnectorConfig.EventConvertingFailureHandlingMode;
 import io.debezium.config.Configuration;
 import io.debezium.data.VerifyRecord;
@@ -777,5 +778,77 @@ public class TableSchemaBuilderTest {
         assertThat(logInterceptor.containsErrorMessage(errorMessage)).isFalse();
         assertThat(logInterceptor.containsWarnMessage(errorMessage)).isFalse();
         logInterceptor.clear();
+    }
+
+    @Test
+    @FixFor("CC-42217")
+    public void shouldIncludeRequiredSignalColumnsWithColumnIncludeList() {
+        final Configuration config = Configuration.create()
+                .with(RelationalDatabaseConnectorConfig.COLUMN_INCLUDE_LIST, "s1\\.customers\\.id")
+                .with(CommonConnectorConfig.SIGNAL_DATA_COLLECTION, "testdb.s1.debezium_signal")
+                .build();
+        final RelationalDatabaseConnectorConfig connectorConfig = new TestRelationalDatabaseConfig(config, null, null, 0);
+
+        final Tables.ColumnNameFilter filter = RelationalDatabaseSchema.overrideColumnFilter(connectorConfig, connectorConfig.getColumnFilter());
+
+        // The signal data collection keeps its required columns even though column.include.list excludes them.
+        assertThat(filter.matches("testdb", "s1", "debezium_signal", "id")).isTrue();
+        assertThat(filter.matches("testdb", "s1", "debezium_signal", "type")).isTrue();
+        assertThat(filter.matches("testdb", "s1", "debezium_signal", "data")).isTrue();
+
+        // Only the required columns are force-included: an extra signal-table column stays filtered out, so a
+        // signal table with more than three columns still yields exactly the required three fields.
+        assertThat(filter.matches("testdb", "s1", "debezium_signal", "extra")).isFalse();
+
+        assertThat(filter.matches("testdb", "s1", "customers", "id")).isTrue();
+        assertThat(filter.matches("testdb", "s1", "customers", "name")).isFalse();
+    }
+
+    @Test
+    @FixFor("CC-42217")
+    public void shouldMatchSignalColumnsCaseInsensitively() {
+        final Configuration config = Configuration.create()
+                .with(RelationalDatabaseConnectorConfig.COLUMN_INCLUDE_LIST, "S1\\.CUSTOMERS\\.ID")
+                .with(CommonConnectorConfig.SIGNAL_DATA_COLLECTION, "TESTDB.S1.DEBEZIUM_SIGNAL")
+                .build();
+        final RelationalDatabaseConnectorConfig connectorConfig = new TestRelationalDatabaseConfig(config, null, null, 0);
+
+        final Tables.ColumnNameFilter filter = RelationalDatabaseSchema.overrideColumnFilter(connectorConfig, connectorConfig.getColumnFilter());
+
+        // Upper-case identifiers (e.g. Oracle) must still be recognised as the required signal columns.
+        assertThat(filter.matches("TESTDB", "S1", "DEBEZIUM_SIGNAL", "ID")).isTrue();
+        assertThat(filter.matches("TESTDB", "S1", "DEBEZIUM_SIGNAL", "TYPE")).isTrue();
+        assertThat(filter.matches("TESTDB", "S1", "DEBEZIUM_SIGNAL", "DATA")).isTrue();
+        assertThat(filter.matches("TESTDB", "S1", "DEBEZIUM_SIGNAL", "EXTRA")).isFalse();
+    }
+
+    @Test
+    @FixFor("CC-42217")
+    public void shouldNotAlterColumnFilterInExcludeListMode() {
+        // In exclude-list mode the signal columns already pass by default, so the filter must be left untouched,
+        // otherwise columns the user deliberately excluded from the signal table would be re-added.
+        final Configuration config = Configuration.create()
+                .with(RelationalDatabaseConnectorConfig.COLUMN_EXCLUDE_LIST, "s1\\.debezium_signal\\.extra")
+                .with(CommonConnectorConfig.SIGNAL_DATA_COLLECTION, "testdb.s1.debezium_signal")
+                .build();
+        final RelationalDatabaseConnectorConfig connectorConfig = new TestRelationalDatabaseConfig(config, null, null, 0);
+        final Tables.ColumnNameFilter original = connectorConfig.getColumnFilter();
+
+        final Tables.ColumnNameFilter filter = RelationalDatabaseSchema.overrideColumnFilter(connectorConfig, original);
+        assertThat(filter).isSameAs(original);
+        assertThat(filter.matches("testdb", "s1", "debezium_signal", "extra")).isFalse();
+        assertThat(filter.matches("testdb", "s1", "debezium_signal", "id")).isTrue();
+    }
+
+    @Test
+    @FixFor("CC-42217")
+    public void shouldNotAlterColumnFilterWhenNoSignalDataCollectionConfigured() {
+        final Configuration config = Configuration.create()
+                .with(RelationalDatabaseConnectorConfig.COLUMN_INCLUDE_LIST, "s1\\.customers\\.id")
+                .build();
+        final RelationalDatabaseConnectorConfig connectorConfig = new TestRelationalDatabaseConfig(config, null, null, 0);
+        final Tables.ColumnNameFilter original = connectorConfig.getColumnFilter();
+
+        assertThat(RelationalDatabaseSchema.overrideColumnFilter(connectorConfig, original)).isSameAs(original);
     }
 }


### PR DESCRIPTION
## Summary
Port of the upstream fix ([debezium/debezium#7717](https://github.com/debezium/debezium/pull/7717), issue `debezium/dbz#2280`) to the `v3.1.2-orcl-hotfix-x` line. Driven by **CC-42217 / INC-11669**.

## Problem
The column filter from `column.include.list` was applied uniformly to every table, **including the signal data collection**. When the signal table's columns were not listed in `column.include.list`, its value schema was built with **0 fields**, so a source-channel signal became an empty `Struct` and was silently dropped (`WARN The signal event ... should have 3 fields but has 0`). As a result, blocking/incremental snapshots triggered via the source channel never ran.

## Fix
`RelationalDatabaseSchema` now wraps the configured column filter so the **required signal columns (`id`, `type`, `data`)** of the signal data collection are always included when `column.include.list` is used — matched **case-insensitively** and limited to those three, so a signal table with extra columns still yields exactly three fields.

Two deliberate scoping decisions:
- **Only the three required columns** (not all signal-table columns): `parseSignallingMessage` requires exactly 3 fields, so force-including everything would re-break signal tables that have more than 3 columns.
- **Only in include-list mode** (exclude-list mode untouched): the bug is specific to `column.include.list` (an exclude list already lets the signal columns through); force-including under an exclude list would override columns of a signal table a user deliberately excluded.

This mirrors `RelationalTableFilters`, which already always includes the signal data collection regardless of `table.include.list` / `table.exclude.list`. Also clarifies the `CommonConnectorConfig` warning to point at column filtering as the likely cause.

## Tests
- Unit tests in `debezium-core` (`TableSchemaBuilderTest`): required columns included, extras excluded, case-insensitive matching, exclude-mode untouched.
- `debezium-core` builds green (full unit-test suite passes).
- **Manually verified end-to-end** against the Oracle XStream connector (`kafka-connect-oracle-xstream-cdc-source`, the sole consumer of this `debezium-core`): with `column.include.list` excluding the signal table's columns, the connector now honours the signal and runs the snapshot.

## Notes
- The connector-agnostic UT lives in `debezium-core` (owns the fixed code); the end-to-end signal IT lives in the connector repo.
