### PR TITLE
CC-41593 Postgres slot retry timeout change

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
@@ -90,9 +90,11 @@ public class PostgresConnection extends JdbcConnection {
             PostgresConnection.class.getClassLoader(), JdbcConfiguration.PORT.withDefault(PostgresConnectorConfig.PORT.defaultValueAsString()));
 
     /**
-     * Obtaining a replication slot may fail if there's a pending transaction. We're retrying to get a slot for 30 min.
+     * Obtaining a replication slot may fail if there's a pending transaction.  We're retrying to get a slot
+     * under 5 min: if slot is not captured within 5 min, the connector fails, rather than trying internally,
+     * Those failure is eventually retried by the operator, but task does not stays in unassigned for longe
      */
-    private static final int MAX_ATTEMPTS_FOR_OBTAINING_REPLICATION_SLOT = 900;
+    private static final int MAX_ATTEMPTS_FOR_OBTAINING_REPLICATION_SLOT = 140;
 
     private static final Duration PAUSE_BETWEEN_REPLICATION_SLOT_RETRIEVAL_ATTEMPTS = Duration.ofSeconds(2);
 

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
@@ -92,7 +92,7 @@ public class PostgresConnection extends JdbcConnection {
     /**
      * Obtaining a replication slot may fail if there's a pending transaction.  We're retrying to get a slot
      * under 5 min: if slot is not captured within 5 min, the connector fails, rather than trying internally,
-     * Those failure is eventually retried by the operator, but task does not stays in unassigned for longe
+     * Those failure is eventually retried by the operator, but task does not stays in unassigned for long
      */
     private static final int MAX_ATTEMPTS_FOR_OBTAINING_REPLICATION_SLOT = 140;
 


### PR DESCRIPTION
**Problem:**
When connector is started, postgres slot acquisition is attempted for 30 min, before failing. Task is not started in this while, thus task status is reported as unassigned for entire 30 min duration, when a slot is already occupied. This causes Unassigned Task Alerts.

**Solution:**
The 30 min retry loop was set, because sometime slot acquired could be awaited due to another long running transaction. But in Cloud world, the failed task can easily be retried on own by operator, hence keeping a full 30 min wait is an overkill. This PR makes that retry loop of 5 min, connector would FAIL, transition into user actionable error and eventually be retried by operator if slot cannot be acquired.  