### PR TITLE
CC-39891: Redact DDL statements from MySqlDatabaseSchema logs

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlDatabaseSchema.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlDatabaseSchema.java
@@ -191,7 +191,7 @@ public class MySqlDatabaseSchema extends HistorizedRelationalDatabaseSchema {
         // - or DDLs for monitored objects
         if (!databaseHistory.storeOnlyCapturedTables() || isGlobalSetVariableStatement(schemaChange.getDdl(), schemaChange.getDatabase())
                 || schemaChange.getTables().stream().map(Table::id).anyMatch(filters.dataCollectionFilter()::isIncluded)) {
-            LOGGER.debug("Recorded DDL statements for database '{}': {}", schemaChange.getDatabase(), schemaChange.getDdl());
+            LOGGER.debug("Recorded DDL statements for database '{}'", schemaChange.getDatabase());
             record(schemaChange, schemaChange.getTableChanges());
         }
     }


### PR DESCRIPTION
https://confluentinc.atlassian.net/browse/CC-39891 (SAST alert ASA-4297, CWE-532)

Backport of #506 to `v1.9.6-hotfix-x`.

The `Recorded DDL statements` log line in `MySqlDatabaseSchema#applySchemaChange` emitted the raw DDL, which can carry table names, column names and default values. On this branch it is the `debezium-connector-mysql` equivalent of the `BinlogDatabaseSchema` line fixed in #506 (the `debezium-connector-binlog` module does not exist in 1.9.x).

### Difference from #506

`Loggings.maybeRedactSensitiveData` does not exist on this branch — `io.debezium.util.Loggings` was never backported — so the DDL parameter is dropped from the message instead. That is the v1.9.6 convention already established by #399, #445 and #454.

Also note the line is at `DEBUG` here rather than `TRACE` as on `v3.2.5-hotfix-x`, so the exposure is a bit wider; dropping the parameter closes it at any level.

```
- LOGGER.debug("Recorded DDL statements for database '{}': {}", schemaChange.getDatabase(), schemaChange.getDdl());
+ LOGGER.debug("Recorded DDL statements for database '{}'", schemaChange.getDatabase());
```

### Notes
- The database name is deliberately left unredacted, matching the existing convention of redacting statements but keeping identifiers (see `AbstractIncrementalSnapshotChangeEventSource`).
- Two other `Recorded DDL statements` lines exist on this branch and are out of scope, matching #506's reasoning that unused paths are excluded: `mysql/legacy/BinlogReader.java#L833` (legacy implementation, only reachable via `internal.implementation=legacy`) and `OracleDatabaseSchema.java#L106`.

### Testing
`mvn -pl debezium-connector-mysql -am compile -DskipTests` passes on JDK 21.