### PR TITLE
CC-39891: Redact DDL statements from BinlogDatabaseSchema logs

### DIFF
--- a/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogDatabaseSchema.java
+++ b/debezium-connector-binlog/src/main/java/io/debezium/connector/binlog/BinlogDatabaseSchema.java
@@ -5,6 +5,8 @@
  */
 package io.debezium.connector.binlog;
 
+import static io.debezium.util.Loggings.maybeRedactSensitiveData;
+
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -133,7 +135,7 @@ public abstract class BinlogDatabaseSchema<P extends BinlogPartition, O extends 
         // - or DDLs for captured objects
         if (!storeOnlyCapturedTables() || isGlobalSetVariableStatement(schemaChange.getDdl(), schemaChange.getDatabase())
                 || schemaChange.getTables().stream().map(Table::id).anyMatch(filters.dataCollectionFilter()::isIncluded)) {
-            LOGGER.trace("Recorded DDL statements for database '{}': {}", schemaChange.getDatabase(), schemaChange.getDdl());
+            LOGGER.trace("Recorded DDL statements for database '{}': {}", schemaChange.getDatabase(), maybeRedactSensitiveData(schemaChange.getDdl()));
             record(schemaChange, schemaChange.getTableChanges());
         }
     }


### PR DESCRIPTION
https://confluentinc.atlassian.net/browse/CC-39891 (SAST alert ASA-4297, CWE-532)

The `Recorded DDL statements` log line in `BinlogDatabaseSchema#applySchemaChange` emitted the raw DDL, which can carry table names, column names and default values.

`maybeRedactSensitiveData` resolves to `[REDACTED]` unless TRACE is enabled on the `Loggings` class. Cloud blocks TRACE from being set for that class ([ref](https://github.com/confluentinc/cc-terraform-shoreline/pull/1691)), so the log is safe on cloud while remaining debuggable on-prem. This matters even though the line is already at TRACE, since Cloud does not block TRACE on `BinlogDatabaseSchema` itself.

Same approach as #442.

### Notes
- The database name is deliberately left unredacted, matching the existing convention of redacting statements but keeping identifiers (see `AbstractIncrementalSnapshotChangeEventSource`).
- CC-39891 also lists `FieldToEmbedding.java#L106` and `OracleDatabaseSchema.java#L119`. Those code paths are not in use, so they are out of scope here.

### Testing
`./mvnw -pl debezium-connector-binlog -am compile -DskipTests` passes on JDK 21.