### PR TITLE
Cherrypicks commits of debezium/dbz#1915 

### DIFF
--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnection.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnection.java
@@ -81,12 +81,15 @@ public class SqlServerConnection extends JdbcConnection {
     private static final String LOCK_TABLE = "SELECT * FROM #table WITH (TABLOCKX)";
     private static final String INCREMENT_LSN = "SELECT #db.sys.fn_cdc_increment_lsn(?)";
     protected static final String LSN_TIMESTAMP_SELECT_STATEMENT = "TODATETIMEOFFSET(#db.sys.fn_cdc_map_lsn_to_time([__$start_lsn]), DATEPART(TZOFFSET, SYSDATETIMEOFFSET()))";
+    private static final String LSN_TIMESTAMP_SELECT_STATEMENT_JOIN = "TODATETIMEOFFSET(ltm.tran_end_time, DATEPART(TZOFFSET, SYSDATETIMEOFFSET()))";
     private static final String GET_ALL_CHANGES_FOR_TABLE_SELECT = "SELECT [__$start_lsn], [__$seqval], [__$operation], [__$update_mask], #, "
             + LSN_TIMESTAMP_SELECT_STATEMENT;
+    private static final String GET_ALL_CHANGES_FOR_TABLE_SELECT_DIRECT = "SELECT cdc_data.[__$start_lsn], cdc_data.[__$seqval], cdc_data.[__$operation], cdc_data.[__$update_mask], #, "
+            + LSN_TIMESTAMP_SELECT_STATEMENT_JOIN;
     private static final String GET_ALL_CHANGES_FOR_TABLE_FROM_FUNCTION = "FROM #db.cdc.#function(?, ?, N'all update old')";
-    private static final String GET_ALL_CHANGES_FOR_TABLE_FROM_DIRECT = "FROM #db.cdc.#table with (nolock)";
+    private static final String GET_ALL_CHANGES_FOR_TABLE_FROM_DIRECT = "FROM #db.cdc.#table AS cdc_data with (nolock) LEFT JOIN #db.cdc.lsn_time_mapping ltm ON ltm.start_lsn = cdc_data.[__$start_lsn]";
     private static final String GET_ALL_CHANGES_FOR_TABLE_FROM_FUNCTION_ORDER_BY = "ORDER BY [__$start_lsn] ASC, [__$seqval] ASC, [__$operation] ASC";
-    private static final String GET_ALL_CHANGES_FOR_TABLE_FROM_DIRECT_ORDER_BY = "ORDER BY [__$start_lsn] ASC, [__$command_id] ASC, [__$seqval] ASC, [__$operation] ASC";
+    private static final String GET_ALL_CHANGES_FOR_TABLE_FROM_DIRECT_ORDER_BY = "ORDER BY cdc_data.[__$start_lsn] ASC, cdc_data.[__$command_id] ASC, cdc_data.[__$seqval] ASC, cdc_data.[__$operation] ASC";
 
     /**
      * Queries the list of captured column names and their change table identifiers in the given database.
@@ -179,23 +182,31 @@ public class SqlServerConnection extends JdbcConnection {
 
     private String buildGetAllChangesForTableQuery(SqlServerConnectorConfig.DataQueryMode dataQueryMode,
                                                    Set<Envelope.Operation> skippedOperations) {
-        String result = GET_ALL_CHANGES_FOR_TABLE_SELECT + " ";
+        boolean isDirectMode = dataQueryMode == SqlServerConnectorConfig.DataQueryMode.DIRECT;
+        String result;
         List<String> where = new LinkedList<>();
         switch (dataQueryMode) {
             case FUNCTION:
-                result += GET_ALL_CHANGES_FOR_TABLE_FROM_FUNCTION + " ";
+                result = GET_ALL_CHANGES_FOR_TABLE_SELECT + " " + GET_ALL_CHANGES_FOR_TABLE_FROM_FUNCTION + " ";
                 break;
             case DIRECT:
-                result += GET_ALL_CHANGES_FOR_TABLE_FROM_DIRECT + " ";
+            default:
+                result = GET_ALL_CHANGES_FOR_TABLE_SELECT_DIRECT + " " + GET_ALL_CHANGES_FOR_TABLE_FROM_DIRECT + " ";
                 break;
         }
-        where.add("(([__$start_lsn] = ? AND [__$seqval] = ? AND [__$operation] > ?) " +
-                "OR ([__$start_lsn] = ? AND [__$seqval] > ?) " +
-                "OR ([__$start_lsn] > ?))");
-        where.add("[__$start_lsn] <= ?");
 
-        if (dataQueryMode == SqlServerConnectorConfig.DataQueryMode.DIRECT) {
-            where.add("[__$start_lsn] >= ?");
+        if (isDirectMode) {
+            where.add("(([cdc_data].[__$start_lsn] = ? AND [cdc_data].[__$seqval] = ? AND [cdc_data].[__$operation] > ?) " +
+                    "OR ([cdc_data].[__$start_lsn] = ? AND [cdc_data].[__$seqval] > ?) " +
+                    "OR ([cdc_data].[__$start_lsn] > ?))");
+            where.add("[cdc_data].[__$start_lsn] <= ?");
+            where.add("[cdc_data].[__$start_lsn] >= ?");
+        }
+        else {
+            where.add("(([__$start_lsn] = ? AND [__$seqval] = ? AND [__$operation] > ?) " +
+                    "OR ([__$start_lsn] = ? AND [__$seqval] > ?) " +
+                    "OR ([__$start_lsn] > ?))");
+            where.add("[__$start_lsn] <= ?");
         }
 
         if (hasSkippedOperations(skippedOperations)) {
@@ -216,7 +227,8 @@ public class SqlServerConnection extends JdbcConnection {
                         break;
                 }
             });
-            where.add("[__$operation] NOT IN (" + String.join(",", skippedOps) + ")");
+            String colPrefix = isDirectMode ? "[cdc_data]." : "";
+            where.add(colPrefix + "[__$operation] NOT IN (" + String.join(",", skippedOps) + ")");
         }
 
         if (!where.isEmpty()) {
@@ -311,7 +323,7 @@ public class SqlServerConnection extends JdbcConnection {
     @Override
     public synchronized void reconnect() throws SQLException {
         // JdbcConnection#reconnect() bypasses connection(boolean) and would
-        //  skip setAutoCommit(false).
+        // skip setAutoCommit(false).
         LOGGER.info("Reopening SQL Server JDBC connection");
         close();
         connection();


### PR DESCRIPTION
Cherrypicks debezium/dbz#1915 : https://github.com/debezium/debezium/pull/7420
This PR intentionally changes `tran_begin_time` to `tran_end_time` to keep behaviour unchanged. Upstream using 'tran_begin_time' is likely an oversight as existing [function](https://learn.microsoft.com/en-us/sql/relational-databases/system-functions/sys-fn-cdc-map-lsn-to-time-transact-sql?view=sql-server-ver17) also uses `tran_end_time` underneath. 
Adding this cherrypick as this improves performance. This is only applicable to direct mode so the actual testing and perf results would be available only once the direct mode fixes are added in (Upstream PR with those fixes is in review [7728](https://github.com/debezium/debezium/pull/7728)). At present, no one uses direct mode on CC.