### PR TITLE
Bump netty to 4.1.136.Final for CVE-2026-44249/45416/50010

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
         <version.jackson>2.16.2</version.jackson>
         <version.jackson.databind>2.16.2</version.jackson.databind>
         <version.org.slf4j>1.7.36</version.org.slf4j>
-        <version.netty>4.1.129.Final</version.netty>
+        <version.netty>4.1.136.Final</version.netty>
         <version.zstd-jni>1.5.6-6</version.zstd-jni>
 
         <!-- Scala version used to build Kafka -->


### PR DESCRIPTION
## What

Bumps `<version.netty>` in the root `pom.xml` from `4.1.129.Final` to `4.1.136.Final`. One-line change; same shape as #259, which last moved this property for a netty CVE round.

## Why

Three HIGH severity CVEs against `io.netty:netty-handler`, all patched in `4.1.135.Final`:

| CVE | Issue |
| --- | --- |
| [CVE-2026-44249](https://nvd.nist.gov/vuln/detail/CVE-2026-44249) | IPv6 subnet rule bypass — incorrect masking in `IpSubnetFilterRule.compareTo()` lets valid public IPs bypass filter rules |
| [CVE-2026-45416](https://nvd.nist.gov/vuln/detail/CVE-2026-45416) | DoS — `SslClientHelloHandler.decode()` eagerly allocates `ctx.alloc().buffer(handshakeLength)`; the length guard is disabled by the commonly-used `SniHandler`/`AbstractSniHandler` constructors (`maxClientHelloLength=0`) |
| [CVE-2026-50010](https://nvd.nist.gov/vuln/detail/CVE-2026-50010) | Hostname verification bypass — `X509TrustManagerWrapper` discards the `SSLEngine`, so endpoint identification is never re-added |

Tracked as CVE-22781 / CVE-22782 / CVE-22783.

## Verified scope

`<version.netty>` feeds `debezium-bom`, which manages eight netty artifacts. Confirmed from a downstream CI build of the plugin assemblies (`confluentinc/debezium-v2-private#391`) that these ten jars ship at `4.1.136.Final` in all five connector plugins:

`netty-buffer`, `netty-codec`, `netty-codec-http2`, `netty-codec-socks`, `netty-common`, `netty-handler`, `netty-handler-proxy`, `netty-resolver`, `netty-transport`, `netty-transport-native-unix-common`

`netty-codec-socks` and `netty-transport-native-unix-common` are not in `debezium-bom` but follow transitively at the same version via `netty-handler-proxy` and `netty-handler` respectively.

Patch-level move within 4.1.x, so binary compatible.

## Known remaining gap (not addressed here)

The same CI build shows five netty artifacts that ship in these plugins but are **not** managed by `<version.netty>`, so this PR does not move them:

| Artifact | postgres | mysql | sqlserver | mongodb |
| --- | --- | --- | --- | --- |
| `netty-codec-http` | 4.1.126 | 4.1.118 | — | 4.1.130 |
| `netty-resolver-dns` | 4.1.112 | — | 4.1.112 | 4.1.112 |
| `netty-codec-dns` | 4.1.112 | — | 4.1.112 | 4.1.112 |
| `netty-transport-native-epoll` | 4.1.118 | — | 4.1.118 | 4.1.118 |
| `netty-transport-native-kqueue` | 4.1.118 | — | 4.1.118 | 4.1.118 |

They arrive transitively (`azure-core-http-netty`, the AWS SDK's `netty-nio-client`, the Mongo driver) and win dependency mediation because nothing pins them. Consequence: the `netty-codec-http` CVEs fixed in 4.1.136 (CVE-2026-55831/55833/56745/56746/59898/59899/59921) and the `netty-resolver-dns` cache-poisoning CVEs fixed in 4.1.135 remain open in these plugins. Closing those needs `netty-codec-http`, `netty-codec-dns`, `netty-resolver-dns` and the two native transports added to `debezium-bom`'s `dependencyManagement` at `${version.netty}` — happy to fold that into this PR if reviewers prefer.

## Follow-ups

Downstream this needs the submodule pointer bumped in `confluentinc/debezium-v2-private` (draft PR open at confluentinc/debezium-v2-private#391), then `DEBEZIUM_V2_SOURCE_CONNECTOR_CLOUD_VERSION` in `cc-docker-connect/cc-connect/cache-versions.env` moved to the resulting plugin version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
